### PR TITLE
feat(dictionary): add schema-validated STE dictionary rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,14 @@ Parent spec lives in Linear HUF-130.
 
 ## Architecture rules (binding, from the HUF-130 spec)
 
-- Pure functional core: the `lint` engine (`src/engine/lint.ts`) is synchronous, no Effect runtime. Effect only at boundaries (CLI IO, config loading and Schema decoding in `src/config/`; layers later).
+- Pure functional core: the `lint` engine (`src/engine/lint.ts`) is synchronous, with no Effect runtime. Effect stays at boundaries such as CLI IO, config loading, and schema validation and loading.
 - New rules must register their id in `src/engine/rules/registry.ts`; the config schema derives valid rule names from it, so unregistered ids are rejected in user config.
 - Three test seams only: pure engine API (~90% of suite, `test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), extension wiring via stubbed ExtensionAPI double. Never run pi itself in tests.
 - Severity model: violations carry `hard`/`soft`; hard violations drive CLI exit code 1.
 - TDD per rule: failing engine-seam test first, then implement.
 - pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`, `wink-nlp`) must stay in `dependencies`, never `devDependencies`.
-- POS tagging is an injected boundary: the engine consumes the pure `Tagger` type (`src/engine/tagger.ts`) and silently skips verb-form rules when `LintOptions.tagger` is absent; the wink-nlp implementation and its Effect layer live in `src/tagger/wink.ts`. Tagger-dependent verdicts are pinned, right or wrong, in `test/engine/verb-form-fixtures.test.ts`.
+- POS tagging is an injected boundary: the engine consumes the pure `Tagger` type (`src/engine/tagger.ts`) and silently skips tagger-dependent checks when `LintOptions.tagger` is absent; the wink-nlp implementation and its Effect layer live in `src/tagger/wink.ts`. Tagger-dependent verb verdicts are pinned, right or wrong, in `test/engine/verb-form-fixtures.test.ts`.
+- The package-owned dictionary format and matching semantics are documented in `src/dictionary/README.md`; load and validate dictionary data before passing it into the synchronous engine.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ If that file cannot be read or validated, the CLI prints a dictionary error and 
 
 ## Attribution
 
-The vendored dictionary data is converted from [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste) at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce` and is used under the MIT License.
-The upstream attribution and ASD-STE100 redistribution note are preserved in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+The vendored dictionary data is converted only from the `dictionary/not-approved-word` word and phrase entries in [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste) at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce`.
+The package at that commit declares the MIT License.
+Exact source details and the ASD-STE100 redistribution note are preserved in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # pi-simple-english
 
-A pi extension that makes the pi coding agent comply with ASD-STE100 Simplified Technical English, plus a standalone `simple-english` CLI exposing the same rule engine.
+A pi extension that makes the pi coding agent comply with ASD-STE100 Simplified Technical English, plus a standalone `simple-english` CLI that exposes the same rule engine.
 
-Reimplementation of [pi-ste](https://github.com/ctotheameron/pi-ste) in TypeScript with Effect.
+This project is a TypeScript and Effect reimplementation of [pi-ste](https://github.com/ctotheameron/pi-ste).
 
 ## CLI
 
@@ -12,8 +12,8 @@ cat notes.md | simple-english
 simple-english --json README.md
 ```
 
-Prints STE violations with line, column, and rule id.
-Exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when a file cannot be read or a config file is invalid.
+The CLI prints STE violations with a line, column, and rule ID.
+It exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when an input file cannot be read or a config file is invalid.
 Soft violations are still printed when the command exits 0.
 `--json` emits a machine-readable report.
 `--config <path>` loads an explicit config file instead of the discovered ones.
@@ -36,6 +36,22 @@ An optional per-project file at `.pi/simple-english.json` deep-merges over it, w
 Every rule can be set to `hard` (violations fail the run), `soft` (violations are reported but do not fail the run), or `off`.
 `maxSentenceWords` tunes the sentence-length cap and must be a positive integer (default 25).
 Config is validated: an unknown rule name, a bad severity or tunable value, or an unknown key produces a readable error, never a silent fall-back to defaults.
+
+## Dictionary
+
+The package vendors the widely cited unapproved word and phrase pairs from pi-ste in `src/dictionary/data/pi-ste.json`.
+Each violation is hard and includes the approved alternative as a suggestion.
+Effect Schema validates the package-owned format when the dictionary loads, while the lint engine receives decoded data and stays pure and synchronous.
+POS metadata limits an entry to the applicable use when the injected tagger is available.
+Entries without POS metadata use word-level matching.
+
+Set `SIMPLE_ENGLISH_DICTIONARY` to another file in the same format to test or supply replacement data.
+If that file cannot be read or validated, the CLI prints a dictionary error and continues with all other lint rules.
+
+## Attribution
+
+The vendored dictionary data is converted from [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste) at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce` and is used under the MIT License.
+The upstream attribution and ASD-STE100 redistribution note are preserved in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -39,20 +39,19 @@ Config is validated: an unknown rule name, a bad severity or tunable value, or a
 
 ## Dictionary
 
-The package vendors the widely cited unapproved word and phrase pairs from pi-ste in `src/dictionary/data/pi-ste.json`.
-Each violation is hard and includes the approved alternative as a suggestion.
+The package includes a bundled list of unapproved words and phrases.
+Dictionary violations are hard by default and include the approved alternative as a suggestion.
 Effect Schema validates the package-owned format when the dictionary loads, while the lint engine receives decoded data and stays pure and synchronous.
 POS metadata limits an entry to the applicable use when the injected tagger is available.
 Entries without POS metadata use word-level matching.
 
-Set `SIMPLE_ENGLISH_DICTIONARY` to another file in the same format to test or supply replacement data.
+Set `SIMPLE_ENGLISH_DICTIONARY` to a replacement file that uses the documented [dictionary data format](src/dictionary/README.md).
 If that file cannot be read or validated, the CLI prints a dictionary error and continues with all other lint rules.
 
 ## Attribution
 
-The vendored dictionary data is converted only from the `dictionary/not-approved-word` word and phrase entries in [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste) at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce`.
-The package at that commit declares the MIT License.
-Exact source details and the ASD-STE100 redistribution note are preserved in [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).
+The bundled dictionary is converted from the MIT-licensed [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste) project.
+See [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md) for the exact pinned source, conversion scope, and ASD-STE100 redistribution note.
 
 ## Development
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,28 @@
+# Third-party notices
+
+## Vendored STE dictionary data
+
+`src/dictionary/data/pi-ste.json` is a data-only conversion of the `dictionary/not-approved-word` entries in [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste), `src/ste/dictionary.gleam`, at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce`.
+The upstream package and README declare the work to be MIT licensed.
+No upstream implementation code is included.
+
+The conversion expands the upstream spelling generators into explicit forms.
+Forms produced by upstream helpers named as verb helpers have `VERB` metadata.
+Entries without source POS metadata use word-level matching.
+
+The upstream attribution says that its dictionary and rule lists come from [`Ryuketsukami/ste-plain-writing`](https://github.com/Ryuketsukami/ste-plain-writing) and [`danyuchn/asd-ste100-skill`](https://github.com/danyuchn/asd-ste100-skill), both under the MIT License.
+The upstream notes also state that ASD owns ASD-STE100 and limits redistribution of its full dictionary.
+For that reason, the vendored data contains only the widely cited word and phrase pairs present in the specified pi-ste source file.
+
+## MIT License notices
+
+Copyright (c) 2026 Ege Çelebi
+Copyright (c) 2026 Ryuketsukami
+Copyright (c) 2026 Dustin Yuchen Teng
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,27 +2,12 @@
 
 ## Vendored STE dictionary data
 
-`src/dictionary/data/pi-ste.json` is a data-only conversion of the `dictionary/not-approved-word` entries in [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste), `src/ste/dictionary.gleam`, at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce`.
-The upstream package and README declare the work to be MIT licensed.
-No upstream implementation code is included.
+`src/dictionary/data/pi-ste.json` is a data-only conversion of the entries returned by `word_entries()` and `phrase_entries()` with the `dictionary/not-approved-word` rule ID in [`ctotheameron/pi-ste`](https://github.com/ctotheameron/pi-ste), `src/ste/dictionary.gleam`, at commit `18a8cc686be2cc0e680705daf2327fb0d1ef93ce`.
+The `package.json` at that commit declares the package to be MIT licensed, and its README also states that the license is MIT.
+No other pi-ste lists or upstream implementation code are included.
 
 The conversion expands the upstream spelling generators into explicit forms.
-Forms produced by upstream helpers named as verb helpers have `VERB` metadata.
+Forms produced by upstream verb helpers have `VERB` metadata.
 Entries without source POS metadata use word-level matching.
 
-The upstream attribution says that its dictionary and rule lists come from [`Ryuketsukami/ste-plain-writing`](https://github.com/Ryuketsukami/ste-plain-writing) and [`danyuchn/asd-ste100-skill`](https://github.com/danyuchn/asd-ste100-skill), both under the MIT License.
-The upstream notes also state that ASD owns ASD-STE100 and limits redistribution of its full dictionary.
-For that reason, the vendored data contains only the widely cited word and phrase pairs present in the specified pi-ste source file.
-
-## MIT License notices
-
-Copyright (c) 2026 Ege Çelebi
-Copyright (c) 2026 Ryuketsukami
-Copyright (c) 2026 Dustin Yuchen Teng
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The pinned source states that ASD owns ASD-STE100, limits redistribution of the full dictionary, and describes these entries as widely cited pairs.

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises"
-import { Effect } from "effect"
+import { Effect, Either } from "effect"
 import { loadConfig } from "../config/load.ts"
+import { loadDictionary } from "../dictionary/load.ts"
 import { lint } from "../engine/lint.ts"
 import type { LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
@@ -38,6 +39,7 @@ interface FileViolation {
   readonly ruleId: string
   readonly severity: string
   readonly message: string
+  readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
 }
@@ -89,6 +91,13 @@ const program = Effect.gen(function* () {
   const tagger = yield* TaggerService
   const { json, configPath, paths } = yield* parseArgs(process.argv.slice(2))
   const config = yield* loadConfig(configPath)
+  const loadedDictionary = yield* Effect.either(
+    loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+  )
+  const dictionary = Either.getOrUndefined(loadedDictionary)
+  if (Either.isLeft(loadedDictionary)) {
+    yield* Effect.sync(() => console.error(loadedDictionary.left.message))
+  }
   const inputs =
     paths.length === 0
       ? [{ path: "<stdin>", text: yield* readStdin }]
@@ -97,7 +106,7 @@ const program = Effect.gen(function* () {
   const report = toCliReport(
     inputs.map(({ path, text }) => ({
       path,
-      report: lint("prose-file", text, { ...config, tagger }),
+      report: lint("prose-file", text, { ...config, dictionary, tagger }),
     })),
   )
 

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -10,4 +10,5 @@
 
 The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags.
 The rule checks an entry without `partsOfSpeech` by word or phrase alone.
-See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for source attribution and license notices.
+The bundled data contains only the `dictionary/not-approved-word` entries from the pinned pi-ste `word_entries()` and `phrase_entries()` functions.
+See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for exact source and license details.

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -3,13 +3,16 @@
 `data/pi-ste.json` uses the package-owned format that `schema.ts` defines and Effect Schema validates.
 
 - `formatVersion` identifies incompatible format changes.
-- `source` pins the repository, commit, and path from which the data was converted.
+- `source` records the source name and pins the repository, commit, and path from which the data was converted.
 - `entries[].unapproved` lists exact case-insensitive word forms or phrases.
   Forms can contain letters, numbers, internal apostrophes, internal hyphens, and horizontal whitespace between words.
 - `entries[].suggestions` lists approved alternatives.
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
 
-The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags.
+Unknown properties and unsupported form syntax cause dictionary validation to fail.
+Matching is token based, and a hyphenated form matches only that exact hyphenated token.
+A phrase can span horizontal whitespace or a soft line break in the same Markdown paragraph, but it cannot span Markdown block boundaries or hard line breaks.
+Fenced and indented Markdown code is excluded from matching.
+The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags for the form's first token.
 The rule checks an entry without `partsOfSpeech` by word or phrase alone.
-The bundled data contains only the `dictionary/not-approved-word` entries from the pinned pi-ste `word_entries()` and `phrase_entries()` functions.
-See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for exact source and license details.
+See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the bundled data's exact source, conversion scope, and license details.

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -5,6 +5,7 @@
 - `formatVersion` identifies incompatible format changes.
 - `source` pins the repository, commit, and path from which the data was converted.
 - `entries[].unapproved` lists exact case-insensitive word forms or phrases.
+  Forms can contain letters, numbers, internal apostrophes, internal hyphens, and horizontal whitespace between words.
 - `entries[].suggestions` lists approved alternatives.
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
 

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -1,0 +1,13 @@
+# Dictionary data format
+
+`data/pi-ste.json` uses the package-owned format that `schema.ts` defines and Effect Schema validates.
+
+- `formatVersion` identifies incompatible format changes.
+- `source` pins the repository, commit, and path from which the data was converted.
+- `entries[].unapproved` lists exact case-insensitive word forms or phrases.
+- `entries[].suggestions` lists approved alternatives.
+- `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
+
+The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags.
+The rule checks an entry without `partsOfSpeech` by word or phrase alone.
+See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for source attribution and license notices.

--- a/src/dictionary/data/pi-ste.json
+++ b/src/dictionary/data/pi-ste.json
@@ -1,0 +1,200 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "ctotheameron/pi-ste dictionary",
+    "repository": "https://github.com/ctotheameron/pi-ste",
+    "commit": "18a8cc686be2cc0e680705daf2327fb0d1ef93ce",
+    "path": "src/ste/dictionary.gleam"
+  },
+  "entries": [
+    {
+      "unapproved": ["initiate", "initiates", "initiated", "initiating"],
+      "suggestions": ["start"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["commence", "commences", "commenced", "commencing"],
+      "suggestions": ["start"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["utilize", "utilizes", "utilized", "utilizing"],
+      "suggestions": ["use"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["utilise", "utilises", "utilised", "utilising"],
+      "suggestions": ["use"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["ensure", "ensures", "ensured", "ensuring"],
+      "suggestions": ["make sure"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["terminate", "terminates", "terminated", "terminating"],
+      "suggestions": ["stop"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["facilitate", "facilitates", "facilitated", "facilitating"],
+      "suggestions": ["help"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["locate", "locates", "located", "locating"],
+      "suggestions": ["find"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["indicate", "indicates", "indicated", "indicating"],
+      "suggestions": ["show"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["require", "requires", "required", "requiring"],
+      "suggestions": ["need"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["purchase", "purchases", "purchased", "purchasing"],
+      "suggestions": ["buy"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["leverage", "leverages", "leveraged", "leveraging"],
+      "suggestions": ["use"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["acquire", "acquires", "acquired", "acquiring"],
+      "suggestions": ["get"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["demonstrate", "demonstrates", "demonstrated", "demonstrating"],
+      "suggestions": ["show"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["originate", "originates", "originated", "originating"],
+      "suggestions": ["start"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["perform", "performs", "performed", "performing"],
+      "suggestions": ["do"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["obtain", "obtains", "obtained", "obtaining"],
+      "suggestions": ["get"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["attempt", "attempts", "attempted", "attempting"],
+      "suggestions": ["try"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["assist", "assists", "assisted", "assisting"],
+      "suggestions": ["help"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["permit", "permits", "permited", "permiting"],
+      "suggestions": ["let"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["modify", "modifies", "modified", "modifying"],
+      "suggestions": ["change"],
+      "partsOfSpeech": ["VERB"]
+    },
+    {
+      "unapproved": ["begin", "begins", "began", "beginning"],
+      "suggestions": ["start"]
+    },
+    {
+      "unapproved": ["approximately"],
+      "suggestions": ["about"]
+    },
+    {
+      "unapproved": ["sufficient"],
+      "suggestions": ["enough"]
+    },
+    {
+      "unapproved": ["subsequent", "subsequently"],
+      "suggestions": ["next"]
+    },
+    {
+      "unapproved": ["prior"],
+      "suggestions": ["before"]
+    },
+    {
+      "unapproved": ["additional", "additionally"],
+      "suggestions": ["more"]
+    },
+    {
+      "unapproved": ["furthermore", "moreover"],
+      "suggestions": ["also"]
+    },
+    {
+      "unapproved": ["comprehensive", "comprehensively"],
+      "suggestions": ["complete"]
+    },
+    {
+      "unapproved": ["utilization"],
+      "suggestions": ["use"]
+    },
+    {
+      "unapproved": ["aforementioned"],
+      "suggestions": ["this"]
+    },
+    {
+      "unapproved": ["whilst"],
+      "suggestions": ["while"]
+    },
+    {
+      "unapproved": ["amongst"],
+      "suggestions": ["among"]
+    },
+    {
+      "unapproved": ["numerous", "myriad", "plethora"],
+      "suggestions": ["many"]
+    },
+    {
+      "unapproved": ["prior to"],
+      "suggestions": ["before"]
+    },
+    {
+      "unapproved": ["subsequent to"],
+      "suggestions": ["after"]
+    },
+    {
+      "unapproved": ["in order to"],
+      "suggestions": ["to"]
+    },
+    {
+      "unapproved": ["a variety of"],
+      "suggestions": ["some"]
+    },
+    {
+      "unapproved": ["in the event that"],
+      "suggestions": ["if"]
+    },
+    {
+      "unapproved": ["due to the fact that"],
+      "suggestions": ["because"]
+    },
+    {
+      "unapproved": ["is able to", "are able to"],
+      "suggestions": ["can"]
+    },
+    {
+      "unapproved": ["make use of", "makes use of"],
+      "suggestions": ["use"]
+    }
+  ]
+}

--- a/src/dictionary/form.ts
+++ b/src/dictionary/form.ts
@@ -1,0 +1,6 @@
+export const DICTIONARY_TOKEN_SOURCE = String.raw`[\p{L}\p{N}]+(?:['’\u2010\u2011-][\p{L}\p{N}]+)*`
+
+export const DICTIONARY_FORM_PATTERN = new RegExp(
+  `^${DICTIONARY_TOKEN_SOURCE}(?:[\t ]+${DICTIONARY_TOKEN_SOURCE})*$`,
+  "u",
+)

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -1,0 +1,49 @@
+import { readFile } from "node:fs/promises"
+import { fileURLToPath } from "node:url"
+import { Effect, ParseResult, Schema } from "effect"
+import { type Dictionary, DictionarySchema } from "./schema.ts"
+
+export const BUNDLED_DICTIONARY_PATH = fileURLToPath(new URL("./data/pi-ste.json", import.meta.url))
+
+export class DictionaryLoadError extends Error {
+  constructor(
+    readonly path: string,
+    readonly reason: string,
+  ) {
+    super(`Cannot load STE dictionary from ${path}: ${reason}`)
+    this.name = "DictionaryLoadError"
+  }
+}
+
+const formatParseError = (error: ParseResult.ParseError): string => {
+  const issue = ParseResult.ArrayFormatter.formatErrorSync(error)[0]
+  if (issue === undefined) {
+    return "invalid dictionary data"
+  }
+  const path = issue.path.reduce<string>((result, segment) => {
+    if (typeof segment === "number") {
+      return `${result}[${segment}]`
+    }
+    return result === "" ? String(segment) : `${result}.${String(segment)}`
+  }, "")
+  return path === "" ? `invalid dictionary data: ${issue.message}` : `${path}: ${issue.message}`
+}
+
+export const loadDictionary = (
+  path = BUNDLED_DICTIONARY_PATH,
+): Effect.Effect<Dictionary, DictionaryLoadError> =>
+  Effect.tryPromise({
+    try: () => readFile(path, "utf8"),
+    catch: (cause) =>
+      new DictionaryLoadError(
+        path,
+        `cannot read file: ${cause instanceof Error ? cause.message : String(cause)}`,
+      ),
+  }).pipe(
+    Effect.flatMap(Schema.decode(Schema.parseJson(DictionarySchema))),
+    Effect.mapError((cause) =>
+      cause instanceof DictionaryLoadError
+        ? cause
+        : new DictionaryLoadError(path, formatParseError(cause)),
+    ),
+  )

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -29,6 +29,11 @@ const formatParseError = (error: ParseResult.ParseError): string => {
   return path === "" ? `invalid dictionary data: ${issue.message}` : `${path}: ${issue.message}`
 }
 
+const decodeDictionary = Schema.decode(Schema.parseJson(DictionarySchema), {
+  onExcessProperty: "error",
+  errors: "all",
+})
+
 export const loadDictionary = (
   path = BUNDLED_DICTIONARY_PATH,
 ): Effect.Effect<Dictionary, DictionaryLoadError> =>
@@ -40,7 +45,7 @@ export const loadDictionary = (
         `cannot read file: ${cause instanceof Error ? cause.message : String(cause)}`,
       ),
   }).pipe(
-    Effect.flatMap(Schema.decode(Schema.parseJson(DictionarySchema))),
+    Effect.flatMap(decodeDictionary),
     Effect.mapError((cause) =>
       cause instanceof DictionaryLoadError
         ? cause

--- a/src/dictionary/schema.ts
+++ b/src/dictionary/schema.ts
@@ -1,0 +1,23 @@
+import { Schema } from "effect"
+
+const DictionarySourceSchema = Schema.Struct({
+  name: Schema.NonEmptyTrimmedString,
+  repository: Schema.NonEmptyTrimmedString,
+  commit: Schema.NonEmptyTrimmedString,
+  path: Schema.NonEmptyTrimmedString,
+})
+
+const DictionaryEntrySchema = Schema.Struct({
+  unapproved: Schema.NonEmptyArray(Schema.NonEmptyTrimmedString),
+  suggestions: Schema.NonEmptyArray(Schema.NonEmptyTrimmedString),
+  partsOfSpeech: Schema.optional(Schema.NonEmptyArray(Schema.NonEmptyTrimmedString)),
+})
+
+export const DictionarySchema = Schema.Struct({
+  formatVersion: Schema.Literal(1),
+  source: DictionarySourceSchema,
+  entries: Schema.Array(DictionaryEntrySchema),
+})
+
+export type Dictionary = typeof DictionarySchema.Type
+export type DictionaryEntry = typeof DictionaryEntrySchema.Type

--- a/src/dictionary/schema.ts
+++ b/src/dictionary/schema.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+import { DICTIONARY_FORM_PATTERN } from "./form.ts"
 
 const DictionarySourceSchema = Schema.Struct({
   name: Schema.NonEmptyTrimmedString,
@@ -7,8 +8,12 @@ const DictionarySourceSchema = Schema.Struct({
   path: Schema.NonEmptyTrimmedString,
 })
 
+const DictionaryFormSchema = Schema.NonEmptyTrimmedString.pipe(
+  Schema.pattern(DICTIONARY_FORM_PATTERN),
+)
+
 const DictionaryEntrySchema = Schema.Struct({
-  unapproved: Schema.NonEmptyArray(Schema.NonEmptyTrimmedString),
+  unapproved: Schema.NonEmptyArray(DictionaryFormSchema),
   suggestions: Schema.NonEmptyArray(Schema.NonEmptyTrimmedString),
   partsOfSpeech: Schema.optional(Schema.NonEmptyArray(Schema.NonEmptyTrimmedString)),
 })

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from "../dictionary/schema.ts"
-import { blankCodeFences } from "./markdown.ts"
+import { blankMarkdownCode } from "./markdown.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
 import { sentenceLength } from "./rules/sentence-length.ts"
 import { verbForm } from "./rules/verb-form.ts"
@@ -17,7 +17,7 @@ interface ResolvedOptions {
 
 const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Violation[]> = {
   "prose-file": (text, { maxSentenceWords, dictionary, tagger }) => {
-    const lines = blankCodeFences(text)
+    const lines = blankMarkdownCode(text)
     return [
       ...sentenceLength(segmentSentences(lines), maxSentenceWords),
       ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,4 +1,6 @@
+import type { Dictionary } from "../dictionary/schema.ts"
 import { blankCodeFences } from "./markdown.ts"
+import { dictionaryRule } from "./rules/dictionary.ts"
 import { sentenceLength } from "./rules/sentence-length.ts"
 import { verbForm } from "./rules/verb-form.ts"
 import { segmentSentences } from "./sentences.ts"
@@ -9,14 +11,16 @@ export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
 interface ResolvedOptions {
   readonly maxSentenceWords: number
+  readonly dictionary?: Dictionary
   readonly tagger?: Tagger
 }
 
 const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Violation[]> = {
-  "prose-file": (text, { maxSentenceWords, tagger }) => {
+  "prose-file": (text, { maxSentenceWords, dictionary, tagger }) => {
     const lines = blankCodeFences(text)
     return [
       ...sentenceLength(segmentSentences(lines), maxSentenceWords),
+      ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
       ...(tagger === undefined ? [] : verbForm(lines, tagger)),
     ]
   },
@@ -25,6 +29,7 @@ const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Viol
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
   const raw = linters[kind](text, {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
+    dictionary: options.dictionary,
     tagger: options.tagger,
   })
   const violations = raw

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -7,17 +7,29 @@ interface ActiveParagraph {
   readonly quoteDepth: number
 }
 
-const FENCE = /^\s{0,3}(?:```|~~~)/
+interface ActiveFence {
+  readonly marker: "`" | "~"
+  readonly length: number
+  readonly quoteDepth: number
+  readonly listIndent: number
+}
+
+interface ListContent {
+  readonly content: string
+  readonly indent: number
+}
+
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[\t ]+|$)/
 const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[\t ]*\r?$/
 const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[\t ]*){3,}|(?:_[\t ]*){3,}|(?:-[\t ]*){3,})\r?$/
-const LIST_MARKER = /^ {0,3}(?:[-+*]|\d{1,9}[.)])(?:[\t ]+|$)/
+const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])([\t ]+|$)/
+const FENCE_OPENER = /^ {0,3}(`{3,}|~{3,})(.*)\r?$/
 
-const markdownContext = (line: string): MarkdownContext => {
+const markdownContext = (line: string, maximumDepth = Number.POSITIVE_INFINITY): MarkdownContext => {
   let contentStart = 0
   let quoteDepth = 0
 
-  while (contentStart < line.length) {
+  while (contentStart < line.length && quoteDepth < maximumDepth) {
     let marker = contentStart
     let spaces = 0
     while (spaces < 4 && line[marker] === " ") {
@@ -37,6 +49,22 @@ const markdownContext = (line: string): MarkdownContext => {
   return { contentStart, quoteDepth }
 }
 
+const listContent = (content: string): ListContent => {
+  let contentStart = 0
+
+  while (true) {
+    const match = content.slice(contentStart).match(LIST_MARKER)
+    if (match === null) {
+      break
+    }
+    const whitespace = match[2] ?? ""
+    const consumedWhitespace = whitespace.length > 4 ? 1 : whitespace.length
+    contentStart += match[0].length - whitespace.length + consumedWhitespace
+  }
+
+  return { content: content.slice(contentStart), indent: contentStart }
+}
+
 const isBlank = (content: string): boolean => /^[\t ]*\r?$/.test(content)
 const isIndentedCode = (content: string): boolean => /^(?: {4}|\t)/.test(content)
 const startsNewBlock = (content: string): boolean =>
@@ -48,24 +76,73 @@ const startsParagraph = (content: string): boolean =>
   !ATX_HEADING.test(content) && !SETEXT_UNDERLINE.test(content) && !THEMATIC_BREAK.test(content)
 const blank = (line: string): string => line.replace(/[^\r]/g, " ")
 
+const fenceOpener = (content: string): Pick<ActiveFence, "marker" | "length"> | undefined => {
+  const match = content.match(FENCE_OPENER)
+  const delimiter = match?.[1]
+  const info = match?.[2] ?? ""
+  if (delimiter === undefined || (delimiter[0] === "`" && info.includes("`"))) {
+    return undefined
+  }
+  const marker = delimiter[0]
+  if (marker !== "`" && marker !== "~") {
+    return undefined
+  }
+  return { marker, length: delimiter.length }
+}
+
+const isFenceCloser = (content: string, fence: ActiveFence): boolean => {
+  const match = content.match(/^ {0,3}(`+|~+)[\t ]*\r?$/)
+  const delimiter = match?.[1]
+  return delimiter?.[0] === fence.marker && delimiter.length >= fence.length
+}
+
+const fenceContainerContent = (line: string, fence: ActiveFence): string | undefined => {
+  const context = markdownContext(line, fence.quoteDepth)
+  if (context.quoteDepth !== fence.quoteDepth) {
+    return isBlank(line) ? "" : undefined
+  }
+  const content = line.slice(context.contentStart)
+  if (fence.listIndent === 0 || isBlank(content)) {
+    return content
+  }
+  if (!content.startsWith(" ".repeat(fence.listIndent))) {
+    return undefined
+  }
+  return content.slice(fence.listIndent)
+}
+
 export function blankMarkdownCode(text: string): string[] {
-  let inFence = false
+  let activeFence: ActiveFence | undefined
   let inIndentedCode = false
   let activeParagraph: ActiveParagraph | undefined
 
   return text.split("\n").map((line) => {
-    if (FENCE.test(line)) {
-      inFence = !inFence
-      inIndentedCode = false
-      activeParagraph = undefined
-      return blank(line)
-    }
-    if (inFence) {
-      return blank(line)
+    if (activeFence !== undefined) {
+      const content = fenceContainerContent(line, activeFence)
+      if (content !== undefined) {
+        if (isFenceCloser(content, activeFence)) {
+          activeFence = undefined
+        }
+        return blank(line)
+      }
+      activeFence = undefined
     }
 
     const context = markdownContext(line)
     const content = line.slice(context.contentStart)
+    const nested = listContent(content)
+    const opener = fenceOpener(nested.content)
+    if (opener !== undefined) {
+      activeFence = {
+        ...opener,
+        quoteDepth: context.quoteDepth,
+        listIndent: nested.indent,
+      }
+      inIndentedCode = false
+      activeParagraph = undefined
+      return blank(line)
+    }
+
     if (isBlank(content)) {
       activeParagraph = undefined
       return inIndentedCode ? blank(line) : line
@@ -86,13 +163,15 @@ export function blankMarkdownCode(text: string): string[] {
       return line
     }
 
-    if (isIndentedCode(content)) {
+    if (isIndentedCode(nested.content)) {
       activeParagraph = undefined
       inIndentedCode = true
       return blank(line)
     }
 
-    activeParagraph = startsParagraph(content) ? { quoteDepth: context.quoteDepth } : undefined
+    activeParagraph = startsParagraph(nested.content)
+      ? { quoteDepth: context.quoteDepth }
+      : undefined
     return line
   })
 }

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -25,7 +25,10 @@ const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[\t ]*){3,}|(?:_[\t ]*){3,}|(?:-[\t ]*){3
 const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])([\t ]+|$)/
 const FENCE_OPENER = /^ {0,3}(`{3,}|~{3,})(.*)\r?$/
 
-const markdownContext = (line: string, maximumDepth = Number.POSITIVE_INFINITY): MarkdownContext => {
+const markdownContext = (
+  line: string,
+  maximumDepth = Number.POSITIVE_INFINITY,
+): MarkdownContext => {
   let contentStart = 0
   let quoteDepth = 0
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,12 +1,98 @@
-const FENCE = /^\s{0,3}(?:```|~~~)/
+interface MarkdownContext {
+  readonly contentStart: number
+  readonly quoteDepth: number
+}
 
-export function blankCodeFences(text: string): string[] {
+interface ActiveParagraph {
+  readonly quoteDepth: number
+}
+
+const FENCE = /^\s{0,3}(?:```|~~~)/
+const ATX_HEADING = /^ {0,3}#{1,6}(?:[\t ]+|$)/
+const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[\t ]*\r?$/
+const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[\t ]*){3,}|(?:_[\t ]*){3,}|(?:-[\t ]*){3,})\r?$/
+const LIST_MARKER = /^ {0,3}(?:[-+*]|\d{1,9}[.)])(?:[\t ]+|$)/
+
+const markdownContext = (line: string): MarkdownContext => {
+  let contentStart = 0
+  let quoteDepth = 0
+
+  while (contentStart < line.length) {
+    let marker = contentStart
+    let spaces = 0
+    while (spaces < 4 && line[marker] === " ") {
+      marker++
+      spaces++
+    }
+    if (spaces > 3 || line[marker] !== ">") {
+      break
+    }
+    contentStart = marker + 1
+    if (line[contentStart] === " " || line[contentStart] === "\t") {
+      contentStart++
+    }
+    quoteDepth++
+  }
+
+  return { contentStart, quoteDepth }
+}
+
+const isBlank = (content: string): boolean => /^[\t ]*\r?$/.test(content)
+const isIndentedCode = (content: string): boolean => /^(?: {4}|\t)/.test(content)
+const startsNewBlock = (content: string): boolean =>
+  ATX_HEADING.test(content) ||
+  LIST_MARKER.test(content) ||
+  SETEXT_UNDERLINE.test(content) ||
+  THEMATIC_BREAK.test(content)
+const startsParagraph = (content: string): boolean =>
+  !ATX_HEADING.test(content) && !SETEXT_UNDERLINE.test(content) && !THEMATIC_BREAK.test(content)
+const blank = (line: string): string => line.replace(/[^\r]/g, " ")
+
+export function blankMarkdownCode(text: string): string[] {
   let inFence = false
+  let inIndentedCode = false
+  let activeParagraph: ActiveParagraph | undefined
+
   return text.split("\n").map((line) => {
     if (FENCE.test(line)) {
       inFence = !inFence
-      return ""
+      inIndentedCode = false
+      activeParagraph = undefined
+      return blank(line)
     }
-    return inFence ? "" : line
+    if (inFence) {
+      return blank(line)
+    }
+
+    const context = markdownContext(line)
+    const content = line.slice(context.contentStart)
+    if (isBlank(content)) {
+      activeParagraph = undefined
+      return inIndentedCode ? blank(line) : line
+    }
+
+    if (inIndentedCode) {
+      if (isIndentedCode(content)) {
+        return blank(line)
+      }
+      inIndentedCode = false
+    }
+
+    if (
+      activeParagraph !== undefined &&
+      context.quoteDepth <= activeParagraph.quoteDepth &&
+      !startsNewBlock(content)
+    ) {
+      return line
+    }
+
+    if (isIndentedCode(content)) {
+      activeParagraph = undefined
+      inIndentedCode = true
+      return blank(line)
+    }
+
+    activeParagraph = startsParagraph(content) ? { quoteDepth: context.quoteDepth } : undefined
+    return line
   })
 }

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -5,6 +5,7 @@ import type { Violation } from "../types.ts"
 interface WordToken {
   readonly text: string
   readonly lower: string
+  readonly lineIndex: number
   readonly offset: number
 }
 
@@ -13,12 +14,15 @@ interface Form {
   readonly words: readonly string[]
 }
 
-const tokenize = (line: string): readonly WordToken[] =>
-  Array.from(line.matchAll(/[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*/gu), (match) => ({
-    text: match[0],
-    lower: match[0].toLowerCase(),
-    offset: match.index,
-  }))
+const tokenize = (lines: readonly string[]): readonly WordToken[] =>
+  lines.flatMap((line, lineIndex) =>
+    Array.from(line.matchAll(/[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*/gu), (match) => ({
+      text: match[0],
+      lower: match[0].toLowerCase(),
+      lineIndex,
+      offset: match.index,
+    })),
+  )
 
 const compileForms = (dictionary: Dictionary): readonly Form[] =>
   dictionary.entries
@@ -27,8 +31,27 @@ const compileForms = (dictionary: Dictionary): readonly Form[] =>
     )
     .sort((left, right) => right.words.length - left.words.length)
 
+const isSoftLineBreak = (
+  lines: readonly string[],
+  previous: WordToken,
+  token: WordToken,
+): boolean => {
+  if (token.lineIndex !== previous.lineIndex + 1) {
+    return false
+  }
+  const previousLine = lines[previous.lineIndex]
+  const nextLine = lines[token.lineIndex]
+  if (previousLine === undefined || nextLine === undefined) {
+    return false
+  }
+  const lineEnd = previousLine.endsWith("\r") ? previousLine.length - 1 : previousLine.length
+  const trailing = previousLine.slice(previous.offset + previous.text.length, lineEnd)
+  const leading = nextLine.slice(0, token.offset)
+  return (trailing === "" || trailing === " ") && /^[\t ]*$/.test(leading)
+}
+
 const hasWords = (
-  line: string,
+  lines: readonly string[],
   tokens: readonly WordToken[],
   start: number,
   words: readonly string[],
@@ -42,10 +65,17 @@ const hasWords = (
       return true
     }
     const previous = tokens[start + index - 1]
-    return (
-      previous !== undefined &&
-      /^\s+$/.test(line.slice(previous.offset + previous.text.length, token.offset))
-    )
+    if (previous === undefined) {
+      return false
+    }
+    if (token.lineIndex === previous.lineIndex) {
+      const line = lines[token.lineIndex]
+      return (
+        line !== undefined &&
+        /^\s+$/.test(line.slice(previous.offset + previous.text.length, token.offset))
+      )
+    }
+    return isSoftLineBreak(lines, previous, token)
   })
 
 const hasPartOfSpeech = (
@@ -76,47 +106,61 @@ export function dictionaryRule(
 ): Violation[] {
   const forms = compileForms(dictionary)
   const violations: Violation[] = []
+  const tokens = tokenize(lines)
+  const taggedTokensByLine = new Map<number, readonly TaggedToken[]>()
 
-  lines.forEach((line, lineIndex) => {
-    const tokens = tokenize(line)
-    let taggedTokens: readonly TaggedToken[] | undefined
-
-    for (let index = 0; index < tokens.length; index++) {
-      const first = tokens[index]
-      if (first === undefined) {
-        continue
+  for (let index = 0; index < tokens.length; index++) {
+    const first = tokens[index]
+    if (first === undefined) {
+      continue
+    }
+    const candidates = forms.filter((form) => hasWords(lines, tokens, index, form.words))
+    const match = candidates.find((form) => {
+      if (form.entry.partsOfSpeech === undefined) {
+        return true
       }
-      const candidates = forms.filter((form) => hasWords(line, tokens, index, form.words))
-      const match = candidates.find((form) => {
-        if (form.entry.partsOfSpeech === undefined) {
-          return true
-        }
-        if (tagger === undefined) {
+      if (tagger === undefined) {
+        return false
+      }
+      let taggedTokens = taggedTokensByLine.get(first.lineIndex)
+      if (taggedTokens === undefined) {
+        const line = lines[first.lineIndex]
+        if (line === undefined) {
           return false
         }
-        taggedTokens ??= tagger(line)
-        return hasPartOfSpeech(form.entry, first, taggedTokens)
-      })
-      if (match === undefined) {
-        continue
+        taggedTokens = tagger(line)
+        taggedTokensByLine.set(first.lineIndex, taggedTokens)
       }
-
-      const last = tokens[index + match.words.length - 1]
-      if (last === undefined) {
-        continue
-      }
-      const found = line.slice(first.offset, last.offset + last.text.length)
-      violations.push({
-        ruleId: "dictionary-not-approved-word",
-        severity: "hard",
-        message: messageFor(match.entry.suggestions, found),
-        suggestions: match.entry.suggestions,
-        line: lineIndex + 1,
-        column: first.offset + 1,
-      })
-      index += match.words.length - 1
+      return hasPartOfSpeech(form.entry, first, taggedTokens)
+    })
+    if (match === undefined) {
+      continue
     }
-  })
+
+    const last = tokens[index + match.words.length - 1]
+    if (last === undefined) {
+      continue
+    }
+    const found =
+      first.lineIndex === last.lineIndex
+        ? lines[first.lineIndex]?.slice(first.offset, last.offset + last.text.length)
+        : tokens
+            .slice(index, index + match.words.length)
+            .map((token) => token.text)
+            .join(" ")
+    if (found === undefined) {
+      continue
+    }
+    violations.push({
+      ruleId: "dictionary-not-approved-word",
+      severity: "hard",
+      message: messageFor(match.entry.suggestions, found),
+      suggestions: match.entry.suggestions,
+      line: first.lineIndex + 1,
+      column: first.offset + 1,
+    })
+    index += match.words.length - 1
+  }
 
   return violations
 }

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -92,6 +92,8 @@ const startsNewBlock = (content: string): boolean =>
 const isParagraphBlock = (content: string): boolean =>
   !isLeafBlock(content) && !SETEXT_UNDERLINE.test(content) && !THEMATIC_BREAK.test(content)
 
+const isIndentedCode = (content: string): boolean => /^(?: {4}|\t)/.test(content)
+
 const markdownContexts = (lines: readonly string[]): readonly MarkdownContext[] => {
   let activeParagraph: ActiveParagraph | undefined
   let nextParagraphId = 0
@@ -110,6 +112,11 @@ const markdownContexts = (lines: readonly string[]): readonly MarkdownContext[] 
       !startsNewBlock(content)
     ) {
       return { ...context, paragraphId: activeParagraph.id }
+    }
+
+    if (isIndentedCode(content)) {
+      activeParagraph = undefined
+      return context
     }
 
     const paragraphId = nextParagraphId++

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -18,6 +18,12 @@ interface Form {
 interface MarkdownContext {
   readonly contentStart: number
   readonly quoteDepth: number
+  readonly paragraphId?: number
+}
+
+interface ActiveParagraph {
+  readonly id: number
+  readonly quoteDepth: number
 }
 
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[\t ]+|$)/
@@ -83,8 +89,40 @@ const startsNewBlock = (content: string): boolean =>
   SETEXT_UNDERLINE.test(content) ||
   THEMATIC_BREAK.test(content)
 
+const isParagraphBlock = (content: string): boolean =>
+  !isLeafBlock(content) && !SETEXT_UNDERLINE.test(content) && !THEMATIC_BREAK.test(content)
+
+const markdownContexts = (lines: readonly string[]): readonly MarkdownContext[] => {
+  let activeParagraph: ActiveParagraph | undefined
+  let nextParagraphId = 0
+
+  return lines.map((line) => {
+    const context = markdownContext(line)
+    const content = blockContent(line, context)
+    if (/^[\t ]*\r?$/.test(content)) {
+      activeParagraph = undefined
+      return context
+    }
+
+    if (
+      activeParagraph !== undefined &&
+      context.quoteDepth <= activeParagraph.quoteDepth &&
+      !startsNewBlock(content)
+    ) {
+      return { ...context, paragraphId: activeParagraph.id }
+    }
+
+    const paragraphId = nextParagraphId++
+    activeParagraph = isParagraphBlock(content)
+      ? { id: paragraphId, quoteDepth: context.quoteDepth }
+      : undefined
+    return { ...context, paragraphId }
+  })
+}
+
 const isSoftLineBreak = (
   lines: readonly string[],
+  contexts: readonly MarkdownContext[],
   previous: WordToken,
   token: WordToken,
 ): boolean => {
@@ -97,14 +135,13 @@ const isSoftLineBreak = (
     return false
   }
 
-  const previousContext = markdownContext(previousLine)
-  const nextContext = markdownContext(nextLine)
-  const previousContent = blockContent(previousLine, previousContext)
-  const nextContent = blockContent(nextLine, nextContext)
+  const previousContext = contexts[previous.lineIndex]
+  const nextContext = contexts[token.lineIndex]
   if (
-    previousContext.quoteDepth !== nextContext.quoteDepth ||
-    isLeafBlock(previousContent) ||
-    startsNewBlock(nextContent)
+    previousContext === undefined ||
+    nextContext === undefined ||
+    previousContext.paragraphId === undefined ||
+    previousContext.paragraphId !== nextContext.paragraphId
   ) {
     return false
   }
@@ -117,6 +154,7 @@ const isSoftLineBreak = (
 
 const hasWords = (
   lines: readonly string[],
+  contexts: readonly MarkdownContext[],
   tokens: readonly WordToken[],
   start: number,
   words: readonly string[],
@@ -140,7 +178,7 @@ const hasWords = (
         /^\s+$/.test(line.slice(previous.offset + previous.text.length, token.offset))
       )
     }
-    return isSoftLineBreak(lines, previous, token)
+    return isSoftLineBreak(lines, contexts, previous, token)
   })
 
 const hasPartOfSpeech = (
@@ -171,6 +209,7 @@ export function dictionaryRule(
 ): Violation[] {
   const forms = compileForms(dictionary)
   const violations: Violation[] = []
+  const contexts = markdownContexts(lines)
   const tokens = tokenize(lines)
   const taggedTokensByLine = new Map<number, readonly TaggedToken[]>()
 
@@ -179,7 +218,9 @@ export function dictionaryRule(
     if (first === undefined) {
       continue
     }
-    const candidates = forms.filter((form) => hasWords(lines, tokens, index, form.words))
+    const candidates = forms.filter((form) =>
+      hasWords(lines, contexts, tokens, index, form.words),
+    )
     const match = candidates.find((form) => {
       if (form.entry.partsOfSpeech === undefined) {
         return true

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -1,0 +1,122 @@
+import type { Dictionary, DictionaryEntry } from "../../dictionary/schema.ts"
+import type { TaggedToken, Tagger } from "../tagger.ts"
+import type { Violation } from "../types.ts"
+
+interface WordToken {
+  readonly text: string
+  readonly lower: string
+  readonly offset: number
+}
+
+interface Form {
+  readonly entry: DictionaryEntry
+  readonly words: readonly string[]
+}
+
+const tokenize = (line: string): readonly WordToken[] =>
+  Array.from(line.matchAll(/[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*/gu), (match) => ({
+    text: match[0],
+    lower: match[0].toLowerCase(),
+    offset: match.index,
+  }))
+
+const compileForms = (dictionary: Dictionary): readonly Form[] =>
+  dictionary.entries
+    .flatMap((entry) =>
+      entry.unapproved.map((form) => ({ entry, words: form.toLowerCase().split(/\s+/) })),
+    )
+    .sort((left, right) => right.words.length - left.words.length)
+
+const hasWords = (
+  line: string,
+  tokens: readonly WordToken[],
+  start: number,
+  words: readonly string[],
+): boolean =>
+  words.every((word, index) => {
+    const token = tokens[start + index]
+    if (token === undefined || token.lower !== word) {
+      return false
+    }
+    if (index === 0) {
+      return true
+    }
+    const previous = tokens[start + index - 1]
+    return (
+      previous !== undefined &&
+      /^\s+$/.test(line.slice(previous.offset + previous.text.length, token.offset))
+    )
+  })
+
+const hasPartOfSpeech = (
+  entry: DictionaryEntry,
+  token: WordToken,
+  taggedTokens: readonly TaggedToken[] | undefined,
+): boolean => {
+  if (entry.partsOfSpeech === undefined) {
+    return true
+  }
+  return (
+    taggedTokens?.some(
+      (tagged) =>
+        tagged.offset === token.offset && entry.partsOfSpeech?.includes(tagged.pos) === true,
+    ) === true
+  )
+}
+
+const messageFor = (suggestions: readonly string[], found: string): string => {
+  const alternatives = suggestions.map((suggestion) => `"${suggestion}"`).join(" or ")
+  return `Use ${alternatives}, not "${found}".`
+}
+
+export function dictionaryRule(
+  lines: readonly string[],
+  dictionary: Dictionary,
+  tagger?: Tagger,
+): Violation[] {
+  const forms = compileForms(dictionary)
+  const violations: Violation[] = []
+
+  lines.forEach((line, lineIndex) => {
+    const tokens = tokenize(line)
+    let taggedTokens: readonly TaggedToken[] | undefined
+
+    for (let index = 0; index < tokens.length; index++) {
+      const first = tokens[index]
+      if (first === undefined) {
+        continue
+      }
+      const candidates = forms.filter((form) => hasWords(line, tokens, index, form.words))
+      const match = candidates.find((form) => {
+        if (form.entry.partsOfSpeech === undefined) {
+          return true
+        }
+        if (tagger === undefined) {
+          return false
+        }
+        taggedTokens ??= tagger(line)
+        return hasPartOfSpeech(form.entry, first, taggedTokens)
+      })
+      if (match === undefined) {
+        continue
+      }
+
+      const last = tokens[index + match.words.length - 1]
+      if (last === undefined) {
+        continue
+      }
+      const found = line.slice(first.offset, last.offset + last.text.length)
+      violations.push({
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: messageFor(match.entry.suggestions, found),
+        suggestions: match.entry.suggestions,
+        line: lineIndex + 1,
+        column: first.offset + 1,
+      })
+      index += match.words.length - 1
+    }
+  })
+
+  return violations
+}

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -1,3 +1,4 @@
+import { DICTIONARY_TOKEN_SOURCE } from "../../dictionary/form.ts"
 import type { Dictionary, DictionaryEntry } from "../../dictionary/schema.ts"
 import type { TaggedToken, Tagger } from "../tagger.ts"
 import type { Violation } from "../types.ts"
@@ -14,15 +15,27 @@ interface Form {
   readonly words: readonly string[]
 }
 
-const tokenize = (lines: readonly string[]): readonly WordToken[] =>
-  lines.flatMap((line, lineIndex) =>
-    Array.from(line.matchAll(/[\p{L}\p{N}]+(?:['’][\p{L}\p{N}]+)*/gu), (match) => ({
+interface MarkdownContext {
+  readonly contentStart: number
+  readonly quoteDepth: number
+}
+
+const ATX_HEADING = /^ {0,3}#{1,6}(?:[\t ]+|$)/
+const LIST_MARKER = /^ {0,3}(?:[-+*]|\d{1,9}[.)])(?:[\t ]+|$)/
+const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[\t ]*\r?$/
+const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[\t ]*){3,}|(?:_[\t ]*){3,}|(?:-[\t ]*){3,})\r?$/
+
+const tokenize = (lines: readonly string[]): readonly WordToken[] => {
+  const tokenPattern = new RegExp(DICTIONARY_TOKEN_SOURCE, "gu")
+  return lines.flatMap((line, lineIndex) =>
+    Array.from(line.matchAll(tokenPattern), (match) => ({
       text: match[0],
       lower: match[0].toLowerCase(),
       lineIndex,
       offset: match.index,
     })),
   )
+}
 
 const compileForms = (dictionary: Dictionary): readonly Form[] =>
   dictionary.entries
@@ -30,6 +43,45 @@ const compileForms = (dictionary: Dictionary): readonly Form[] =>
       entry.unapproved.map((form) => ({ entry, words: form.toLowerCase().split(/\s+/) })),
     )
     .sort((left, right) => right.words.length - left.words.length)
+
+const markdownContext = (line: string): MarkdownContext => {
+  let contentStart = 0
+  let quoteDepth = 0
+
+  while (contentStart < line.length) {
+    let marker = contentStart
+    let spaces = 0
+    while (spaces < 4 && line[marker] === " ") {
+      marker++
+      spaces++
+    }
+    if (spaces > 3 || line[marker] !== ">") {
+      break
+    }
+    contentStart = marker + 1
+    if (line[contentStart] === " " || line[contentStart] === "\t") {
+      contentStart++
+    }
+    quoteDepth++
+  }
+
+  return { contentStart, quoteDepth }
+}
+
+const blockContent = (line: string, context: MarkdownContext): string =>
+  line.slice(context.contentStart)
+
+const isLeafBlock = (content: string): boolean => {
+  const listMarker = content.match(LIST_MARKER)
+  const nestedContent = listMarker === null ? content : content.slice(listMarker[0].length)
+  return ATX_HEADING.test(nestedContent)
+}
+
+const startsNewBlock = (content: string): boolean =>
+  ATX_HEADING.test(content) ||
+  LIST_MARKER.test(content) ||
+  SETEXT_UNDERLINE.test(content) ||
+  THEMATIC_BREAK.test(content)
 
 const isSoftLineBreak = (
   lines: readonly string[],
@@ -44,9 +96,22 @@ const isSoftLineBreak = (
   if (previousLine === undefined || nextLine === undefined) {
     return false
   }
+
+  const previousContext = markdownContext(previousLine)
+  const nextContext = markdownContext(nextLine)
+  const previousContent = blockContent(previousLine, previousContext)
+  const nextContent = blockContent(nextLine, nextContext)
+  if (
+    previousContext.quoteDepth !== nextContext.quoteDepth ||
+    isLeafBlock(previousContent) ||
+    startsNewBlock(nextContent)
+  ) {
+    return false
+  }
+
   const lineEnd = previousLine.endsWith("\r") ? previousLine.length - 1 : previousLine.length
   const trailing = previousLine.slice(previous.offset + previous.text.length, lineEnd)
-  const leading = nextLine.slice(0, token.offset)
+  const leading = nextLine.slice(nextContext.contentStart, token.offset)
   return (trailing === "" || trailing === " ") && /^[\t ]*$/.test(leading)
 }
 

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -225,9 +225,7 @@ export function dictionaryRule(
     if (first === undefined) {
       continue
     }
-    const candidates = forms.filter((form) =>
-      hasWords(lines, contexts, tokens, index, form.words),
-    )
+    const candidates = forms.filter((form) => hasWords(lines, contexts, tokens, index, form.words))
     const match = candidates.find((form) => {
       if (form.entry.partsOfSpeech === undefined) {
         return true

--- a/src/engine/rules/registry.ts
+++ b/src/engine/rules/registry.ts
@@ -1,4 +1,5 @@
 export const ruleIds = [
+  "dictionary-not-approved-word",
   "sentence-length",
   "verb-progressive",
   "verb-passive",

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,5 +1,8 @@
-import type { RuleId } from "./rules/registry.ts"
+import type { Dictionary } from "../dictionary/schema.ts"
+import type { RuleId as RegisteredRuleId } from "./rules/registry.ts"
 import type { Tagger } from "./tagger.ts"
+
+export type RuleId = RegisteredRuleId | "dictionary-not-approved-word"
 
 export type LintKind = "prose-file"
 
@@ -11,6 +14,7 @@ export interface Violation {
   readonly ruleId: RuleId
   readonly severity: Severity
   readonly message: string
+  readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
 }
@@ -18,7 +22,8 @@ export interface Violation {
 export interface LintOptions {
   readonly rules?: Partial<Record<RuleId, RuleSetting>>
   readonly maxSentenceWords?: number
-  // POS tagger for the verb-form rules; when absent those rules do not run.
+  readonly dictionary?: Dictionary
+  // POS tagger for the verb-form rules and POS-aware dictionary entries.
   readonly tagger?: Tagger
 }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,8 +1,6 @@
 import type { Dictionary } from "../dictionary/schema.ts"
-import type { RuleId as RegisteredRuleId } from "./rules/registry.ts"
+import type { RuleId } from "./rules/registry.ts"
 import type { Tagger } from "./tagger.ts"
-
-export type RuleId = RegisteredRuleId | "dictionary-not-approved-word"
 
 export type LintKind = "prose-file"
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -137,6 +137,7 @@ describe("simple-english CLI", () => {
 
   test.each([
     ["invalid", "test/fixtures/invalid-dictionary.json", "entries[0].unapproved"],
+    ["unknown-property", "test/fixtures/unknown-dictionary-property.json", "partOfSpeech"],
     [
       "unsupported-form",
       "test/fixtures/unsupported-dictionary-form.json",

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, test } from "vitest"
-import { runCli } from "./run-cli.ts"
+import { type CliOptions, runCli as runCliBase } from "./run-cli.ts"
+
+interface DictionaryCliOptions extends CliOptions {
+  readonly dictionaryPath?: string
+}
+
+async function runCli(args: string[], options: DictionaryCliOptions = {}) {
+  const originalDictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
+  if (options.dictionaryPath === undefined) {
+    delete process.env.SIMPLE_ENGLISH_DICTIONARY
+  } else {
+    process.env.SIMPLE_ENGLISH_DICTIONARY = options.dictionaryPath
+  }
+
+  const { dictionaryPath: _, ...cliOptions } = options
+  try {
+    return await runCliBase(args, cliOptions)
+  } finally {
+    if (originalDictionaryPath === undefined) {
+      delete process.env.SIMPLE_ENGLISH_DICTIONARY
+    } else {
+      process.env.SIMPLE_ENGLISH_DICTIONARY = originalDictionaryPath
+    }
+  }
+}
 
 describe("simple-english CLI", () => {
   test("exits 0 on a clean file", async () => {
@@ -77,6 +101,50 @@ describe("simple-english CLI", () => {
     expect(result.code).toBe(0)
     expect(result.stdout).toContain("<stdin>:1:10 verb-passive")
     expect(result.stdout).toContain("active voice")
+  })
+
+  test("uses the bundled dictionary and prints its approved alternative", async () => {
+    const result = await runCli([], { stdin: "We attempt the repair." })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("<stdin>:1:4 dictionary-not-approved-word")
+    expect(result.stdout).toContain('Use "try", not "attempt".')
+  })
+
+  test("accepts an approved alternative and a word used as an allowed POS", async () => {
+    const result = await runCli([], { stdin: "We try the repair. The attempt failed." })
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toBe("")
+  })
+
+  test("uses word-level fallback for bundled entries without POS metadata", async () => {
+    const result = await runCli([], { stdin: "It is approximately five millimeters." })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain('Use "about", not "approximately".')
+  })
+
+  test.each([
+    ["invalid", "test/fixtures/invalid-dictionary.json", "entries[0].unapproved"],
+    ["unreadable", "test/fixtures/missing-dictionary.json", "cannot read file"],
+  ])("reports an %s dictionary and continues other rules", async (_kind, path, error) => {
+    const longSentence = `${Array.from({ length: 26 }, (_, i) => `word${i}`).join(" ")}.`
+    const input = [
+      longSentence,
+      "The pump is running.",
+      "The technician has finished the task.",
+      "The bolt was removed.",
+    ].join("\n")
+    const result = await runCli([], { stdin: input, dictionaryPath: path })
+
+    expect(result.code).toBe(1)
+    expect(result.stderr).toContain("Cannot load STE dictionary")
+    expect(result.stderr).toContain(error)
+    expect(result.stdout).toContain("sentence-length")
+    expect(result.stdout).toContain("verb-progressive")
+    expect(result.stdout).toContain("verb-perfect")
+    expect(result.stdout).toContain("verb-passive")
   })
 
   test("errors with exit code 2 on an unreadable file", async () => {

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -111,6 +111,16 @@ describe("simple-english CLI", () => {
     expect(result.stdout).toContain('Use "try", not "attempt".')
   })
 
+  test("loads and matches a hyphenated dictionary form", async () => {
+    const result = await runCli([], {
+      stdin: "Use state-of-the-art parts.",
+      dictionaryPath: "test/fixtures/hyphenated-dictionary.json",
+    })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain('Use "advanced", not "state-of-the-art".')
+  })
+
   test("accepts an approved alternative and a word used as an allowed POS", async () => {
     const result = await runCli([], { stdin: "We try the repair. The attempt failed." })
 
@@ -127,6 +137,11 @@ describe("simple-english CLI", () => {
 
   test.each([
     ["invalid", "test/fixtures/invalid-dictionary.json", "entries[0].unapproved"],
+    [
+      "unsupported-form",
+      "test/fixtures/unsupported-dictionary-form.json",
+      "entries[0].unapproved[0]",
+    ],
     ["unreadable", "test/fixtures/missing-dictionary.json", "cannot read file"],
   ])("reports an %s dictionary and continues other rules", async (_kind, path, error) => {
     const longSentence = `${Array.from({ length: 26 }, (_, i) => `word${i}`).join(" ")}.`

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -8,7 +8,7 @@ interface DictionaryCliOptions extends CliOptions {
 async function runCli(args: string[], options: DictionaryCliOptions = {}) {
   const originalDictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
   if (options.dictionaryPath === undefined) {
-    delete process.env.SIMPLE_ENGLISH_DICTIONARY
+    Reflect.deleteProperty(process.env, "SIMPLE_ENGLISH_DICTIONARY")
   } else {
     process.env.SIMPLE_ENGLISH_DICTIONARY = options.dictionaryPath
   }
@@ -18,7 +18,7 @@ async function runCli(args: string[], options: DictionaryCliOptions = {}) {
     return await runCliBase(args, cliOptions)
   } finally {
     if (originalDictionaryPath === undefined) {
-      delete process.env.SIMPLE_ENGLISH_DICTIONARY
+      Reflect.deleteProperty(process.env, "SIMPLE_ENGLISH_DICTIONARY")
     } else {
       process.env.SIMPLE_ENGLISH_DICTIONARY = originalDictionaryPath
     }

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -32,9 +32,9 @@ describe("config schema", () => {
     expect(result._tag).toBe("Right")
   })
 
-  test("accepts every severity setting", () => {
+  test("accepts every severity setting for the dictionary rule", () => {
     for (const setting of ["hard", "soft", "off"]) {
-      expect(decode({ rules: { "sentence-length": setting } })._tag).toBe("Right")
+      expect(decode({ rules: { "dictionary-not-approved-word": setting } })._tag).toBe("Right")
     }
   })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -113,6 +113,21 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("matches phrases across lazy Markdown block quote continuations", () => {
+    const report = lint("prose-file", "> in order\nto continue", { dictionary })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "to", not "in order to".',
+        suggestions: ["to"],
+        line: 1,
+        column: 3,
+      },
+    ])
+  })
+
   test("does not match phrases across Markdown block boundaries", () => {
     expect(lint("prose-file", "Do this prior\n\nto assembly.", { dictionary }).violations).toEqual(
       [],
@@ -122,6 +137,8 @@ describe("lint prose-file: dictionary rule", () => {
     )
     expect(lint("prose-file", "# In order\nto continue", { dictionary }).violations).toEqual([])
     expect(lint("prose-file", "- In order\n- to continue", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "> In order\n# to continue", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "> # In order\nto continue", { dictionary }).violations).toEqual([])
   })
 
   test("matches hyphenated forms as one exact token", () => {

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -155,6 +155,41 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", ">     approximately", { dictionary }).violations).toEqual([])
   })
 
+  test("ignores indented code in Markdown list containers", () => {
+    expect(lint("prose-file", "-     approximately", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "1.     in order to", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "- -     approximately", { dictionary }).violations).toEqual([])
+  })
+
+  test("checks prose in Markdown list items", () => {
+    expect(lint("prose-file", "- approximately", { dictionary }).violations).toHaveLength(1)
+  })
+
+  test("keeps fenced code open until a matching delimiter closes it", () => {
+    const input = "````\n~~~\n```\napproximately\n````\napproximately"
+    const report = lint("prose-file", input, { dictionary })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "about", not "approximately".',
+        suggestions: ["about"],
+        line: 6,
+        column: 1,
+      },
+    ])
+  })
+
+  test("ignores fenced code in Markdown containers", () => {
+    expect(
+      lint("prose-file", "> ```\n> approximately\n> ```", { dictionary }).violations,
+    ).toEqual([])
+    expect(
+      lint("prose-file", "- ```\n  approximately\n  ```", { dictionary }).violations,
+    ).toEqual([])
+  })
+
   test("checks indented CommonMark paragraph continuations", () => {
     const report = lint("prose-file", "It is\n    approximately five millimeters.", { dictionary })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -149,6 +149,27 @@ describe("lint prose-file: dictionary rule", () => {
     )
   })
 
+  test("ignores unapproved forms inside Markdown indented code", () => {
+    expect(lint("prose-file", "    approximately", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "\tin order to", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", ">     approximately", { dictionary }).violations).toEqual([])
+  })
+
+  test("checks indented CommonMark paragraph continuations", () => {
+    const report = lint("prose-file", "It is\n    approximately five millimeters.", { dictionary })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "about", not "approximately".',
+        suggestions: ["about"],
+        line: 2,
+        column: 5,
+      },
+    ])
+  })
+
   test("matches hyphenated forms as one exact token", () => {
     const report = lint("prose-file", "Use state-of-the-art parts.", { dictionary })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -15,6 +15,8 @@ const dictionary = {
     { unapproved: ["attempt", "attempts"], suggestions: ["try"], partsOfSpeech: ["VERB"] },
     { unapproved: ["approximately"], suggestions: ["about"] },
     { unapproved: ["prior to"], suggestions: ["before"] },
+    { unapproved: ["in order to"], suggestions: ["to"] },
+    { unapproved: ["state-of-the-art"], suggestions: ["advanced"] },
   ],
 } as const satisfies Dictionary
 
@@ -96,13 +98,46 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
-  test("does not match phrases across paragraph or hard line breaks", () => {
+  test("matches phrases across continued Markdown block quotes", () => {
+    const report = lint("prose-file", "> in order\n> to continue", { dictionary })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "to", not "in order to".',
+        suggestions: ["to"],
+        line: 1,
+        column: 3,
+      },
+    ])
+  })
+
+  test("does not match phrases across Markdown block boundaries", () => {
     expect(lint("prose-file", "Do this prior\n\nto assembly.", { dictionary }).violations).toEqual(
       [],
     )
     expect(lint("prose-file", "Do this prior  \nto assembly.", { dictionary }).violations).toEqual(
       [],
     )
+    expect(lint("prose-file", "# In order\nto continue", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "- In order\n- to continue", { dictionary }).violations).toEqual([])
+  })
+
+  test("matches hyphenated forms as one exact token", () => {
+    const report = lint("prose-file", "Use state-of-the-art parts.", { dictionary })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "advanced", not "state-of-the-art".',
+        suggestions: ["advanced"],
+        line: 1,
+        column: 5,
+      },
+    ])
+    expect(lint("prose-file", "Use state of the art parts.", { dictionary }).violations).toEqual([])
   })
 
   test("skips POS-aware entries when no tagger is available", () => {

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest"
+import type { Dictionary } from "../../src/dictionary/schema.ts"
+import { lint } from "../../src/engine/lint.ts"
+import type { Tagger } from "../../src/engine/tagger.ts"
+
+const dictionary = {
+  formatVersion: 1,
+  source: {
+    name: "test fixture",
+    repository: "https://example.test/dictionary",
+    commit: "fixture",
+    path: "dictionary.json",
+  },
+  entries: [
+    { unapproved: ["attempt", "attempts"], suggestions: ["try"], partsOfSpeech: ["VERB"] },
+    { unapproved: ["approximately"], suggestions: ["about"] },
+  ],
+} as const satisfies Dictionary
+
+const tagger: Tagger = (text) => {
+  if (text === "Attempt the repair.") {
+    return [
+      { text: "Attempt", pos: "VERB", lemma: "attempt", offset: 0 },
+      { text: "the", pos: "DET", lemma: "the", offset: 8 },
+      { text: "repair", pos: "NOUN", lemma: "repair", offset: 12 },
+      { text: ".", pos: "PUNCT", lemma: ".", offset: 18 },
+    ]
+  }
+  if (text === "The attempt failed.") {
+    return [
+      { text: "The", pos: "DET", lemma: "the", offset: 0 },
+      { text: "attempt", pos: "NOUN", lemma: "attempt", offset: 4 },
+      { text: "failed", pos: "VERB", lemma: "fail", offset: 12 },
+      { text: ".", pos: "PUNCT", lemma: ".", offset: 18 },
+    ]
+  }
+  throw new Error(`missing tagger fixture for: ${text}`)
+}
+
+describe("lint prose-file: dictionary rule", () => {
+  test("flags an unapproved word as hard and suggests its approved alternative", () => {
+    const report = lint("prose-file", "Attempt the repair.", { dictionary, tagger })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "try", not "Attempt".',
+        suggestions: ["try"],
+        line: 1,
+        column: 1,
+      },
+    ])
+  })
+
+  test("does not flag approved alternatives", () => {
+    expect(lint("prose-file", "Try the repair.", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "It is about five millimeters.", { dictionary }).violations).toEqual(
+      [],
+    )
+  })
+
+  test("uses POS metadata to allow a noun and reject the same word as a verb", () => {
+    expect(lint("prose-file", "The attempt failed.", { dictionary, tagger }).violations).toEqual([])
+    expect(
+      lint("prose-file", "Attempt the repair.", { dictionary, tagger }).violations.map(
+        (violation) => violation.ruleId,
+      ),
+    ).toEqual(["dictionary-not-approved-word"])
+  })
+
+  test("falls back to word-level matching when POS metadata is absent", () => {
+    const report = lint("prose-file", "It is approximately five millimeters.", { dictionary })
+
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "dictionary-not-approved-word",
+      message: 'Use "about", not "approximately".',
+      suggestions: ["about"],
+      column: 7,
+    })
+  })
+
+  test("skips POS-aware entries when no tagger is available", () => {
+    expect(lint("prose-file", "Attempt the repair.", { dictionary }).violations).toEqual([])
+  })
+})

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -141,6 +141,14 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", "> # In order\nto continue", { dictionary }).violations).toEqual([])
   })
 
+  test("does not match phrases across Markdown indented code boundaries", () => {
+    expect(lint("prose-file", "    in order\nto continue", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", "\tin order\nto continue", { dictionary }).violations).toEqual([])
+    expect(lint("prose-file", ">     in order\n> to continue", { dictionary }).violations).toEqual(
+      [],
+    )
+  })
+
   test("matches hyphenated forms as one exact token", () => {
     const report = lint("prose-file", "Use state-of-the-art parts.", { dictionary })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -182,12 +182,12 @@ describe("lint prose-file: dictionary rule", () => {
   })
 
   test("ignores fenced code in Markdown containers", () => {
-    expect(
-      lint("prose-file", "> ```\n> approximately\n> ```", { dictionary }).violations,
-    ).toEqual([])
-    expect(
-      lint("prose-file", "- ```\n  approximately\n  ```", { dictionary }).violations,
-    ).toEqual([])
+    expect(lint("prose-file", "> ```\n> approximately\n> ```", { dictionary }).violations).toEqual(
+      [],
+    )
+    expect(lint("prose-file", "- ```\n  approximately\n  ```", { dictionary }).violations).toEqual(
+      [],
+    )
   })
 
   test("checks indented CommonMark paragraph continuations", () => {

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -14,6 +14,7 @@ const dictionary = {
   entries: [
     { unapproved: ["attempt", "attempts"], suggestions: ["try"], partsOfSpeech: ["VERB"] },
     { unapproved: ["approximately"], suggestions: ["about"] },
+    { unapproved: ["prior to"], suggestions: ["before"] },
   ],
 } as const satisfies Dictionary
 
@@ -78,6 +79,30 @@ describe("lint prose-file: dictionary rule", () => {
       suggestions: ["about"],
       column: 7,
     })
+  })
+
+  test("matches phrases across Markdown soft line breaks at the source position", () => {
+    const report = lint("prose-file", "Start here.\nUse this prior\n  to assembly.", { dictionary })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: 'Use "before", not "prior to".',
+        suggestions: ["before"],
+        line: 2,
+        column: 10,
+      },
+    ])
+  })
+
+  test("does not match phrases across paragraph or hard line breaks", () => {
+    expect(lint("prose-file", "Do this prior\n\nto assembly.", { dictionary }).violations).toEqual(
+      [],
+    )
+    expect(lint("prose-file", "Do this prior  \nto assembly.", { dictionary }).violations).toEqual(
+      [],
+    )
   })
 
   test("skips POS-aware entries when no tagger is available", () => {

--- a/test/fixtures/hyphenated-dictionary.json
+++ b/test/fixtures/hyphenated-dictionary.json
@@ -1,0 +1,15 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "hyphenated fixture",
+    "repository": "https://example.test/dictionary",
+    "commit": "fixture",
+    "path": "dictionary.json"
+  },
+  "entries": [
+    {
+      "unapproved": ["state-of-the-art"],
+      "suggestions": ["advanced"]
+    }
+  ]
+}

--- a/test/fixtures/invalid-dictionary.json
+++ b/test/fixtures/invalid-dictionary.json
@@ -1,0 +1,15 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "invalid fixture",
+    "repository": "https://example.test/dictionary",
+    "commit": "fixture",
+    "path": "dictionary.json"
+  },
+  "entries": [
+    {
+      "unapproved": [],
+      "suggestions": ["use"]
+    }
+  ]
+}

--- a/test/fixtures/unknown-dictionary-property.json
+++ b/test/fixtures/unknown-dictionary-property.json
@@ -1,0 +1,16 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "unknown property fixture",
+    "repository": "https://example.test/dictionary",
+    "commit": "fixture",
+    "path": "dictionary.json"
+  },
+  "entries": [
+    {
+      "unapproved": ["attempt"],
+      "suggestions": ["try"],
+      "partOfSpeech": ["VERB"]
+    }
+  ]
+}

--- a/test/fixtures/unsupported-dictionary-form.json
+++ b/test/fixtures/unsupported-dictionary-form.json
@@ -1,0 +1,15 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "unsupported form fixture",
+    "repository": "https://example.test/dictionary",
+    "commit": "fixture",
+    "path": "dictionary.json"
+  },
+  "entries": [
+    {
+      "unapproved": ["word/slash"],
+      "suggestions": ["word"]
+    }
+  ]
+}


### PR DESCRIPTION
## Intent

Implement Linear HUF-137 by building the Simplified Technical English dictionary rule on the merged HUF-133 tagger seam. Vendor only the relevant MIT-licensed dictionary data from ctotheameron/pi-ste after inspecting the exact source and license, convert it to a package-owned Effect Schema-validated format, preserve upstream attribution and add clear README attribution without copying unrelated implementation code. Emit hard violations for unapproved words with approved alternatives as suggestions, never flag approved alternatives, use the injected tagger for POS-specific entries while retaining word-level fallback for entries without POS metadata, and keep dictionary loading at an Effect boundary with the lint engine pure and synchronous. Invalid or unreadable dictionary data must report a concise readable error while all non-dictionary rules continue. Use deterministic local engine and CLI fixtures with no network or pi invocation, stay self-contained from HUF-132, HUF-134, HUF-135, and HUF-136, and pass tests, lint, typecheck, PR validation, and CI.

## What Changed

- Add an attributed, bundled STE dictionary with hard violations, approved-alternative suggestions, phrase and hyphen matching, and POS-aware filtering through the injected tagger.
- Load bundled or custom dictionaries at the CLI Effect boundary, reporting validation and read errors while continuing non-dictionary linting.
- Improve Markdown code and paragraph handling, and add deterministic engine, config, and CLI coverage for dictionary behavior.

## Risk Assessment

🚨 High: The Markdown preprocessing can suppress required hard dictionary violations in valid list and blockquote prose, so the change should not merge without correction or explicit approval.

## Testing

No prior baseline results were supplied; targeted engine, config, and spawned CLI tests completed successfully, and manual CLI evidence confirmed hard suggestions, approved/POS-aware acceptance, and continued linting after invalid dictionary data.

<details>
<summary>Evidence: End-to-end dictionary CLI transcript</summary>

```text
$ printf 'We attempt the repair. It is approximately five millimeters.' | simple-english --json
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "Use \"try\", not \"attempt\".",
      "suggestions": [
        "try"
      ],
      "line": 1,
      "column": 4
    },
    {
      "file": "<stdin>",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "Use \"about\", not \"approximately\".",
      "suggestions": [
        "about"
      ],
      "line": 1,
      "column": 30
    }
  ],
  "summary": {
    "total": 2,
    "hard": 2
  }
}
[exit 1]

$ printf 'We try the repair. The attempt failed. It is about five millimeters.' | simple-english --json
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
[exit 0]

$ printf <long-sentence> | SIMPLE_ENGLISH_DICTIONARY=test/fixtures/invalid-dictionary.json simple-english
Cannot load STE dictionary from test/fixtures/invalid-dictionary.json: entries[0].unapproved[0]: is missing
<stdin>:1:1 sentence-length Sentence has 27 words; the maximum is 25.
[exit 1]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `AGENTS.md` - merge conflict rebasing onto origin/main
- ⚠️ `README.md` - merge conflict rebasing onto origin/main
- ⚠️ `src/cli/main.ts` - merge conflict rebasing onto origin/main
- ⚠️ `src/engine/types.ts` - merge conflict rebasing onto origin/main
- ⚠️ `test/cli/cli.test.ts` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/engine/types.ts:5` - The dictionary rule ID is added outside the rule registry. Consequently, config decoding still rejects `rules.dictionary-not-approved-word`, contrary to the documented guarantee that every rule supports `hard`, `soft`, and `off`. Register the ID in `src/engine/rules/registry.ts` and derive all rule types from that registry.
- ⚠️ `src/engine/rules/dictionary.ts:82` - Matching restarts for every physical line, so a bundled phrase split by normal Markdown wrapping, such as `prior\nto`, produces no hard violation even though it renders as the unapproved phrase `prior to`. Confirm whether phrases must span soft line breaks; if so, scan adjacent prose as one stream while mapping matches back to line and column.
- ⚠️ `THIRD_PARTY_NOTICES.md:13` - The pinned upstream attribution does not say the vendored not-approved word and phrase pairs came from the two named projects. It credits unrelated phrasal-verb, hedge, marketing, irregular-participle, and rule-summary lists, none of which are vendored here. Clarify this provenance so the notice preserves the exact upstream attribution without implying unsupported ownership of the bundled data.

🔧 Fix: Fix dictionary registry, wrapping, and provenance
2 issues (1 error, 1 warning) still open:
- 🚨 `src/engine/rules/dictionary.ts:50` - `isSoftLineBreak` does not model Markdown block continuity. It misses a real soft break in `&gt; in order\n&gt; to continue` because the second quote marker is non-whitespace, while it incorrectly joins `# In order\nto continue` across a heading boundary and emits a hard violation. Track Markdown block/container continuity before matching phrases rather than treating adjacent physical lines as sufficient.
- ⚠️ `src/dictionary/schema.ts:11` - The documented replacement format accepts any nonempty string, but the matcher only supports alphanumeric or apostrophe tokens separated by whitespace. A schema-valid form such as `state-of-the-art` can never match because it compiles as one word while input tokenization produces four tokens. Either support hyphenated forms consistently or reject unsupported forms during dictionary validation.

🔧 Fix: Fix Markdown phrase continuity and hyphenated forms
1 error still open:
- 🚨 `src/engine/rules/dictionary.ts:105` - The quote-depth equality check still rejects genuine Markdown soft breaks in lazy blockquote continuations. For example, `&gt; in order\nto continue` is one blockquote paragraph, but the depth changes from 1 to 0, so the required phrase violation remains unreachable. Track paragraph/container continuity across lines, including lazy blockquote lines, instead of comparing only physical quote markers.

🔧 Fix: Support lazy blockquote phrase matching
2 errors still open:
- 🚨 `src/engine/rules/dictionary.ts:116` - Indented code is treated as paragraph prose. For `    in order\nto continue`, both lines receive one paragraph ID, so the rule reports `in order to` across an indented-code boundary rather than a genuine Markdown soft break. Model indented code at the Markdown context boundary and add this regression fixture.
- 🚨 `src/dictionary/load.ts:43` - Intent requires: &#34;Invalid or unreadable dictionary data must report a concise readable error while all non-dictionary rules continue.&#34; This decode uses Effect&#39;s default `onExcessProperty: &#34;ignore&#34;`, so a typo such as `partOfSpeech` is silently removed and the entry becomes a broad word-level rule instead of producing an error. Reject excess properties at the dictionary loading boundary.

🔧 Fix: Fix dictionary Markdown boundaries and strict validation
1 warning still open:
- ⚠️ `src/engine/rules/dictionary.ts:220` - Indented code receives no paragraph ID, but `tokenize(lines)` still scans it. Thus `    approximately` or `    in order to` inside an indented Markdown code block emits a hard violation, unlike fenced code that preprocessing intentionally blanks. Confirm whether prose linting must exclude indented code; if so, exclude these tokens at the Markdown preprocessing boundary while preserving CommonMark paragraph continuations.

🔧 Fix: Exclude indented Markdown code from prose linting
2 errors still open:
- 🚨 `src/engine/markdown.ts:89` - The durable indented-code fix still scans CommonMark list items whose first block is indented code. For `-     approximately`, `content` starts with the list marker, so `isIndentedCode` returns false and the dictionary emits a hard violation for code. Resolve list-container indentation at this shared preprocessing boundary before classifying content.
- 🚨 `src/engine/markdown.ts:57` - Fence state toggles for any raw backtick or tilde fence instead of matching the active CommonMark opener. Inside a backtick fence, a `~~~` line incorrectly closes the fence, causing a following `approximately` code line to emit a hard dictionary violation. Blockquote-prefixed fences are also not detected. Track the opener delimiter, run length, and container prefix at this shared boundary.

🔧 Fix: Fix Markdown code container parsing
1 error still open:
- 🚨 `src/engine/markdown.ts:133` - The required criterion says &#34;Emit hard violations for unapproved words,&#34; but container tracking remains line-local. For `- item\n  ```\napproximately`, the continued-list opener records `listIndent: 0`, so the unindented prose line is incorrectly blanked as code after it exits the list. The fixed parsing order also misses `- &gt; ```\n  &gt; approximately`, and line 102 carries `&gt; ```\n\n&gt; approximately` into a new blockquote. Track the active ordered Markdown container stack at this shared preprocessing boundary and add regressions for these reachable paths.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/engine/dictionary.test.ts`
- `bunx vitest run test/cli/cli.test.ts -t 'bundled dictionary|hyphenated dictionary|approved alternative|word-level fallback|reports an .* dictionary'`
- `bunx vitest run test/config/schema.test.ts -t 'dictionary rule'`
- <code>Spawned `bun src/cli/main.ts --json` with bundled dictionary stdin containing unapproved words, approved alternatives, and a POS-allowed noun.</code>
- <code>Spawned `bun src/cli/main.ts` with `SIMPLE_ENGLISH_DICTIONARY=test/fixtures/invalid-dictionary.json` and a long sentence to verify readable errors and continued non-dictionary linting.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
