### PR TITLE
feat(engine): add POS-tagged verb-form lint rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ Parent spec lives in Linear HUF-130.
 - Three test seams only: pure engine API (~90% of suite, `test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), extension wiring via stubbed ExtensionAPI double. Never run pi itself in tests.
 - Severity model: violations carry `hard`/`soft`; hard violations drive CLI exit code 1.
 - TDD per rule: failing engine-seam test first, then implement.
-- pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`) must stay in `dependencies`, never `devDependencies`.
+- pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`, `wink-nlp`) must stay in `dependencies`, never `devDependencies`.
+- POS tagging is an injected boundary: the engine consumes the pure `Tagger` type (`src/engine/tagger.ts`) and silently skips verb-form rules when `LintOptions.tagger` is absent; the wink-nlp implementation and its Effect layer live in `src/tagger/wink.ts`. Tagger-dependent verdicts are pinned, right or wrong, in `test/engine/verb-form-fixtures.test.ts`.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ simple-english --json README.md
 ```
 
 Prints STE violations with line, column, and rule id.
-Exits 1 when hard violations exist, 0 when clean, 2 when a file cannot be read.
+Exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when a file cannot be read.
+Soft violations are still printed when the command exits 0.
 `--json` emits a machine-readable report.
 
 ## Development

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "pi-simple-english",
       "dependencies": {
         "effect": "^3.14.0",
+        "wink-eng-lite-web-model": "^1.8.1",
+        "wink-nlp": "^2.4.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
@@ -247,5 +249,9 @@
     "vitest": ["vitest@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.7", "@vitest/mocker": "3.2.7", "@vitest/pretty-format": "^3.2.7", "@vitest/runner": "3.2.7", "@vitest/snapshot": "3.2.7", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.7", "@vitest/ui": "3.2.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wink-eng-lite-web-model": ["wink-eng-lite-web-model@1.8.1", "", {}, "sha512-M2tSOU/rVNkDj8AS8IoKJaM7apJJjS0cN+hE8CPazfnB4A/ojyc9+7RMPk18UOiIdSyWk7MR6w8z9lWix2l5tA=="],
+
+    "wink-nlp": ["wink-nlp@2.4.0", "", {}, "sha512-d02inlNJL0LLNTLoYfkxZYGrqnYDSZV4HI4WpeuyIEfpu7UcUqUW1ZYWr+JTFm4ZR6dQdzOW/FtHEQRO+o/zzA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "effect": "^3.14.0"
+    "effect": "^3.14.0",
+    "wink-eng-lite-web-model": "^1.8.1",
+    "wink-nlp": "^2.4.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises"
 import { Effect } from "effect"
 import { lint } from "../engine/lint.ts"
 import type { LintReport } from "../engine/types.ts"
+import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
 
 interface FileViolation {
   readonly file: string
@@ -57,6 +58,7 @@ const render = (report: CliReport, json: boolean): string => {
 }
 
 const program = Effect.gen(function* () {
+  const tagger = yield* TaggerService
   const args = process.argv.slice(2)
   const json = args.includes("--json")
   const paths = args.filter((arg) => arg !== "--json")
@@ -66,7 +68,7 @@ const program = Effect.gen(function* () {
       : yield* Effect.forEach(paths, readInput)
 
   const report = toCliReport(
-    inputs.map(({ path, text }) => ({ path, report: lint("prose-file", text) })),
+    inputs.map(({ path, text }) => ({ path, report: lint("prose-file", text, { tagger }) })),
   )
 
   const output = render(report, json)
@@ -76,7 +78,7 @@ const program = Effect.gen(function* () {
   return report.summary.hard > 0 ? 1 : 0
 })
 
-const exitCode = await Effect.runPromise(program).catch((error) => {
+const exitCode = await Effect.runPromise(Effect.provide(program, WinkTaggerLive)).catch((error) => {
   console.error(String(error))
   return 2
 })

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,17 +1,32 @@
 import { blankCodeFences } from "./markdown.ts"
 import { sentenceLength } from "./rules/sentence-length.ts"
+import { verbForm } from "./rules/verb-form.ts"
 import { segmentSentences } from "./sentences.ts"
+import type { Tagger } from "./tagger.ts"
 import type { LintKind, LintOptions, LintReport, Violation } from "./types.ts"
 
 export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
-const linters: Record<LintKind, (text: string, maxSentenceWords: number) => Violation[]> = {
-  "prose-file": (text, maxSentenceWords) =>
-    sentenceLength(segmentSentences(blankCodeFences(text)), maxSentenceWords),
+interface ResolvedOptions {
+  readonly maxSentenceWords: number
+  readonly tagger?: Tagger
+}
+
+const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Violation[]> = {
+  "prose-file": (text, { maxSentenceWords, tagger }) => {
+    const lines = blankCodeFences(text)
+    return [
+      ...sentenceLength(segmentSentences(lines), maxSentenceWords),
+      ...(tagger === undefined ? [] : verbForm(lines, tagger)),
+    ]
+  },
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const violations = linters[kind](text, options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS)
+  const violations = linters[kind](text, {
+    maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
+    tagger: options.tagger,
+  }).sort((a, b) => a.line - b.line || a.column - b.column)
   return {
     violations,
     summary: {

--- a/src/engine/rules/verb-form.ts
+++ b/src/engine/rules/verb-form.ts
@@ -1,0 +1,76 @@
+import type { TaggedToken, Tagger } from "../tagger.ts"
+import type { Violation } from "../types.ts"
+
+const BE_FORMS = new Set(["am", "is", "are", "was", "were", "be", "been", "being"])
+
+const isBeForm = (token: TaggedToken) => BE_FORMS.has(token.text.toLowerCase())
+
+const isPerfectAuxiliary = (token: TaggedToken) => token.pos === "AUX" && token.lemma === "have"
+
+// Adverbs and "not" may sit between the auxiliary and its verb
+// ("was quickly closed", "were not shown") without breaking the construct.
+const isSkippable = (token: TaggedToken) =>
+  token.pos === "ADV" || token.text.toLowerCase() === "not"
+
+const isProgressiveVerb = (token: TaggedToken) =>
+  token.pos === "VERB" && token.text.toLowerCase().endsWith("ing")
+
+// After a be/have auxiliary, any non-"ing" verb is a past participle in
+// practice, which covers irregular forms (broken, sent, written) without a list.
+const isPastParticiple = (token: TaggedToken) =>
+  token.pos === "VERB" && !token.text.toLowerCase().endsWith("ing")
+
+function nextContentToken(tokens: readonly TaggedToken[], start: number): TaggedToken | undefined {
+  for (let i = start; i < tokens.length; i++) {
+    const token = tokens[i]
+    if (token !== undefined && !isSkippable(token)) {
+      return token
+    }
+  }
+  return undefined
+}
+
+export function verbForm(lines: readonly string[], tag: Tagger): Violation[] {
+  const violations: Violation[] = []
+
+  lines.forEach((line, index) => {
+    if (line.trim() === "") {
+      return
+    }
+    const tokens = tag(line)
+
+    tokens.forEach((token, i) => {
+      const head = nextContentToken(tokens, i + 1)
+      if (head === undefined) {
+        return
+      }
+      const found = line.slice(token.offset, head.offset + head.text.length)
+      const position = { line: index + 1, column: token.offset + 1 }
+
+      if (isBeForm(token) && isProgressiveVerb(head)) {
+        violations.push({
+          ruleId: "verb-progressive",
+          severity: "hard",
+          message: `Use a simple tense. Do not use the progressive. Found: "${found}".`,
+          ...position,
+        })
+      } else if (isBeForm(token) && isPastParticiple(head)) {
+        violations.push({
+          ruleId: "verb-passive",
+          severity: "soft",
+          message: `Use the active voice, unless the actor is unknown. Found: "${found}".`,
+          ...position,
+        })
+      } else if (isPerfectAuxiliary(token) && isPastParticiple(head)) {
+        violations.push({
+          ruleId: "verb-perfect",
+          severity: "hard",
+          message: `Use the simple past. Do not use the perfect tense. Found: "${found}".`,
+          ...position,
+        })
+      }
+    })
+  })
+
+  return violations
+}

--- a/src/engine/tagger.ts
+++ b/src/engine/tagger.ts
@@ -1,0 +1,8 @@
+export interface TaggedToken {
+  readonly text: string
+  readonly pos: string
+  readonly lemma: string
+  readonly offset: number
+}
+
+export type Tagger = (text: string) => readonly TaggedToken[]

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,3 +1,5 @@
+import type { Tagger } from "./tagger.ts"
+
 export type LintKind = "prose-file"
 
 export type Severity = "hard" | "soft"
@@ -12,6 +14,8 @@ export interface Violation {
 
 export interface LintOptions {
   readonly maxSentenceWords?: number
+  // POS tagger for the verb-form rules; when absent those rules do not run.
+  readonly tagger?: Tagger
 }
 
 export interface LintReport {

--- a/src/tagger/wink.ts
+++ b/src/tagger/wink.ts
@@ -1,0 +1,36 @@
+import { Context, Layer } from "effect"
+import model from "wink-eng-lite-web-model"
+import winkNLP, { type ItemToken, type ItsFunction } from "wink-nlp"
+import type { TaggedToken, Tagger } from "../engine/tagger.ts"
+
+export function makeWinkTagger(): Tagger {
+  const nlp = winkNLP(model, ["sbd", "pos"])
+  const its = nlp.its
+  // wink-nlp's d.ts declares its.lemma with a signature token.out() rejects;
+  // at runtime it is a valid token helper, so cast to the accepted shape.
+  const lemma = its.lemma as unknown as ItsFunction<string>
+  return (text) => {
+    const doc = nlp.readDoc(text)
+    const tokens: TaggedToken[] = []
+    // wink-nlp does not expose character offsets, so recover them by scanning
+    // for each token value in order; values are verbatim slices of the input.
+    let cursor = 0
+    doc.tokens().each((token: ItemToken) => {
+      const value = token.out(its.value)
+      const found = text.indexOf(value, cursor)
+      const offset = found === -1 ? cursor : found
+      tokens.push({
+        text: value,
+        pos: token.out(its.pos),
+        lemma: token.out(lemma),
+        offset,
+      })
+      cursor = offset + value.length
+    })
+    return tokens
+  }
+}
+
+export class TaggerService extends Context.Tag("TaggerService")<TaggerService, Tagger>() {}
+
+export const WinkTaggerLive = Layer.sync(TaggerService, makeWinkTagger)

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -94,6 +94,22 @@ describe("simple-english CLI", () => {
     })
   })
 
+  test("exits 1 on progressive tense, a hard violation", async () => {
+    const result = await runCli([], "The pump is running.")
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("<stdin>:1:10 verb-progressive")
+    expect(result.stdout).toContain("Do not use the progressive")
+  })
+
+  test("prints passive voice but exits 0 because it is soft", async () => {
+    const result = await runCli([], "The bolt was removed.")
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain("<stdin>:1:10 verb-passive")
+    expect(result.stdout).toContain("active voice")
+  })
+
   test("errors with exit code 2 on an unreadable file", async () => {
     const result = await runCli(["test/fixtures/does-not-exist.md"])
 

--- a/test/engine/verb-form-fixtures.test.ts
+++ b/test/engine/verb-form-fixtures.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+import { makeWinkTagger } from "../../src/tagger/wink.ts"
+
+// Fixture suite against the real wink-nlp tagger. Each entry pins the accepted
+// verdict, right or wrong, so tagger or rule changes surface as diffs here.
+const tagger = makeWinkTagger()
+
+const ruleIds = (text: string) =>
+  lint("prose-file", text, { tagger }).violations.map((violation) => violation.ruleId)
+
+interface Fixture {
+  readonly text: string
+  readonly expected: readonly string[]
+  readonly note?: string
+}
+
+const passives: readonly Fixture[] = [
+  { text: "The bolt was removed by the technician.", expected: ["verb-passive"] },
+  { text: "The cables are connected to the panel.", expected: ["verb-passive"] },
+  { text: "The filter must be replaced every month.", expected: ["verb-passive"] },
+  { text: "The window was broken.", expected: ["verb-passive"] },
+  { text: "The report was written by the engineer.", expected: ["verb-passive"] },
+  { text: "The parts were taken from the shelf.", expected: ["verb-passive"] },
+  { text: "The instructions are given in chapter two.", expected: ["verb-passive"] },
+  { text: "The results were not shown.", expected: ["verb-passive"] },
+  { text: "The valve was quickly closed by the operator.", expected: ["verb-passive"] },
+]
+
+const actives: readonly Fixture[] = [
+  { text: "The technician removes the bolt.", expected: [] },
+  { text: "Remove the bolt.", expected: [] },
+  { text: "The pump supplies fuel to the engine.", expected: [] },
+  { text: "The team completed the test.", expected: [] },
+  { text: "The engineer wrote the report.", expected: [] },
+  { text: "Turn the handle to the left.", expected: [] },
+]
+
+const progressives: readonly Fixture[] = [
+  { text: "The pump is running.", expected: ["verb-progressive"] },
+  { text: "The technicians were installing the pump.", expected: ["verb-progressive"] },
+  { text: "The light is flashing quickly.", expected: ["verb-progressive"] },
+]
+
+const perfects: readonly Fixture[] = [
+  { text: "The technician has finished the task.", expected: ["verb-perfect"] },
+  { text: "The team had completed the test before the review.", expected: ["verb-perfect"] },
+  { text: "We have removed the old filter.", expected: ["verb-perfect"] },
+]
+
+const tricky: readonly Fixture[] = [
+  {
+    text: "The door is closed.",
+    expected: ["verb-passive"],
+    note: "adjectival state, accepted false positive; the pi-ste reference flags it too",
+  },
+  {
+    text: "The system is being tested.",
+    expected: ["verb-passive"],
+    note: "passive progressive; wink tags 'being' AUX, so only the passive fires",
+  },
+  {
+    text: "The report has been sent.",
+    expected: ["verb-passive"],
+    note: "perfect passive reported as passive only, mirroring the pi-ste reference",
+  },
+  {
+    text: "The goal is to win.",
+    expected: [],
+    note: "infinitive after a linking verb is not a participle",
+  },
+  {
+    text: "The equipment is ready.",
+    expected: [],
+    note: "plain adjective predicate",
+  },
+  {
+    text: "The manual is interesting.",
+    expected: [],
+    note: "wink tags 'interesting' ADJ; the pi-ste regex wrongly flags this as progressive",
+  },
+  {
+    text: "The technicians have the tools.",
+    expected: [],
+    note: "main-verb have is not a perfect auxiliary",
+  },
+]
+
+const suites: readonly [string, readonly Fixture[]][] = [
+  ["passive voice", passives],
+  ["active voice", actives],
+  ["progressive tense", progressives],
+  ["perfect tense", perfects],
+  ["tricky pinned verdicts", tricky],
+]
+
+describe("verb-form rules against the real wink-nlp tagger", () => {
+  for (const [name, fixtures] of suites) {
+    describe(name, () => {
+      for (const fixture of fixtures) {
+        test(`"${fixture.text}" -> [${fixture.expected.join(", ")}]`, () => {
+          expect(ruleIds(fixture.text)).toEqual(fixture.expected)
+        })
+      }
+    })
+  }
+
+  test("verdicts are deterministic across repeated runs", () => {
+    const text = "The bolt was removed by the technician."
+    const first = lint("prose-file", text, { tagger })
+    const second = lint("prose-file", text, { tagger: makeWinkTagger() })
+    expect(second).toEqual(first)
+  })
+})

--- a/test/engine/verb-form.test.ts
+++ b/test/engine/verb-form.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+import type { TaggedToken, Tagger } from "../../src/engine/tagger.ts"
+
+// Stub tagger: each input line maps to a "word/POS/lemma ..." annotation,
+// mirroring real wink-nlp output so the rule logic is tested without the model.
+function stubTagger(annotations: Record<string, string>): Tagger {
+  return (text) => {
+    const annotation = annotations[text]
+    if (annotation === undefined) {
+      throw new Error(`stub tagger has no annotation for: "${text}"`)
+    }
+    const tokens: TaggedToken[] = []
+    let cursor = 0
+    for (const entry of annotation.split(" ")) {
+      const [word, pos, lemma] = entry.split("/")
+      if (word === undefined || pos === undefined || lemma === undefined) {
+        throw new Error(`bad stub annotation entry: "${entry}"`)
+      }
+      const offset = text.indexOf(word, cursor)
+      tokens.push({ text: word, pos, lemma, offset })
+      cursor = offset + word.length
+    }
+    return tokens
+  }
+}
+
+describe("lint prose-file: verb-form rules (stub tagger)", () => {
+  test("flags passive voice as a soft violation with a rewrite hint", () => {
+    const text = "The bolt was removed."
+    const tagger = stubTagger({
+      [text]: "The/DET/the bolt/NOUN/bolt was/AUX/be removed/VERB/remove ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "verb-passive",
+      severity: "soft",
+      line: 1,
+      column: 10,
+    })
+    expect(report.violations[0]?.message).toContain("active voice")
+    expect(report.violations[0]?.message).toContain('Found: "was removed"')
+    expect(report.summary).toEqual({ total: 1, hard: 0 })
+  })
+
+  test("flags progressive tense as a hard violation", () => {
+    const text = "The pump is running."
+    const tagger = stubTagger({
+      [text]: "The/DET/the pump/NOUN/pump is/AUX/be running/VERB/run ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "verb-progressive",
+      severity: "hard",
+      line: 1,
+      column: 10,
+    })
+    expect(report.violations[0]?.message).toContain("simple tense")
+    expect(report.violations[0]?.message).toContain('Found: "is running"')
+  })
+
+  test("flags perfect tense as a hard violation", () => {
+    const text = "The technician has finished the task."
+    const tagger = stubTagger({
+      [text]:
+        "The/DET/the technician/NOUN/technician has/AUX/have finished/VERB/finish the/DET/the task/NOUN/task ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "verb-perfect",
+      severity: "hard",
+      line: 1,
+      column: 16,
+    })
+    expect(report.violations[0]?.message).toContain("simple past")
+    expect(report.violations[0]?.message).toContain('Found: "has finished"')
+  })
+
+  test("does not flag active voice", () => {
+    const text = "Remove the bolt."
+    const tagger = stubTagger({
+      [text]: "Remove/VERB/remove the/DET/the bolt/NOUN/bolt ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
+  })
+
+  test("detects passive across an intervening adverb", () => {
+    const text = "The valve was quickly closed."
+    const tagger = stubTagger({
+      [text]:
+        "The/DET/the valve/NOUN/valve was/AUX/be quickly/ADV/quickly closed/VERB/close ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.ruleId).toBe("verb-passive")
+    expect(report.violations[0]?.message).toContain('Found: "was quickly closed"')
+  })
+
+  test("detects passive across a negation", () => {
+    const text = "The results were not shown."
+    const tagger = stubTagger({
+      [text]: "The/DET/the results/NOUN/result were/AUX/be not/PART/not shown/VERB/show ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.ruleId).toBe("verb-passive")
+  })
+
+  test("does not flag an infinitive after a linking verb", () => {
+    const text = "The goal is to win."
+    const tagger = stubTagger({
+      [text]: "The/DET/the goal/NOUN/goal is/AUX/be to/PART/to win/VERB/win ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
+  })
+
+  test("does not flag main-verb have", () => {
+    const text = "The technicians have the tools."
+    const tagger = stubTagger({
+      [text]:
+        "The/DET/the technicians/NOUN/technician have/VERB/have the/DET/the tools/NOUN/tool ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
+  })
+
+  test("flags 'has been sent' as passive only, mirroring the pi-ste reference", () => {
+    const text = "The report has been sent."
+    const tagger = stubTagger({
+      [text]: "The/DET/the report/NOUN/report has/AUX/have been/AUX/be sent/VERB/send ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ ruleId: "verb-passive", severity: "soft" })
+    expect(report.violations[0]?.message).toContain('Found: "been sent"')
+  })
+
+  test("skips verb-form rules when no tagger is provided", () => {
+    expect(lint("prose-file", "The bolt was removed.").violations).toHaveLength(0)
+  })
+
+  test("reports the line of the violation and ignores fenced code blocks", () => {
+    const passive = "The bolt was removed."
+    const text = ["```", passive, "```", "", passive].join("\n")
+    const tagger = stubTagger({
+      [passive]: "The/DET/the bolt/NOUN/bolt was/AUX/be removed/VERB/remove ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ ruleId: "verb-passive", line: 5, column: 10 })
+  })
+
+  test("flags each occurrence on a line", () => {
+    const text = "The bolt was removed. The panel was cleaned."
+    const tagger = stubTagger({
+      [text]:
+        "The/DET/the bolt/NOUN/bolt was/AUX/be removed/VERB/remove ./PUNCT/. The/DET/the panel/NOUN/panel was/AUX/be cleaned/VERB/clean ./PUNCT/.",
+    })
+
+    const report = lint("prose-file", text, { tagger })
+
+    expect(report.violations).toHaveLength(2)
+    expect(report.violations[0]).toMatchObject({ ruleId: "verb-passive", column: 10 })
+    expect(report.violations[1]).toMatchObject({ ruleId: "verb-passive", column: 33 })
+  })
+})


### PR DESCRIPTION
## Intent

Implement Linear HUF-133 for pi-simple-english: add verb-form lint rules (passive voice, progressive tense, perfect tense) detected via real POS tagging with wink-nlp, not regex heuristics. Severity split deliberately mirrors the pi-ste Gleam reference (github.com/ctotheameron/pi-ste): passive is soft, progressive and perfect are hard; messages reuse its wording with a 'Found: ...' snippet as the rewrite hint. The tagger is an injectable boundary per the HUF-130 spec: the engine consumes a pure sync Tagger function type (src/engine/tagger.ts) and deliberately skips verb-form rules when LintOptions.tagger is absent, keeping the engine core pure with no wink dependency; wink-nlp is wrapped behind an Effect Context.Tag and Layer in src/tagger/wink.ts provided at the CLI boundary. wink-nlp and wink-eng-lite-web-model are runtime dependencies (not dev) because pi installs with npm install --omit=dev. Deliberate decisions: detection is line-based (mirroring pi-ste, so cross-line constructs are not matched); be-forms match by surface text because wink lemmatizes 'being' to 'being'; a participle after an auxiliary is any non-ing VERB, which covers irregular participles without a word list; 'has been sent' is pinned as passive-only and 'The door is closed' is pinned as an accepted adjectival false positive, both mirroring pi-ste behavior; 'is being tested' is pinned as passive-only since wink tags 'being' AUX; violations are sorted by line then column in lint(). Tests follow the project's engine-seam rule: stub-tagger tests avoid the real model, a separate fixture suite pins verdicts against the real wink model including tricky non-passives, and CLI E2E tests assert hard progressive gives exit 1 while soft passive prints but exits 0. An upstream d.ts bug in wink-nlp forces a commented cast for its.lemma. Scope excludes dictionary rules (HUF-137). Sibling tickets HUF-132/134/135/136 are being built in parallel on separate branches, so the change stays self-contained and additive to shared files.

## What Changed

- Add line-based passive, progressive, and perfect tense detection through an injectable POS tagger.
- Integrate wink-nlp at the CLI boundary, with passive violations soft and progressive or perfect violations hard.
- Add engine, real-model fixture, and CLI coverage, and clarify soft-violation exit behavior.

## Risk Assessment

✅ Low: The change is well-bounded, matches the stated intent, preserves the pure engine boundary, and includes focused engine and CLI coverage.

## Testing

No prior baseline results were supplied; after resolving the missing local dependencies, the focused engine, real wink model, and CLI suites completed successfully, while manual CLI transcripts confirmed severity, exit codes, rewrite hints, line-based detection, and operation after an omit-dev install.

<details>
<summary>Evidence: CLI verb-form behavior transcript</summary>

```text
$ printf "The bolt was removed.\\n" | bun src/cli/main.ts
<stdin>:1:10 verb-passive Use the active voice, unless the actor is unknown. Found: "was removed".
exit: 0

$ printf "The pump is running.\\n" | bun src/cli/main.ts
<stdin>:1:10 verb-progressive Use a simple tense. Do not use the progressive. Found: "is running".
exit: 1

$ printf "The technician has finished the task.\\n" | bun src/cli/main.ts --json
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "verb-perfect",
      "severity": "hard",
      "message": "Use the simple past. Do not use the perfect tense. Found: \"has finished\".",
      "line": 1,
      "column": 16
    }
  ],
  "summary": {
    "total": 1,
    "hard": 1
  }
}
exit: 1

$ printf "The technician has\\nfinished the task.\\n" | bun src/cli/main.ts --json
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit: 0
```
</details>
<details>
<summary>Evidence: Production omit-dev installation and CLI transcript</summary>

```text
$ npm install --omit=dev --ignore-scripts --package-lock=false
install exit: 0
$ npm ls --omit=dev --depth=0 effect wink-nlp wink-eng-lite-web-model
pi-simple-english@0.1.0 /tmp/no-mistakes-evidence/01KYV977Q7QAP4NJRD7ADG1EAZ/npm-omit-dev-check
├── effect@3.22.1
├── wink-eng-lite-web-model@1.8.1
└── wink-nlp@2.4.0


$ printf "The pump is running.\\n" | bun src/cli/main.ts
<stdin>:1:10 verb-progressive Use a simple tense. Do not use the progressive. Found: "is running".
exit: 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun x vitest run test/engine/verb-form.test.ts test/engine/verb-form-fixtures.test.ts test/cli/cli.test.ts` (initially blocked by missing local dependencies)</code>
- `bun install --frozen-lockfile`
- `bun run test -- test/engine/verb-form.test.ts test/engine/verb-form-fixtures.test.ts test/cli/cli.test.ts`
- `Manual stdin CLI checks for soft passive, hard progressive, hard perfect, and cross-line perfect behavior`
- <code>Production-style `npm install --omit=dev --ignore-scripts --package-lock=false`, dependency inspection, and CLI execution in a temporary evidence sandbox</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
