### PR TITLE
feat: pure lint engine and simple-english CLI walking skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: bun run lint
+      - run: bun run typecheck
+      - run: bun run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 coverage/
 *.log
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+## What this project is
+
+A pi extension (TypeScript + Effect) that makes the pi coding agent comply with ASD-STE100 Simplified Technical English, plus a standalone `simple-english` CLI (`src/cli/main.ts`) exposing the same rule engine.
+Behavioral reference: https://github.com/ctotheameron/pi-ste (Gleam) - this is a reimplementation, not a fork.
+Parent spec lives in Linear HUF-130.
+
+## Architecture rules (binding, from the HUF-130 spec)
+
+- Pure functional core: the `lint` engine (`src/engine/lint.ts`) is synchronous, no Effect runtime. Effect only at boundaries (CLI IO now; Schema and layers later).
+- Three test seams only: pure engine API (~90% of suite, `test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), extension wiring via stubbed ExtensionAPI double. Never run pi itself in tests.
+- Severity model: violations carry `hard`/`soft`; hard violations drive CLI exit code 1.
+- TDD per rule: failing engine-seam test first, then implement.
+- pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`) must stay in `dependencies`, never `devDependencies`.
+
+## Commands
+
+- `bun run test` (Vitest), `bun run lint` (Biome), `bun run typecheck` (tsc). CI (`.github/workflows/ci.yml`) runs all three on bun 1.3.14.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 JIA YI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# pi-simple-english
+
+A pi extension that makes the pi coding agent comply with ASD-STE100 Simplified Technical English, plus a standalone `simple-english` CLI exposing the same rule engine.
+
+Reimplementation of [pi-ste](https://github.com/ctotheameron/pi-ste) in TypeScript with Effect.
+
+## CLI
+
+```sh
+simple-english README.md
+cat notes.md | simple-english
+simple-english --json README.md
+```
+
+Prints STE violations with line, column, and rule id.
+Exits 1 when hard violations exist, 0 otherwise.
+`--json` emits a machine-readable report.
+
+## Development
+
+```sh
+bun install
+bun run test
+bun run lint
+bun run typecheck
+```
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ simple-english --json README.md
 ```
 
 Prints STE violations with line, column, and rule id.
-Exits 1 when hard violations exist, 0 otherwise.
+Exits 1 when hard violations exist, 0 when clean, 2 when a file cannot be read.
 `--json` emits a machine-readable report.
 
 ## Development

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "asNeeded"
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "files": {
+    "ignore": [".claude/**"]
+  },
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,251 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "pi-simple-english",
+      "dependencies": {
+        "effect": "^3.14.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@types/node": "^22.0.0",
+        "typescript": "^5.8.0",
+        "vitest": "^3.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.3", "", { "os": "android", "cpu": "arm" }, "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.3", "", { "os": "android", "cpu": "arm64" }, "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.3", "", { "os": "linux", "cpu": "arm" }, "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.3", "", { "os": "linux", "cpu": "arm" }, "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.3", "", { "os": "linux", "cpu": "none" }, "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.3", "", { "os": "linux", "cpu": "x64" }, "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.3", "", { "os": "linux", "cpu": "x64" }, "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.3", "", { "os": "none", "cpu": "arm64" }, "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.7", "", { "dependencies": { "@vitest/spy": "3.2.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.7", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.7", "", { "dependencies": { "@vitest/utils": "3.2.7", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.7", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "rollup": ["rollup@4.62.3", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.3", "@rollup/rollup-android-arm64": "4.62.3", "@rollup/rollup-darwin-arm64": "4.62.3", "@rollup/rollup-darwin-x64": "4.62.3", "@rollup/rollup-freebsd-arm64": "4.62.3", "@rollup/rollup-freebsd-x64": "4.62.3", "@rollup/rollup-linux-arm-gnueabihf": "4.62.3", "@rollup/rollup-linux-arm-musleabihf": "4.62.3", "@rollup/rollup-linux-arm64-gnu": "4.62.3", "@rollup/rollup-linux-arm64-musl": "4.62.3", "@rollup/rollup-linux-loong64-gnu": "4.62.3", "@rollup/rollup-linux-loong64-musl": "4.62.3", "@rollup/rollup-linux-ppc64-gnu": "4.62.3", "@rollup/rollup-linux-ppc64-musl": "4.62.3", "@rollup/rollup-linux-riscv64-gnu": "4.62.3", "@rollup/rollup-linux-riscv64-musl": "4.62.3", "@rollup/rollup-linux-s390x-gnu": "4.62.3", "@rollup/rollup-linux-x64-gnu": "4.62.3", "@rollup/rollup-linux-x64-musl": "4.62.3", "@rollup/rollup-openbsd-x64": "4.62.3", "@rollup/rollup-openharmony-arm64": "4.62.3", "@rollup/rollup-win32-arm64-msvc": "4.62.3", "@rollup/rollup-win32-ia32-msvc": "4.62.3", "@rollup/rollup-win32-x64-gnu": "4.62.3", "@rollup/rollup-win32-x64-msvc": "4.62.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.7", "@vitest/mocker": "3.2.7", "@vitest/pretty-format": "^3.2.7", "@vitest/runner": "3.2.7", "@vitest/snapshot": "3.2.7", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.7", "@vitest/ui": "3.2.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "pi-simple-english",
+  "version": "0.1.0",
+  "description": "ASD-STE100 Simplified Technical English lint engine and CLI for the pi coding agent",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "simple-english": "./src/cli/main.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "lint": "biome check .",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "effect": "^3.14.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+import { readFile } from "node:fs/promises"
+import { Effect } from "effect"
+import { lint } from "../engine/lint.ts"
+import type { LintReport } from "../engine/types.ts"
+
+interface FileViolation {
+  readonly file: string
+  readonly ruleId: string
+  readonly severity: string
+  readonly message: string
+  readonly line: number
+  readonly column: number
+}
+
+interface CliReport {
+  readonly violations: readonly FileViolation[]
+  readonly summary: { readonly total: number; readonly hard: number }
+}
+
+const readStdin = Effect.promise(async () => {
+  const chunks: Buffer[] = []
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer)
+  }
+  return Buffer.concat(chunks).toString("utf8")
+})
+
+const readInput = (path: string) =>
+  path === "-"
+    ? readStdin.pipe(Effect.map((text) => ({ path: "<stdin>", text })))
+    : Effect.tryPromise({
+        try: () => readFile(path, "utf8"),
+        catch: (cause) => new Error(`cannot read ${path}: ${cause}`),
+      }).pipe(Effect.map((text) => ({ path, text })))
+
+const toCliReport = (reports: readonly { path: string; report: LintReport }[]): CliReport => {
+  const violations = reports.flatMap(({ path, report }) =>
+    report.violations.map((violation) => ({ file: path, ...violation })),
+  )
+  return {
+    violations,
+    summary: {
+      total: violations.length,
+      hard: violations.filter((violation) => violation.severity === "hard").length,
+    },
+  }
+}
+
+const render = (report: CliReport, json: boolean): string => {
+  if (json) {
+    return JSON.stringify(report, null, 2)
+  }
+  return report.violations
+    .map((v) => `${v.file}:${v.line}:${v.column} ${v.ruleId} ${v.message}`)
+    .join("\n")
+}
+
+const program = Effect.gen(function* () {
+  const args = process.argv.slice(2)
+  const json = args.includes("--json")
+  const paths = args.filter((arg) => arg !== "--json")
+  const inputs =
+    paths.length === 0
+      ? [{ path: "<stdin>", text: yield* readStdin }]
+      : yield* Effect.forEach(paths, readInput)
+
+  const report = toCliReport(
+    inputs.map(({ path, text }) => ({ path, report: lint("prose-file", text) })),
+  )
+
+  const output = render(report, json)
+  if (output !== "") {
+    console.log(output)
+  }
+  return report.summary.hard > 0 ? 1 : 0
+})
+
+const exitCode = await Effect.runPromise(program).catch((error) => {
+  console.error(String(error))
+  return 2
+})
+process.exit(exitCode)

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,0 +1,22 @@
+import { blankCodeFences } from "./markdown.ts"
+import { sentenceLength } from "./rules/sentence-length.ts"
+import { segmentSentences } from "./sentences.ts"
+import type { LintKind, LintOptions, LintReport, Violation } from "./types.ts"
+
+export const DEFAULT_MAX_SENTENCE_WORDS = 25
+
+const linters: Record<LintKind, (text: string, maxSentenceWords: number) => Violation[]> = {
+  "prose-file": (text, maxSentenceWords) =>
+    sentenceLength(segmentSentences(blankCodeFences(text)), maxSentenceWords),
+}
+
+export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
+  const violations = linters[kind](text, options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS)
+  return {
+    violations,
+    summary: {
+      total: violations.length,
+      hard: violations.filter((violation) => violation.severity === "hard").length,
+    },
+  }
+}

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,0 +1,12 @@
+const FENCE = /^\s{0,3}(?:```|~~~)/
+
+export function blankCodeFences(text: string): string[] {
+  let inFence = false
+  return text.split("\n").map((line) => {
+    if (FENCE.test(line)) {
+      inFence = !inFence
+      return ""
+    }
+    return inFence ? "" : line
+  })
+}

--- a/src/engine/rules/sentence-length.ts
+++ b/src/engine/rules/sentence-length.ts
@@ -1,0 +1,24 @@
+import type { Sentence } from "../sentences.ts"
+import type { Violation } from "../types.ts"
+
+export function sentenceLength(sentences: readonly Sentence[], maxWords: number): Violation[] {
+  return sentences.flatMap((sentence) => {
+    const count = countWords(sentence.text)
+    if (count <= maxWords) {
+      return []
+    }
+    return [
+      {
+        ruleId: "sentence-length",
+        severity: "hard" as const,
+        message: `Sentence has ${count} words; the maximum is ${maxWords}.`,
+        line: sentence.line,
+        column: sentence.column,
+      },
+    ]
+  })
+}
+
+function countWords(text: string): number {
+  return text.split(/\s+/).filter((word) => word !== "").length
+}

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -1,0 +1,52 @@
+export interface Sentence {
+  readonly text: string
+  readonly line: number
+  readonly column: number
+}
+
+const TERMINATOR = /[.!?]+(\s|$)/
+
+// A sentence starts at the first non-whitespace character and ends at
+// terminal punctuation followed by whitespace, at a blank line, or at EOF.
+// Sentences may span lines; position is where the sentence starts (1-based).
+export function segmentSentences(lines: readonly string[]): Sentence[] {
+  const sentences: Sentence[] = []
+  let open: { line: number; column: number; parts: string[] } | null = null
+
+  const close = () => {
+    if (!open) return
+    const text = open.parts.join(" ").trim()
+    if (text !== "") {
+      sentences.push({ text, line: open.line, column: open.column })
+    }
+    open = null
+  }
+
+  lines.forEach((raw, index) => {
+    if (raw.trim() === "") {
+      close()
+      return
+    }
+    let rest = raw
+    let offset = 0
+    while (rest.trim() !== "") {
+      if (!open) {
+        const indent = rest.length - rest.trimStart().length
+        open = { line: index + 1, column: offset + indent + 1, parts: [] }
+      }
+      const terminator = rest.match(TERMINATOR)
+      if (terminator?.index === undefined) {
+        open.parts.push(rest.trim())
+        break
+      }
+      const end = terminator.index + terminator[0].length
+      open.parts.push(rest.slice(0, end).trim())
+      close()
+      offset += end
+      rest = rest.slice(end)
+    }
+  })
+  close()
+
+  return sentences
+}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,0 +1,23 @@
+export type LintKind = "prose-file"
+
+export type Severity = "hard" | "soft"
+
+export interface Violation {
+  readonly ruleId: string
+  readonly severity: Severity
+  readonly message: string
+  readonly line: number
+  readonly column: number
+}
+
+export interface LintOptions {
+  readonly maxSentenceWords?: number
+}
+
+export interface LintReport {
+  readonly violations: readonly Violation[]
+  readonly summary: {
+    readonly total: number
+    readonly hard: number
+  }
+}

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,0 +1,103 @@
+import { execFile } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url))
+
+interface CliResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+async function runCli(args: string[], stdin?: string): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      "bun",
+      ["src/cli/main.ts", ...args],
+      { cwd: repoRoot },
+      (error, stdout, stderr) => {
+        const code = error && typeof error.code === "number" ? error.code : 0
+        if (error && typeof error.code !== "number") {
+          reject(error)
+          return
+        }
+        resolve({ code, stdout, stderr })
+      },
+    )
+    if (stdin !== undefined) {
+      child.stdin?.write(stdin)
+    }
+    child.stdin?.end()
+  })
+}
+
+describe("simple-english CLI", () => {
+  test("exits 0 on a clean file", async () => {
+    const result = await runCli(["test/fixtures/clean.md"])
+
+    expect(result.code).toBe(0)
+    expect(result.stdout.trim()).toBe("")
+  })
+
+  test("exits 1 and prints violations with line, column, and rule id for a file", async () => {
+    const result = await runCli(["test/fixtures/violations.md"])
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("test/fixtures/violations.md:3:1")
+    expect(result.stdout).toContain("sentence-length")
+    expect(result.stdout).toContain("maximum is 25")
+  })
+
+  test("lints stdin when no paths are given", async () => {
+    const longSentence = `${Array.from({ length: 30 }, (_, i) => `word${i}`).join(" ")}.`
+    const result = await runCli([], longSentence)
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("<stdin>:1:1")
+    expect(result.stdout).toContain("sentence-length")
+  })
+
+  test("exits 0 on clean stdin", async () => {
+    const result = await runCli([], "A short sentence.")
+
+    expect(result.code).toBe(0)
+  })
+
+  test("--json emits a stable machine-readable report", async () => {
+    const result = await runCli(["--json", "test/fixtures/violations.md"])
+
+    expect(result.code).toBe(1)
+    const report = JSON.parse(result.stdout)
+    expect(report).toEqual({
+      violations: [
+        {
+          file: "test/fixtures/violations.md",
+          ruleId: "sentence-length",
+          severity: "hard",
+          message: expect.stringContaining("maximum is 25"),
+          line: 3,
+          column: 1,
+        },
+      ],
+      summary: { total: 1, hard: 1 },
+    })
+  })
+
+  test("--json on clean input emits an empty report and exits 0", async () => {
+    const result = await runCli(["--json"], "A short sentence.")
+
+    expect(result.code).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual({
+      violations: [],
+      summary: { total: 0, hard: 0 },
+    })
+  })
+
+  test("errors with exit code 2 on an unreadable file", async () => {
+    const result = await runCli(["test/fixtures/does-not-exist.md"])
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("does-not-exist.md")
+  })
+})

--- a/test/engine/lint.test.ts
+++ b/test/engine/lint.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+describe("lint prose-file: sentence-length rule", () => {
+  const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
+
+  test("flags a sentence over 25 words as a hard violation", () => {
+    const report = lint("prose-file", `${words(26)}.`)
+
+    expect(report.violations).toHaveLength(1)
+    const violation = report.violations[0]
+    expect(violation).toMatchObject({
+      ruleId: "sentence-length",
+      severity: "hard",
+      line: 1,
+      column: 1,
+    })
+    expect(violation?.message).toContain("26")
+    expect(violation?.message).toContain("25")
+  })
+
+  test("does not flag a sentence of exactly 25 words", () => {
+    const report = lint("prose-file", `${words(25)}.`)
+
+    expect(report.violations).toHaveLength(0)
+  })
+
+  test("does not flag short sentences", () => {
+    const report = lint("prose-file", "Remove the bolt. Turn the handle to the left.")
+
+    expect(report.violations).toHaveLength(0)
+  })
+
+  test("returns no violations for empty input", () => {
+    expect(lint("prose-file", "").violations).toHaveLength(0)
+    expect(lint("prose-file", "   \n\n  ").violations).toHaveLength(0)
+  })
+
+  test("word cap is configurable via options", () => {
+    const text = `${words(10)}.`
+
+    expect(lint("prose-file", text, { maxSentenceWords: 9 }).violations).toHaveLength(1)
+    expect(lint("prose-file", text, { maxSentenceWords: 10 }).violations).toHaveLength(0)
+  })
+
+  test("reports the line and column where the long sentence starts", () => {
+    const text = `Short sentence here.\n\nAnother short one. ${words(30)}.`
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 20 })
+  })
+
+  test("counts a sentence that spans multiple lines once, at its start", () => {
+    const text = `${words(13)}\n${words(13)}.`
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("ignores fenced code blocks", () => {
+    const text = [
+      "A short sentence.",
+      "```ts",
+      `const x = "${words(40)}"`,
+      "```",
+      "Another short sentence.",
+    ].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("still flags prose after a fenced code block, with correct position", () => {
+    const text = ["```", words(40), "```", `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
+  })
+
+  test("summary counts total and hard violations", () => {
+    const text = `${words(26)}. ${words(27)}.`
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(2)
+    expect(report.summary).toEqual({ total: 2, hard: 2 })
+  })
+})

--- a/test/fixtures/clean.md
+++ b/test/fixtures/clean.md
@@ -1,0 +1,9 @@
+# Clean fixture
+
+All sentences here are short. They comply with the rule.
+
+```ts
+const example = "this string inside a fenced code block has many many many many many many many many many many many many many many many many many many many many many words"
+```
+
+The code block above must not trigger the rule.

--- a/test/fixtures/violations.md
+++ b/test/fixtures/violations.md
@@ -1,0 +1,5 @@
+# Fixture with a violation
+
+This sentence is deliberately far too long because it keeps adding more and more filler words until the total word count clearly exceeds the configured maximum of twenty five.
+
+A short closing sentence.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Intent

Implement Linear ticket HUF-131 (walking skeleton for the pi-simple-english project, parent spec HUF-130): starting from an empty init commit, establish the repo (bun 1.3.14 + TypeScript + Effect + Vitest, Biome for lint/format, GitHub Actions CI running lint/typecheck/tests, MIT license) and build the narrowest complete path: a pure synchronous lint engine plus a simple-english CLI. The engine is lint(kind, text, options) with only the prose-file kind; one real rule (sentence-length) flags sentences over 25 words as hard violations with line, column, rule id, and message; the word cap is an engine option with hardcoded default 25 (config system is a later ticket). Basic markdown fenced-code-block exclusion so code samples do not trigger the rule. The CLI is a thin adapter: file paths or stdin in, human-readable path:line:col output by default, --json for a stable machine-readable report, exit 1 on hard violations, 0 clean, 2 on unreadable files. Deliberate decisions: Effect only at the CLI boundary, engine stays pure with no Effect runtime (binding HUF-130 spec decision); effect lives in dependencies not devDependencies because pi installs extension deps with npm install --omit=dev; TDD was mandated and followed (engine-seam tests and CLI E2E tests spawning bun src/cli/main.ts were written first and watched fail); scope deliberately excludes wink-nlp, dictionary vendoring, config system, and pi extension wiring (later tickets); no AI attribution trailers allowed in commits; Conventional Commit subjects; AGENTS.md added to capture binding architecture rules from the spec.

## What Changed

- Scaffolded the project from an empty init commit: bun 1.3.14 + TypeScript + Effect + Vitest, Biome for lint/format, GitHub Actions CI running lint/typecheck/tests, MIT license, and AGENTS.md capturing the binding architecture rules from the HUF-130 spec.
- Added a pure synchronous lint engine (`src/engine/`) exposing `lint(kind, text, options)` with the prose-file kind and one rule: sentence-length flags sentences over 25 words (configurable via an engine option, default 25) as hard violations with line, column, rule id, and message. Basic markdown fenced-code-block exclusion keeps code samples out of the rule; per the review, nested fence lengths (e.g. ``` inside ````) are a known limitation deferred to a later hardening pass.
- Added the `simple-english` CLI (`src/cli/main.ts`) as a thin Effect-based adapter: file paths or stdin in, human-readable `path:line:col` output by default, `--json` for a stable machine-readable report, and exit codes 1 on hard violations, 0 when clean, 2 on unreadable files.

## Risk Assessment

✅ Low: Greenfield walking skeleton with a small pure engine, every required intent criterion verifiably present in the diff, no forbidden scope or AI attribution, and tests covering the mandated engine and CLI seams including exit codes and JSON shape.

## Testing

Ran the full targeted engine and CLI test suites (17 tests, all passing) after a fresh `bun install`, then manually exercised the CLI end-to-end and captured a transcript covering violation output with line/column/rule id, exit codes 0/1/2, stdin input, --json reports, and code-fence exclusion; also verified the binding constraints (pure engine with no Effect imports, effect in dependencies, no AI attribution trailers, Conventional Commit subjects). Everything the intent requires works as specified.

<details>
<summary>Evidence: simple-english CLI end-to-end transcript (violations, clean file with code fence, --json, stdin, exit codes 0/1/2)</summary>

<code>$ bun src/cli/main.ts test/fixtures/violations.md&#10;test/fixtures/violations.md:3:1 sentence-length Sentence has 29 words; the maximum is 25.&#10;(exit 1)&#10;&#10;$ bun src/cli/main.ts test/fixtures/clean.md # long sentence inside ```ts fence is excluded&#10;(exit 0)&#10;&#10;$ bun src/cli/main.ts --json test/fixtures/violations.md&#10;{&#10;&#34;violations&#34;: [&#10;{&#10;&#34;file&#34;: &#34;test/fixtures/violations.md&#34;,&#10;&#34;ruleId&#34;: &#34;sentence-length&#34;,&#10;&#34;severity&#34;: &#34;hard&#34;,&#10;&#34;message&#34;: &#34;Sentence has 29 words; the maximum is 25.&#34;,&#10;&#34;line&#34;: 3,&#10;&#34;column&#34;: 1&#10;}&#10;],&#10;&#34;summary&#34;: { &#34;total&#34;: 1, &#34;hard&#34;: 1 }&#10;}&#10;(exit 1)&#10;&#10;$ printf &#39;word %.0s&#39; {1..30} | sed &#39;s/ $/./&#39; | bun src/cli/main.ts&#10;&lt;stdin&gt;:1:1 sentence-length Sentence has 30 words; the maximum is 25.&#10;(exit 1)&#10;&#10;$ echo &#39;A short sentence.&#39; | bun src/cli/main.ts&#10;(exit 0)&#10;&#10;$ bun src/cli/main.ts test/fixtures/missing.md&#10;(FiberFailure) Error: cannot read test/fixtures/missing.md: Error: ENOENT: no such file or directory, open &#39;test/fixtures/missing.md&#39;&#10;(exit 2)</code>

```text
# simple-english CLI end-to-end transcript (bun 1.3.14, commit 5710e66)

## 1. File with a >25-word sentence: human-readable path:line:col output, exit 1
$ bun src/cli/main.ts test/fixtures/violations.md
test/fixtures/violations.md:3:1 sentence-length Sentence has 29 words; the maximum is 25.
(exit 1)

## 2. Clean file with a long sentence inside a fenced code block: fence excluded, exit 0
$ bun src/cli/main.ts test/fixtures/clean.md
(exit 0)

## 3. --json machine-readable report, exit 1
$ bun src/cli/main.ts --json test/fixtures/violations.md
{
  "violations": [
    {
      "file": "test/fixtures/violations.md",
      "ruleId": "sentence-length",
      "severity": "hard",
      "message": "Sentence has 29 words; the maximum is 25.",
      "line": 3,
      "column": 1
    }
  ],
  "summary": {
    "total": 1,
    "hard": 1
  }
}
(exit 1)

## 4. stdin input (no paths)
$ echo 'one two three ... (30 words).' | bun src/cli/main.ts
<stdin>:1:1 sentence-length Sentence has 30 words; the maximum is 25.
(exit 1)

## 5. Clean stdin, exit 0
$ echo 'A short sentence.' | bun src/cli/main.ts
(exit 0)

## 6. Unreadable file: error to stderr, exit 2
$ bun src/cli/main.ts test/fixtures/missing.md
(FiberFailure) Error: cannot read test/fixtures/missing.md: Error: ENOENT: no such file or directory, open 'test/fixtures/missing.md'
(exit 2)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/engine/markdown.ts:6` - Fence detection toggles on any line matching ``` or ~~~ without tracking the fence character or length, so a longer fence containing a shorter one (e.g. a ````-fenced block showing ``` examples) mis-toggles and can blank prose or expose code to the rule. The intent explicitly scopes this ticket to &#39;basic markdown fenced-code-block exclusion&#39;, so this is an acknowledged limitation to address when markdown handling is hardened, not a defect in this change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun run vitest run test/engine/lint.test.ts test/cli/cli.test.ts` - 17 tests passed (10 engine-seam, 7 CLI E2E spawning `bun src/cli/main.ts`)</code>
- <code>Manual E2E: `bun src/cli/main.ts test/fixtures/violations.md` - printed `test/fixtures/violations.md:3:1 sentence-length Sentence has 29 words; the maximum is 25.` and exited 1</code>
- <code>Manual E2E: `bun src/cli/main.ts test/fixtures/clean.md` - long sentence inside a fenced code block did not trigger the rule, exited 0</code>
- <code>Manual E2E: `bun src/cli/main.ts --json test/fixtures/violations.md` - stable JSON report with file, ruleId, severity, message, line, column, and summary; exited 1</code>
- <code>Manual E2E: piped 30-word sentence to `bun src/cli/main.ts` with no paths - flagged `&lt;stdin&gt;:1:1`, exited 1; clean stdin exited 0</code>
- <code>Manual E2E: `bun src/cli/main.ts test/fixtures/missing.md` - error on stderr, exited 2</code>
- <code>Constraint checks: grep confirmed no `effect` imports under `src/engine/`; `effect` is in `dependencies` in package.json; `git log b6676266..5710e666` bodies contain no AI attribution trailers and use Conventional Commit subjects; LICENSE, `.github/workflows/ci.yml`, and AGENTS.md present</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
