### PR TITLE
feat(config): add layered rule configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Parent spec lives in Linear HUF-130.
 
 ## Architecture rules (binding, from the HUF-130 spec)
 
-- Pure functional core: the `lint` engine (`src/engine/lint.ts`) is synchronous, no Effect runtime. Effect only at boundaries (CLI IO now; Schema and layers later).
+- Pure functional core: the `lint` engine (`src/engine/lint.ts`) is synchronous, no Effect runtime. Effect only at boundaries (CLI IO, config loading and Schema decoding in `src/config/`; layers later).
+- New rules must register their id in `src/engine/rules/registry.ts`; the config schema derives valid rule names from it, so unregistered ids are rejected in user config.
 - Three test seams only: pure engine API (~90% of suite, `test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), extension wiring via stubbed ExtensionAPI double. Never run pi itself in tests.
 - Severity model: violations carry `hard`/`soft`; hard violations drive CLI exit code 1.
 - TDD per rule: failing engine-seam test first, then implement.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,29 @@ simple-english --json README.md
 ```
 
 Prints STE violations with line, column, and rule id.
-Exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when a file cannot be read.
+Exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when a file cannot be read or a config file is invalid.
 Soft violations are still printed when the command exits 0.
 `--json` emits a machine-readable report.
+`--config <path>` loads an explicit config file instead of the discovered ones.
+
+## Configuration
+
+Config is optional JSON.
+The global file lives in the pi agent config directory at `~/.pi/agent/simple-english.json`.
+An optional per-project file at `.pi/simple-english.json` deep-merges over it, with the project value winning per key.
+
+```json
+{
+  "rules": {
+    "sentence-length": "soft"
+  },
+  "maxSentenceWords": 20
+}
+```
+
+Every rule can be set to `hard` (violations fail the run), `soft` (violations are reported but do not fail the run), or `off`.
+`maxSentenceWords` tunes the sentence-length cap (default 25).
+Config is validated: an unknown rule name, a bad severity value, or an unknown key produces an error naming the bad key, never a silent fall-back to defaults.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Soft violations are still printed when the command exits 0.
 
 ## Configuration
 
-Config is optional JSON.
-The global file lives in the pi agent config directory at `~/.pi/agent/simple-english.json`.
+Config is an optional JSON object.
+The global file lives at `simple-english.json` in the pi agent config directory, which defaults to `~/.pi/agent` and honors `PI_CODING_AGENT_DIR`.
 An optional per-project file at `.pi/simple-english.json` deep-merges over it, with the project value winning per key.
 
 ```json
@@ -34,8 +34,8 @@ An optional per-project file at `.pi/simple-english.json` deep-merges over it, w
 ```
 
 Every rule can be set to `hard` (violations fail the run), `soft` (violations are reported but do not fail the run), or `off`.
-`maxSentenceWords` tunes the sentence-length cap (default 25).
-Config is validated: an unknown rule name, a bad severity value, or an unknown key produces an error naming the bad key, never a silent fall-back to defaults.
+`maxSentenceWords` tunes the sentence-length cap and must be a positive integer (default 25).
+Config is validated: an unknown rule name, a bad severity or tunable value, or an unknown key produces a readable error, never a silent fall-back to defaults.
 
 ## Development
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,9 +1,37 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises"
 import { Effect } from "effect"
+import { loadConfig } from "../config/load.ts"
 import { lint } from "../engine/lint.ts"
 import type { LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
+
+interface CliArgs {
+  readonly json: boolean
+  readonly configPath: string | undefined
+  readonly paths: readonly string[]
+}
+
+const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
+  Effect.gen(function* () {
+    let json = false
+    let configPath: string | undefined
+    const paths: string[] = []
+    for (let i = 0; i < args.length; i++) {
+      const arg = args[i] as string
+      if (arg === "--json") {
+        json = true
+      } else if (arg === "--config") {
+        configPath = args[++i]
+        if (configPath === undefined) {
+          yield* Effect.fail(new Error("--config requires a file path"))
+        }
+      } else {
+        paths.push(arg)
+      }
+    }
+    return { json, configPath, paths }
+  })
 
 interface FileViolation {
   readonly file: string
@@ -59,16 +87,18 @@ const render = (report: CliReport, json: boolean): string => {
 
 const program = Effect.gen(function* () {
   const tagger = yield* TaggerService
-  const args = process.argv.slice(2)
-  const json = args.includes("--json")
-  const paths = args.filter((arg) => arg !== "--json")
+  const { json, configPath, paths } = yield* parseArgs(process.argv.slice(2))
+  const config = yield* loadConfig(configPath)
   const inputs =
     paths.length === 0
       ? [{ path: "<stdin>", text: yield* readStdin }]
       : yield* Effect.forEach(paths, readInput)
 
   const report = toCliReport(
-    inputs.map(({ path, text }) => ({ path, report: lint("prose-file", text, { tagger }) })),
+    inputs.map(({ path, text }) => ({
+      path,
+      report: lint("prose-file", text, { ...config, tagger }),
+    })),
   )
 
   const output = render(report, json)
@@ -78,7 +108,17 @@ const program = Effect.gen(function* () {
   return report.summary.hard > 0 ? 1 : 0
 })
 
-const exitCode = await Effect.runPromise(Effect.provide(program, WinkTaggerLive)).catch((error) => {
+const handled = program.pipe(
+  Effect.provide(WinkTaggerLive),
+  Effect.catchAll((error) =>
+    Effect.sync(() => {
+      console.error(error.message)
+      return 2
+    }),
+  ),
+)
+
+const exitCode = await Effect.runPromise(handled).catch((error) => {
   console.error(String(error))
   return 2
 })

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -5,7 +5,20 @@ import { Effect } from "effect"
 import { mergeConfigs } from "./merge.ts"
 import { ConfigError, type SteConfig, decodeConfig } from "./schema.ts"
 
-export const globalConfigPath = (): string => join(homedir(), ".pi", "agent", "simple-english.json")
+const agentConfigDirectory = (): string => {
+  const configured = process.env.PI_CODING_AGENT_DIR
+  if (!configured) {
+    return join(homedir(), ".pi", "agent")
+  }
+  if (configured === "~") {
+    return homedir()
+  }
+  return configured.startsWith("~/") || (process.platform === "win32" && configured.startsWith("~\\"))
+    ? join(homedir(), configured.slice(2))
+    : configured
+}
+
+export const globalConfigPath = (): string => join(agentConfigDirectory(), "simple-english.json")
 
 export const projectConfigPath = (cwd: string): string => join(cwd, ".pi", "simple-english.json")
 

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -13,7 +13,8 @@ const agentConfigDirectory = (): string => {
   if (configured === "~") {
     return homedir()
   }
-  return configured.startsWith("~/") || (process.platform === "win32" && configured.startsWith("~\\"))
+  return configured.startsWith("~/") ||
+    (process.platform === "win32" && configured.startsWith("~\\"))
     ? join(homedir(), configured.slice(2))
     : configured
 }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import { Effect } from "effect"
+import { mergeConfigs } from "./merge.ts"
+import { ConfigError, type SteConfig, decodeConfig } from "./schema.ts"
+
+export const globalConfigPath = (): string => join(homedir(), ".pi", "agent", "simple-english.json")
+
+export const projectConfigPath = (cwd: string): string => join(cwd, ".pi", "simple-english.json")
+
+const isMissingFile = (cause: unknown): boolean =>
+  typeof cause === "object" && cause !== null && (cause as { code?: string }).code === "ENOENT"
+
+const readConfigFile = (path: string, optional: boolean): Effect.Effect<SteConfig, ConfigError> =>
+  Effect.tryPromise({
+    try: () => readFile(path, "utf8"),
+    catch: (cause) => cause,
+  }).pipe(
+    Effect.matchEffect({
+      onFailure: (cause) =>
+        optional && isMissingFile(cause)
+          ? Effect.succeed<SteConfig>({})
+          : Effect.fail(new ConfigError(`cannot read config file ${path}: ${cause}`)),
+      onSuccess: (text) =>
+        Effect.try({
+          try: () => JSON.parse(text) as unknown,
+          catch: (cause) => new ConfigError(`invalid JSON in ${path}: ${cause}`),
+        }).pipe(Effect.flatMap((json) => decodeConfig(json, path))),
+    }),
+  )
+
+export const loadConfig = (
+  explicitPath?: string,
+  cwd = process.cwd(),
+): Effect.Effect<SteConfig, ConfigError> =>
+  explicitPath === undefined
+    ? Effect.all([
+        readConfigFile(globalConfigPath(), true),
+        readConfigFile(projectConfigPath(cwd), true),
+      ]).pipe(Effect.map(([global, project]) => mergeConfigs(global, project)))
+    : readConfigFile(explicitPath, false)

--- a/src/config/merge.ts
+++ b/src/config/merge.ts
@@ -1,0 +1,20 @@
+import type { SteConfig } from "./schema.ts"
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const deepMerge = (
+  base: Record<string, unknown>,
+  over: Record<string, unknown>,
+): Record<string, unknown> => {
+  const merged = { ...base }
+  for (const [key, value] of Object.entries(over)) {
+    const existing = merged[key]
+    merged[key] =
+      isPlainObject(existing) && isPlainObject(value) ? deepMerge(existing, value) : value
+  }
+  return merged
+}
+
+export const mergeConfigs = (global: SteConfig, project: SteConfig): SteConfig =>
+  deepMerge(global as Record<string, unknown>, project as Record<string, unknown>) as SteConfig

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,69 @@
+import { Effect, ParseResult, Schema } from "effect"
+import { type RuleId, ruleIds } from "../engine/rules/registry.ts"
+import type { RuleSetting } from "../engine/types.ts"
+
+export interface SteConfig {
+  readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
+  readonly maxSentenceWords?: number
+}
+
+const RuleSettingSchema = Schema.Literal("hard", "soft", "off").annotations({
+  message: (issue) => ({
+    message: `must be "hard", "soft", or "off", got ${JSON.stringify(issue.actual)}`,
+    override: true,
+  }),
+})
+
+const RulesSchema = Schema.partial(
+  Schema.Struct(Object.fromEntries(ruleIds.map((id) => [id, RuleSettingSchema]))),
+)
+
+const MaxSentenceWordsSchema = Schema.Int.pipe(Schema.positive()).annotations({
+  message: (issue) => ({
+    message: `must be a positive integer, got ${JSON.stringify(issue.actual)}`,
+    override: true,
+  }),
+})
+
+const SteConfigSchema = Schema.Struct({
+  rules: Schema.optional(RulesSchema),
+  maxSentenceWords: Schema.optional(MaxSentenceWordsSchema),
+})
+
+const decodeUnknown = Schema.decodeUnknown(SteConfigSchema, {
+  onExcessProperty: "error",
+  errors: "all",
+})
+
+export class ConfigError extends Error {
+  readonly _tag = "ConfigError"
+}
+
+const formatError = (error: ParseResult.ParseError, source: string): string => {
+  // Optional fields decode as `T | undefined` unions, so every failure also
+  // reports a useless "Expected undefined" branch; drop those.
+  const issues = ParseResult.ArrayFormatter.formatErrorSync(error).filter(
+    (issue) => !issue.message.startsWith("Expected undefined"),
+  )
+  const lines = [
+    ...new Set(
+      issues.map(
+        (issue) => `${issue.path.length > 0 ? issue.path.join(".") : "config"}: ${issue.message}`,
+      ),
+    ),
+  ]
+  const detail =
+    lines.length > 0
+      ? lines.map((line) => `  ${line}`).join("\n")
+      : `  ${ParseResult.TreeFormatter.formatErrorSync(error)}`
+  return `invalid config in ${source}:\n${detail}`
+}
+
+export const decodeConfig = (
+  input: unknown,
+  source: string,
+): Effect.Effect<SteConfig, ConfigError> =>
+  decodeUnknown(input).pipe(
+    Effect.mapError((error) => new ConfigError(formatError(error, source))),
+    Effect.map((config) => config as SteConfig),
+  )

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -23,10 +23,19 @@ const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Viol
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const violations = linters[kind](text, {
+  const raw = linters[kind](text, {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     tagger: options.tagger,
-  }).sort((a, b) => a.line - b.line || a.column - b.column)
+  })
+  const violations = raw
+    .flatMap((violation) => {
+      const setting = options.rules?.[violation.ruleId]
+      if (setting === undefined) {
+        return [violation]
+      }
+      return setting === "off" ? [] : [{ ...violation, severity: setting }]
+    })
+    .sort((a, b) => a.line - b.line || a.column - b.column)
   return {
     violations,
     summary: {

--- a/src/engine/rules/registry.ts
+++ b/src/engine/rules/registry.ts
@@ -1,0 +1,8 @@
+export const ruleIds = [
+  "sentence-length",
+  "verb-progressive",
+  "verb-passive",
+  "verb-perfect",
+] as const
+
+export type RuleId = (typeof ruleIds)[number]

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -4,6 +4,8 @@ export type LintKind = "prose-file"
 
 export type Severity = "hard" | "soft"
 
+export type RuleSetting = Severity | "off"
+
 export interface Violation {
   readonly ruleId: string
   readonly severity: Severity
@@ -13,6 +15,7 @@ export interface Violation {
 }
 
 export interface LintOptions {
+  readonly rules?: Readonly<Record<string, RuleSetting>>
   readonly maxSentenceWords?: number
   // POS tagger for the verb-form rules; when absent those rules do not run.
   readonly tagger?: Tagger

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,3 +1,4 @@
+import type { RuleId } from "./rules/registry.ts"
 import type { Tagger } from "./tagger.ts"
 
 export type LintKind = "prose-file"
@@ -7,7 +8,7 @@ export type Severity = "hard" | "soft"
 export type RuleSetting = Severity | "off"
 
 export interface Violation {
-  readonly ruleId: string
+  readonly ruleId: RuleId
   readonly severity: Severity
   readonly message: string
   readonly line: number
@@ -15,7 +16,7 @@ export interface Violation {
 }
 
 export interface LintOptions {
-  readonly rules?: Readonly<Record<string, RuleSetting>>
+  readonly rules?: Partial<Record<RuleId, RuleSetting>>
   readonly maxSentenceWords?: number
   // POS tagger for the verb-form rules; when absent those rules do not run.
   readonly tagger?: Tagger

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -64,7 +64,7 @@ describe("simple-english CLI", () => {
   })
 
   test("exits 1 on progressive tense, a hard violation", async () => {
-    const result = await runCli([], "The pump is running.")
+    const result = await runCli([], { stdin: "The pump is running." })
 
     expect(result.code).toBe(1)
     expect(result.stdout).toContain("<stdin>:1:10 verb-progressive")
@@ -72,7 +72,7 @@ describe("simple-english CLI", () => {
   })
 
   test("prints passive voice but exits 0 because it is soft", async () => {
-    const result = await runCli([], "The bolt was removed.")
+    const result = await runCli([], { stdin: "The bolt was removed." })
 
     expect(result.code).toBe(0)
     expect(result.stdout).toContain("<stdin>:1:10 verb-passive")

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,36 +1,5 @@
-import { execFile } from "node:child_process"
-import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
-
-const repoRoot = fileURLToPath(new URL("../..", import.meta.url))
-
-interface CliResult {
-  code: number
-  stdout: string
-  stderr: string
-}
-
-async function runCli(args: string[], stdin?: string): Promise<CliResult> {
-  return new Promise((resolve, reject) => {
-    const child = execFile(
-      "bun",
-      ["src/cli/main.ts", ...args],
-      { cwd: repoRoot },
-      (error, stdout, stderr) => {
-        const code = error && typeof error.code === "number" ? error.code : 0
-        if (error && typeof error.code !== "number") {
-          reject(error)
-          return
-        }
-        resolve({ code, stdout, stderr })
-      },
-    )
-    if (stdin !== undefined) {
-      child.stdin?.write(stdin)
-    }
-    child.stdin?.end()
-  })
-}
+import { runCli } from "./run-cli.ts"
 
 describe("simple-english CLI", () => {
   test("exits 0 on a clean file", async () => {
@@ -51,7 +20,7 @@ describe("simple-english CLI", () => {
 
   test("lints stdin when no paths are given", async () => {
     const longSentence = `${Array.from({ length: 30 }, (_, i) => `word${i}`).join(" ")}.`
-    const result = await runCli([], longSentence)
+    const result = await runCli([], { stdin: longSentence })
 
     expect(result.code).toBe(1)
     expect(result.stdout).toContain("<stdin>:1:1")
@@ -59,7 +28,7 @@ describe("simple-english CLI", () => {
   })
 
   test("exits 0 on clean stdin", async () => {
-    const result = await runCli([], "A short sentence.")
+    const result = await runCli([], { stdin: "A short sentence." })
 
     expect(result.code).toBe(0)
   })
@@ -85,7 +54,7 @@ describe("simple-english CLI", () => {
   })
 
   test("--json on clean input emits an empty report and exits 0", async () => {
-    const result = await runCli(["--json"], "A short sentence.")
+    const result = await runCli(["--json"], { stdin: "A short sentence." })
 
     expect(result.code).toBe(0)
     expect(JSON.parse(result.stdout)).toEqual({

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -44,6 +44,17 @@ describe("simple-english CLI config", () => {
     expect(result.stdout).toContain("maximum is 5")
   })
 
+  test("PI_CODING_AGENT_DIR overrides the default pi agent config directory", async () => {
+    const home = await makeHome({ maxSentenceWords: 20 })
+    const agentDir = await makeTempDir()
+    await writeJson(join(agentDir, "simple-english.json"), { maxSentenceWords: 5 })
+    const cwd = await makeProject()
+    const result = await runCli([], { cwd, home, agentDir, stdin: tenWords })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("maximum is 5")
+  })
+
   test("project config deep-merges over global with project winning per key", async () => {
     const home = await makeHome({ maxSentenceWords: 5, rules: { "sentence-length": "soft" } })
     const cwd = await makeProject({ maxSentenceWords: 8 })

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -1,0 +1,122 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+import { makeTempDir, runCli } from "./run-cli.ts"
+
+const tenWords = "one two three four five six seven eight nine ten."
+
+const writeJson = async (path: string, value: unknown): Promise<void> => {
+  await mkdir(join(path, ".."), { recursive: true })
+  await writeFile(path, JSON.stringify(value, null, 2))
+}
+
+const makeProject = async (config?: unknown): Promise<string> => {
+  const cwd = await makeTempDir()
+  if (config !== undefined) {
+    await mkdir(join(cwd, ".pi"), { recursive: true })
+    await writeJson(join(cwd, ".pi", "simple-english.json"), config)
+  }
+  return cwd
+}
+
+const makeHome = async (config: unknown): Promise<string> => {
+  const home = await makeTempDir()
+  await mkdir(join(home, ".pi", "agent"), { recursive: true })
+  await writeJson(join(home, ".pi", "agent", "simple-english.json"), config)
+  return home
+}
+
+describe("simple-english CLI config", () => {
+  test("project config changes the sentence word cap", async () => {
+    const cwd = await makeProject({ maxSentenceWords: 5 })
+    const result = await runCli([], { cwd, stdin: tenWords })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("maximum is 5")
+  })
+
+  test("global config in the pi agent config directory applies", async () => {
+    const home = await makeHome({ maxSentenceWords: 5 })
+    const cwd = await makeProject()
+    const result = await runCli([], { cwd, home, stdin: tenWords })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("maximum is 5")
+  })
+
+  test("project config deep-merges over global with project winning per key", async () => {
+    const home = await makeHome({ maxSentenceWords: 5, rules: { "sentence-length": "soft" } })
+    const cwd = await makeProject({ maxSentenceWords: 8 })
+    const result = await runCli(["--json"], { cwd, home, stdin: tenWords })
+
+    // Project cap (8) wins; the global soft override survives the merge, so exit is 0.
+    expect(result.code).toBe(0)
+    const report = JSON.parse(result.stdout)
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0].severity).toBe("soft")
+    expect(report.violations[0].message).toContain("maximum is 8")
+  })
+
+  test("a rule set to off in project config is suppressed", async () => {
+    const cwd = await makeProject({ maxSentenceWords: 5, rules: { "sentence-length": "off" } })
+    const result = await runCli([], { cwd, stdin: tenWords })
+
+    expect(result.code).toBe(0)
+    expect(result.stdout.trim()).toBe("")
+  })
+
+  test("--config points at an explicit file and ignores discovered configs", async () => {
+    const cwd = await makeProject({ maxSentenceWords: 5 })
+    const explicit = join(await makeTempDir(), "custom.json")
+    await writeJson(explicit, { rules: { "sentence-length": "off" } })
+    const result = await runCli(["--config", explicit], { cwd, stdin: tenWords })
+
+    expect(result.code).toBe(0)
+    expect(result.stdout.trim()).toBe("")
+  })
+
+  test("an invalid config file exits 2 with a readable error naming the file and key", async () => {
+    const cwd = await makeProject({ rules: { "sentence-length": "warn" } })
+    const result = await runCli([], { cwd, stdin: "A short sentence." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain(join(cwd, ".pi", "simple-english.json"))
+    expect(result.stderr).toContain("sentence-length")
+    expect(result.stderr).toContain("warn")
+    expect(result.stderr).not.toContain("FiberFailure")
+    expect(result.stderr).not.toContain("at <anonymous>")
+  })
+
+  test("a config file with malformed JSON exits 2 naming the file", async () => {
+    const cwd = await makeProject()
+    await mkdir(join(cwd, ".pi"), { recursive: true })
+    await writeFile(join(cwd, ".pi", "simple-english.json"), "{ not json")
+    const result = await runCli([], { cwd, stdin: "A short sentence." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain(join(cwd, ".pi", "simple-english.json"))
+  })
+
+  test("a missing explicit --config file exits 2 naming the path", async () => {
+    const cwd = await makeProject()
+    const missing = join(cwd, "nope.json")
+    const result = await runCli(["--config", missing], { cwd, stdin: "A short sentence." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain(missing)
+  })
+
+  test("--config without a path exits 2 with a usage error", async () => {
+    const result = await runCli(["--config"], { stdin: "A short sentence." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("--config")
+  })
+
+  test("defaults apply when no config files exist", async () => {
+    const cwd = await makeProject()
+    const result = await runCli([], { cwd, stdin: tenWords })
+
+    expect(result.code).toBe(0)
+  })
+})

--- a/test/cli/run-cli.ts
+++ b/test/cli/run-cli.ts
@@ -1,0 +1,48 @@
+import { execFile } from "node:child_process"
+import { mkdtemp } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export const repoRoot = fileURLToPath(new URL("../..", import.meta.url))
+const cliPath = join(repoRoot, "src", "cli", "main.ts")
+
+export interface CliResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+export interface CliOptions {
+  stdin?: string
+  cwd?: string
+  home?: string
+}
+
+export const makeTempDir = (): Promise<string> => mkdtemp(join(tmpdir(), "ste-cli-"))
+
+// HOME defaults to an empty temp dir so tests never read the developer's real global config.
+const hermeticHome = makeTempDir()
+
+export async function runCli(args: string[], options: CliOptions = {}): Promise<CliResult> {
+  const home = options.home ?? (await hermeticHome)
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      "bun",
+      [cliPath, ...args],
+      { cwd: options.cwd ?? repoRoot, env: { ...process.env, HOME: home } },
+      (error, stdout, stderr) => {
+        const code = error && typeof error.code === "number" ? error.code : 0
+        if (error && typeof error.code !== "number") {
+          reject(error)
+          return
+        }
+        resolve({ code, stdout, stderr })
+      },
+    )
+    if (options.stdin !== undefined) {
+      child.stdin?.write(options.stdin)
+    }
+    child.stdin?.end()
+  })
+}

--- a/test/cli/run-cli.ts
+++ b/test/cli/run-cli.ts
@@ -17,6 +17,7 @@ export interface CliOptions {
   stdin?: string
   cwd?: string
   home?: string
+  agentDir?: string
 }
 
 export const makeTempDir = (): Promise<string> => mkdtemp(join(tmpdir(), "ste-cli-"))
@@ -26,11 +27,12 @@ const hermeticHome = makeTempDir()
 
 export async function runCli(args: string[], options: CliOptions = {}): Promise<CliResult> {
   const home = options.home ?? (await hermeticHome)
+  const env = { ...process.env, HOME: home, PI_CODING_AGENT_DIR: options.agentDir }
   return new Promise((resolve, reject) => {
     const child = execFile(
       "bun",
       [cliPath, ...args],
-      { cwd: options.cwd ?? repoRoot, env: { ...process.env, HOME: home } },
+      { cwd: options.cwd ?? repoRoot, env },
       (error, stdout, stderr) => {
         const code = error && typeof error.code === "number" ? error.code : 0
         if (error && typeof error.code !== "number") {

--- a/test/config/merge.test.ts
+++ b/test/config/merge.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest"
+import { mergeConfigs } from "../../src/config/merge.ts"
+
+describe("config merge", () => {
+  test("project scalar wins over global", () => {
+    const merged = mergeConfigs({ maxSentenceWords: 20 }, { maxSentenceWords: 15 })
+
+    expect(merged).toEqual({ maxSentenceWords: 15 })
+  })
+
+  test("rules deep-merge per key with project winning", () => {
+    const merged = mergeConfigs(
+      { rules: { "sentence-length": "soft" }, maxSentenceWords: 20 },
+      { rules: { "sentence-length": "off" } },
+    )
+
+    expect(merged).toEqual({ rules: { "sentence-length": "off" }, maxSentenceWords: 20 })
+  })
+
+  test("keys set only on one side survive the merge", () => {
+    const merged = mergeConfigs({ rules: { "sentence-length": "soft" } }, { maxSentenceWords: 15 })
+
+    expect(merged).toEqual({ rules: { "sentence-length": "soft" }, maxSentenceWords: 15 })
+  })
+
+  test("empty configs merge to empty", () => {
+    expect(mergeConfigs({}, {})).toEqual({})
+  })
+})

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -1,0 +1,74 @@
+import { Effect } from "effect"
+import { describe, expect, test } from "vitest"
+import { decodeConfig } from "../../src/config/schema.ts"
+
+const decode = (input: unknown) => Effect.runSync(Effect.either(decodeConfig(input, "test.json")))
+
+const expectDecodeError = (input: unknown): string => {
+  const result = decode(input)
+  expect(result._tag).toBe("Left")
+  return result._tag === "Left" ? result.left.message : ""
+}
+
+describe("config schema", () => {
+  test("decodes a full valid config", () => {
+    const result = decode({
+      rules: { "sentence-length": "soft" },
+      maxSentenceWords: 20,
+    })
+
+    expect(result._tag).toBe("Right")
+    if (result._tag === "Right") {
+      expect(result.right).toEqual({
+        rules: { "sentence-length": "soft" },
+        maxSentenceWords: 20,
+      })
+    }
+  })
+
+  test("decodes an empty config", () => {
+    const result = decode({})
+
+    expect(result._tag).toBe("Right")
+  })
+
+  test("accepts every severity setting", () => {
+    for (const setting of ["hard", "soft", "off"]) {
+      expect(decode({ rules: { "sentence-length": setting } })._tag).toBe("Right")
+    }
+  })
+
+  test("a typo'd rule name produces a readable error naming the bad key", () => {
+    const message = expectDecodeError({ rules: { "sentence-lenght": "hard" } })
+
+    expect(message).toContain("sentence-lenght")
+    expect(message).toContain("test.json")
+  })
+
+  test("an invalid severity value produces a readable error naming the value", () => {
+    const message = expectDecodeError({ rules: { "sentence-length": "warn" } })
+
+    expect(message).toContain("sentence-length")
+    expect(message).toContain("warn")
+    expect(message).toContain('"hard", "soft", or "off"')
+  })
+
+  test("an unknown top-level key produces a readable error naming the key", () => {
+    const message = expectDecodeError({ maxSentenceWord: 10 })
+
+    expect(message).toContain("maxSentenceWord")
+  })
+
+  test("maxSentenceWords must be a positive integer", () => {
+    for (const bad of ["25", 0, 12.5]) {
+      const message = expectDecodeError({ maxSentenceWords: bad })
+      expect(message).toContain("maxSentenceWords")
+      expect(message).toContain("positive integer")
+    }
+  })
+
+  test("a non-object config is rejected", () => {
+    expect(decode("hard")._tag).toBe("Left")
+    expect(decode(null)._tag).toBe("Left")
+  })
+})

--- a/test/engine/lint.test.ts
+++ b/test/engine/lint.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, expectTypeOf, test } from "vitest"
 import { lint } from "../../src/engine/lint.ts"
+import type { RuleId } from "../../src/engine/rules/registry.ts"
+import type { LintOptions, RuleSetting, Violation } from "../../src/engine/types.ts"
 
 describe("lint prose-file: sentence-length rule", () => {
   const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
@@ -108,13 +110,11 @@ describe("lint prose-file: sentence-length rule", () => {
     expect(report.summary).toEqual({ total: 1, hard: 1 })
   })
 
-  test("overrides for other rules do not affect this rule", () => {
-    const report = lint("prose-file", `${words(26)}.`, {
-      rules: { "some-future-rule": "off" },
-    })
-
-    expect(report.violations).toHaveLength(1)
-    expect(report.violations[0]?.severity).toBe("hard")
+  test("engine types are keyed by registry-derived rule IDs", () => {
+    expectTypeOf<Violation["ruleId"]>().toEqualTypeOf<RuleId>()
+    expectTypeOf<LintOptions["rules"]>().toEqualTypeOf<
+      Partial<Record<RuleId, RuleSetting>> | undefined
+    >()
   })
 
   test("summary counts total and hard violations", () => {

--- a/test/engine/lint.test.ts
+++ b/test/engine/lint.test.ts
@@ -79,6 +79,44 @@ describe("lint prose-file: sentence-length rule", () => {
     expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
   })
 
+  test("per-rule override to soft downgrades the violation and the hard count", () => {
+    const report = lint("prose-file", `${words(26)}.`, {
+      rules: { "sentence-length": "soft" },
+    })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.severity).toBe("soft")
+    expect(report.summary).toEqual({ total: 1, hard: 0 })
+  })
+
+  test("per-rule override to off suppresses the rule entirely", () => {
+    const report = lint("prose-file", `${words(26)}.`, {
+      rules: { "sentence-length": "off" },
+    })
+
+    expect(report.violations).toHaveLength(0)
+    expect(report.summary).toEqual({ total: 0, hard: 0 })
+  })
+
+  test("per-rule override to hard keeps the violation hard", () => {
+    const report = lint("prose-file", `${words(26)}.`, {
+      rules: { "sentence-length": "hard" },
+    })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.severity).toBe("hard")
+    expect(report.summary).toEqual({ total: 1, hard: 1 })
+  })
+
+  test("overrides for other rules do not affect this rule", () => {
+    const report = lint("prose-file", `${words(26)}.`, {
+      rules: { "some-future-rule": "off" },
+    })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.severity).toBe("hard")
+  })
+
   test("summary counts total and hard violations", () => {
     const text = `${words(26)}. ${words(27)}.`
     const report = lint("prose-file", text)


### PR DESCRIPTION
## Intent

Implement Linear HUF-136 for pi-simple-english so users can tune every registered lint rule to hard, soft, or off and configure tunable rule values such as the sentence word cap. Validate config with Effect Schema and produce readable errors for unknown rule names and invalid severities. Load global config from the pi agent config directory, deep-merge an optional per-project config over it per key, preserve defaults when files are absent, and add an explicit CLI config-file flag. Keep the lint engine pure and generic over registry-derived rule IDs because sibling rule tickets will add IDs later. Scope excludes extension session-start config loading, which belongs to HUF-138.

## What Changed

- Add Effect Schema-validated configuration for registered rule severities and the sentence word cap, with readable validation errors.
- Load and deep-merge global and project configuration, honor `PI_CODING_AGENT_DIR`, and support an explicit `--config` CLI path.
- Apply `hard`, `soft`, and `off` overrides through the pure lint engine using registry-derived rule IDs.

## Risk Assessment

✅ Low: The config loading, schema validation, deep merge, CLI override, and registry-derived rule typing are well-bounded and satisfy the stated intent without material source risks.

## Testing

The initial targeted run lacked Vitest, so I restored lockfile-pinned dependencies and reran it successfully. End-to-end CLI transcripts then confirmed all configuration behaviors and readable validation errors; no UI artifact was applicable to this CLI-only change.

<details>
<summary>Evidence: End-to-end CLI configuration transcript</summary>

```text

=== Global soft rule plus project maxSentenceWords override (deep merge) ===
$ --json
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "sentence-length",
      "severity": "soft",
      "message": "Sentence has 10 words; the maximum is 8.",
      "line": 1,
      "column": 1
    }
  ],
  "summary": {
    "total": 1,
    "hard": 0
  }
}
exit: 0

=== Project turns the registered rule off ===
$ --json
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit: 0

=== Explicit config selects hard severity and cap 5, ignoring discovered off config ===
$ --config /tmp/no-mistakes-evidence/01KYV95G109ZFCMCHEEZFJR229/explicit.json --json
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "sentence-length",
      "severity": "hard",
      "message": "Sentence has 10 words; the maximum is 5.",
      "line": 1,
      "column": 1
    }
  ],
  "summary": {
    "total": 1,
    "hard": 1
  }
}
exit: 1

=== Unknown rule produces a readable config error ===
$ --config /tmp/no-mistakes-evidence/01KYV95G109ZFCMCHEEZFJR229/unknown-rule.json
invalid config in /tmp/no-mistakes-evidence/01KYV95G109ZFCMCHEEZFJR229/unknown-rule.json:
  rules.not-a-rule: is unexpected, expected: "sentence-length"
exit: 2

=== Invalid severity produces a readable config error ===
$ --config /tmp/no-mistakes-evidence/01KYV95G109ZFCMCHEEZFJR229/invalid-severity.json
invalid config in /tmp/no-mistakes-evidence/01KYV95G109ZFCMCHEEZFJR229/invalid-severity.json:
  rules.sentence-length: must be "hard", "soft", or "off", got "warn"
exit: 2

=== Absent config files preserve defaults (10 words is below default cap 25) ===
$ cd /tmp/no-mistakes-evidence/01KYV95G109ZFCMCHEEZFJR229/empty-project && printf <10-word-sentence> | simple-english --json
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/config/load.ts:8` - Intent requires “Load global config from the pi agent config directory,” but this hardcodes ~/.pi/agent and ignores Pi&#39;s PI_CODING_AGENT_DIR override. Users with a custom agent directory will silently get defaults instead of their global config. Resolve PI_CODING_AGENT_DIR first, with ~/.pi/agent as the fallback.
- 🚨 `src/engine/types.ts:16` - Intent requires the lint engine to be “generic over registry-derived rule IDs,” but LintOptions.rules uses Record&lt;string, RuleSetting&gt; and Violation.ruleId remains string. A sibling rule can emit a typo that compiles, while the schema accepts only the registered spelling, so its configured override is unreachable. Use RuleId for Violation.ruleId and Partial&lt;Record&lt;RuleId, RuleSetting&gt;&gt; at the engine boundary.

🔧 Fix: Honor Pi agent directory and constrain rule IDs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bun run test -- test/engine/lint.test.ts test/config/schema.test.ts test/config/merge.test.ts test/cli/config.test.ts`
- <code>`bun install --frozen-lockfile` to restore missing test dependencies, followed by the targeted test command again</code>
- <code>End-to-end CLI checks for global and project deep merging, hard/soft/off settings, custom word caps, `--config`, absent-file defaults, unknown rules, and invalid severities</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
