### PR TITLE
feat(engine): lint comments and commit messages by content kind

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Parent spec lives in Linear HUF-130.
 - pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`, `wink-nlp`) must stay in `dependencies`, never `devDependencies`.
 - POS tagging is an injected boundary: the engine consumes the pure `Tagger` type (`src/engine/tagger.ts`) and silently skips tagger-dependent checks when `LintOptions.tagger` is absent; the wink-nlp implementation and its Effect layer live in `src/tagger/wink.ts`. Tagger-dependent verb verdicts are pinned, right or wrong, in `test/engine/verb-form-fixtures.test.ts`.
 - The package-owned dictionary format and matching semantics are documented in `src/dictionary/README.md`; load and validate dictionary data before passing it into the synchronous engine.
+- Extractors (`src/engine/comments.ts`, `markdown.ts`, `identifiers.ts`) blank non-prose with spaces so violation line/column always map to the original file. `test/fixtures/**` is excluded from Biome because tests pin exact byte positions in fixtures; do not let a formatter touch them.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,29 @@ This project is a TypeScript and Effect reimplementation of [pi-ste](https://git
 
 ```sh
 simple-english README.md
+simple-english src/main.ts
+git log -1 --format=%B | simple-english --kind commit-message
 cat notes.md | simple-english
 simple-english --json README.md
 ```
 
+The CLI selects a content kind from each file extension:
+
+- `slash-source` lints comments in `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.go`, `.rs`, `.java`, `.c`, `.h`, `.cpp`, `.hpp`, `.cc`, `.cs`, `.swift`, `.kt`, and `.scala` files.
+- `hash-source` lints comments in `.sh`, `.bash`, `.zsh`, `.py`, `.rb`, `.yaml`, `.yml`, `.toml`, and `.pl` files.
+- `prose-file` lints all other files, including extensionless paths.
+
+Extension matching is case-insensitive.
+Standard input defaults to `prose-file`.
+Use `--kind prose-file`, `--kind slash-source`, `--kind hash-source`, or `--kind commit-message` to override automatic selection for files or standard input.
+The `commit-message` kind lints the complete commit message.
+
+All kinds preserve original line and column positions and ignore identifiers plus Markdown fenced and indented code.
+Inline code is excluded from all rules except `semicolon`.
+Source kinds lint only comments and ignore comment markers inside string literals.
+
 The CLI prints STE violations with a line, column, severity, and rule ID.
-It exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when an input file cannot be read or a config file is invalid.
+It exits 1 when hard violations exist, 0 when no hard violations exist, and 2 for input, argument, or config errors.
 Soft violations are still printed when the command exits 0.
 `--json` emits a machine-readable report with the severity of each violation and an approved suggestion for phrasal verbs.
 `--config <path>` loads an explicit config file instead of the discovered ones.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
-    "ignore": [".claude/**"]
+    "ignore": [".claude/**", "test/fixtures/**"]
   },
   "vcs": {
     "enabled": true,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -33,7 +33,9 @@ const SLASH_EXTENSIONS = new Set([
 const HASH_EXTENSIONS = new Set(["sh", "bash", "zsh", "py", "rb", "yaml", "yml", "toml", "pl"])
 
 const kindForPath = (path: string): LintKind => {
-  const extension = path.slice(path.lastIndexOf(".") + 1).toLowerCase()
+  const dot = path.lastIndexOf(".")
+  if (dot <= path.lastIndexOf("/")) return "prose-file"
+  const extension = path.slice(dot + 1).toLowerCase()
   if (SLASH_EXTENSIONS.has(extension)) return "slash-source"
   if (HASH_EXTENSIONS.has(extension)) return "hash-source"
   return "prose-file"
@@ -43,6 +45,7 @@ interface CliArgs {
   readonly json: boolean
   readonly configPath: string | undefined
   readonly kind: string | undefined
+  readonly kindMissingValue: boolean
   readonly paths: readonly string[]
 }
 
@@ -51,6 +54,7 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
     let json = false
     let configPath: string | undefined
     let kind: string | undefined
+    let kindMissingValue = false
     const paths: string[] = []
     for (let i = 0; i < args.length; i++) {
       const arg = args[i] as string
@@ -63,13 +67,14 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
         }
       } else if (arg === "--kind") {
         kind = args[++i]
+        if (kind === undefined) kindMissingValue = true
       } else if (arg.startsWith("--kind=")) {
         kind = arg.slice("--kind=".length)
       } else {
         paths.push(arg)
       }
     }
-    return { json, configPath, kind, paths }
+    return { json, configPath, kind, kindMissingValue, paths }
   })
 
 const isLintKind = (value: string): value is LintKind =>
@@ -131,7 +136,14 @@ const render = (report: CliReport, json: boolean): string => {
 
 const program = Effect.gen(function* () {
   const tagger = yield* TaggerService
-  const { json, configPath, kind, paths } = yield* parseArgs(process.argv.slice(2))
+  const { json, configPath, kind, kindMissingValue, paths } = yield* parseArgs(
+    process.argv.slice(2),
+  )
+  if (kindMissingValue) {
+    return yield* Effect.fail(
+      new Error(`--kind requires a value; expected one of: ${KINDS.join(", ")}`),
+    )
+  }
   if (kind !== undefined && !isLintKind(kind)) {
     return yield* Effect.fail(
       new Error(`unknown kind "${kind}"; expected one of: ${KINDS.join(", ")}`),

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,7 +4,7 @@ import { Effect, Either } from "effect"
 import { loadConfig } from "../config/load.ts"
 import { loadDictionary } from "../dictionary/load.ts"
 import { lint } from "../engine/lint.ts"
-import type { LintKind, LintReport } from "../engine/types.ts"
+import type { LintKind, LintReport, SourceDialect } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
 
 const KINDS: readonly LintKind[] = ["prose-file", "slash-source", "hash-source", "commit-message"]
@@ -32,13 +32,21 @@ const SLASH_EXTENSIONS = new Set([
 
 const HASH_EXTENSIONS = new Set(["sh", "bash", "zsh", "py", "rb", "yaml", "yml", "toml", "pl"])
 
-const kindForPath = (path: string): LintKind => {
+interface PathClassification {
+  readonly kind: LintKind
+  readonly sourceDialect: SourceDialect
+}
+
+const classifyPath = (path: string): PathClassification => {
   const dot = path.lastIndexOf(".")
-  if (dot <= path.lastIndexOf("/")) return "prose-file"
+  if (dot <= path.lastIndexOf("/")) return { kind: "prose-file", sourceDialect: "general" }
   const extension = path.slice(dot + 1).toLowerCase()
-  if (SLASH_EXTENSIONS.has(extension)) return "slash-source"
-  if (HASH_EXTENSIONS.has(extension)) return "hash-source"
-  return "prose-file"
+  if (SLASH_EXTENSIONS.has(extension)) return { kind: "slash-source", sourceDialect: "general" }
+  if (HASH_EXTENSIONS.has(extension)) {
+    const sourceDialect = ["sh", "bash", "zsh"].includes(extension) ? "shell" : "general"
+    return { kind: "hash-source", sourceDialect }
+  }
+  return { kind: "prose-file", sourceDialect: "general" }
 }
 
 interface CliArgs {
@@ -163,10 +171,18 @@ const program = Effect.gen(function* () {
       : yield* Effect.forEach(paths, readInput)
 
   const report = toCliReport(
-    inputs.map(({ path, text }) => ({
-      path,
-      report: lint(kind ?? kindForPath(path), text, { ...config, dictionary, tagger }),
-    })),
+    inputs.map(({ path, text }) => {
+      const classification = classifyPath(path)
+      return {
+        path,
+        report: lint(kind ?? classification.kind, text, {
+          ...config,
+          dictionary,
+          tagger,
+          sourceDialect: classification.sourceDialect,
+        }),
+      }
+    }),
   )
 
   const output = render(report, json)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,12 +4,45 @@ import { Effect, Either } from "effect"
 import { loadConfig } from "../config/load.ts"
 import { loadDictionary } from "../dictionary/load.ts"
 import { lint } from "../engine/lint.ts"
-import type { LintReport } from "../engine/types.ts"
+import type { LintKind, LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
+
+const KINDS: readonly LintKind[] = ["prose-file", "slash-source", "hash-source", "commit-message"]
+
+const SLASH_EXTENSIONS = new Set([
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "go",
+  "rs",
+  "java",
+  "c",
+  "h",
+  "cpp",
+  "hpp",
+  "cc",
+  "cs",
+  "swift",
+  "kt",
+  "scala",
+])
+
+const HASH_EXTENSIONS = new Set(["sh", "bash", "zsh", "py", "rb", "yaml", "yml", "toml", "pl"])
+
+const kindForPath = (path: string): LintKind => {
+  const extension = path.slice(path.lastIndexOf(".") + 1).toLowerCase()
+  if (SLASH_EXTENSIONS.has(extension)) return "slash-source"
+  if (HASH_EXTENSIONS.has(extension)) return "hash-source"
+  return "prose-file"
+}
 
 interface CliArgs {
   readonly json: boolean
   readonly configPath: string | undefined
+  readonly kind: string | undefined
   readonly paths: readonly string[]
 }
 
@@ -17,6 +50,7 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
   Effect.gen(function* () {
     let json = false
     let configPath: string | undefined
+    let kind: string | undefined
     const paths: string[] = []
     for (let i = 0; i < args.length; i++) {
       const arg = args[i] as string
@@ -27,12 +61,19 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
         if (configPath === undefined) {
           yield* Effect.fail(new Error("--config requires a file path"))
         }
+      } else if (arg === "--kind") {
+        kind = args[++i]
+      } else if (arg.startsWith("--kind=")) {
+        kind = arg.slice("--kind=".length)
       } else {
         paths.push(arg)
       }
     }
-    return { json, configPath, paths }
+    return { json, configPath, kind, paths }
   })
+
+const isLintKind = (value: string): value is LintKind =>
+  (KINDS as readonly string[]).includes(value)
 
 interface FileViolation {
   readonly file: string
@@ -90,7 +131,12 @@ const render = (report: CliReport, json: boolean): string => {
 
 const program = Effect.gen(function* () {
   const tagger = yield* TaggerService
-  const { json, configPath, paths } = yield* parseArgs(process.argv.slice(2))
+  const { json, configPath, kind, paths } = yield* parseArgs(process.argv.slice(2))
+  if (kind !== undefined && !isLintKind(kind)) {
+    return yield* Effect.fail(
+      new Error(`unknown kind "${kind}"; expected one of: ${KINDS.join(", ")}`),
+    )
+  }
   const config = yield* loadConfig(configPath)
   const loadedDictionary = yield* Effect.either(
     loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
@@ -107,7 +153,7 @@ const program = Effect.gen(function* () {
   const report = toCliReport(
     inputs.map(({ path, text }) => ({
       path,
-      report: lint("prose-file", text, { ...config, dictionary, tagger }),
+      report: lint(kind ?? kindForPath(path), text, { ...config, dictionary, tagger }),
     })),
   )
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -74,8 +74,13 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
           yield* Effect.fail(new Error("--config requires a file path"))
         }
       } else if (arg === "--kind") {
-        kind = args[++i]
-        if (kind === undefined) kindMissingValue = true
+        const value = args[i + 1]
+        if (value === undefined || value.startsWith("--")) {
+          kindMissingValue = true
+        } else {
+          kind = value
+          i++
+        }
       } else if (arg.startsWith("--kind=")) {
         kind = arg.slice("--kind=".length)
       } else {

--- a/src/engine/comments.ts
+++ b/src/engine/comments.ts
@@ -1,3 +1,5 @@
+import type { SourceDialect } from "./types.ts"
+
 export interface ExtractedComments {
   readonly lines: readonly string[]
   readonly contentStarts: readonly number[]
@@ -15,9 +17,47 @@ const isRustLifetime = (line: string, index: number): boolean => {
   return line[end] !== "'"
 }
 
+type MultilineLiteral =
+  | { readonly kind: "escaped"; readonly terminator: string }
+  | { readonly kind: "literal"; readonly terminator: string }
+  | { readonly kind: "verbatim" }
+
+const hasTokenBoundary = (line: string, index: number): boolean =>
+  index === 0 || !/[A-Za-z0-9_]/.test(line[index - 1] ?? "")
+
+const multilineLiteralAt = (
+  line: string,
+  index: number,
+): { literal: MultilineLiteral; end: number } | null => {
+  if (!hasTokenBoundary(line, index)) return null
+
+  const csharp = line.slice(index).match(/^(?:\$@|@\$|@)"/)
+  if (csharp !== null) {
+    return { literal: { kind: "verbatim" }, end: index + csharp[0].length }
+  }
+
+  const rust = line.slice(index).match(/^(?:br|r)(#{0,255})"/)
+  if (rust !== null) {
+    return {
+      literal: { kind: "literal", terminator: `"${rust[1] as string}` },
+      end: index + rust[0].length,
+    }
+  }
+
+  const cpp = line.slice(index).match(/^(?:u8|u|U|L)?R"([^ ()\\\t\r\n]{0,16})\(/)
+  if (cpp !== null) {
+    return {
+      literal: { kind: "literal", terminator: `)${cpp[1] as string}"` },
+      end: index + cpp[0].length,
+    }
+  }
+
+  return null
+}
+
 export function extractSlashComments(text: string): ExtractedComments {
   let inBlock = false
-  let multilineQuote: "`" | '"""' | null = null
+  let multilineLiteral: MultilineLiteral | null = null
   const contentStarts: number[] = []
 
   const lines = text.split("\n").map((line) => {
@@ -52,14 +92,27 @@ export function extractSlashComments(text: string): ExtractedComments {
         continue
       }
 
-      if (multilineQuote !== null) {
-        if (multilineQuote === "`" && ch === "\\") {
+      if (multilineLiteral !== null) {
+        if (multilineLiteral.kind === "escaped" && ch === "\\") {
           i += 2
           continue
         }
-        if (line.startsWith(multilineQuote, i)) {
-          i += multilineQuote.length
-          multilineQuote = null
+        if (multilineLiteral.kind === "verbatim") {
+          if (line.startsWith('""', i)) {
+            i += 2
+            continue
+          }
+          if (ch === '"') {
+            multilineLiteral = null
+            i++
+            continue
+          }
+          i++
+          continue
+        }
+        if (line.startsWith(multilineLiteral.terminator, i)) {
+          i += multilineLiteral.terminator.length
+          multilineLiteral = null
           continue
         }
         i++
@@ -76,13 +129,19 @@ export function extractSlashComments(text: string): ExtractedComments {
         continue
       }
 
+      const boundedLiteral = multilineLiteralAt(line, i)
+      if (boundedLiteral !== null) {
+        multilineLiteral = boundedLiteral.literal
+        i = boundedLiteral.end
+        continue
+      }
       if (line.startsWith('"""', i)) {
-        multilineQuote = '"""'
+        multilineLiteral = { kind: "literal", terminator: '"""' }
         i += 3
         continue
       }
       if (ch === "`") {
-        multilineQuote = "`"
+        multilineLiteral = { kind: "escaped", terminator: "`" }
         i++
         continue
       }
@@ -122,19 +181,64 @@ interface Heredoc {
   readonly stripTabs: boolean
 }
 
-const HEREDOC = /^<<(-)?[ \t]*(?:'([^']+)'|"([^"]+)"|\\([A-Za-z_][\w]*)|([A-Za-z_][\w]*))/
+interface ParsedHeredoc extends Heredoc {
+  readonly end: number
+}
 
-export function extractHashComments(text: string): ExtractedComments {
-  let quote: "'" | '"' | "'''" | '"""' | null = null
+const parseHeredoc = (line: string, start: number): ParsedHeredoc | null => {
+  if (!line.startsWith("<<", start) || line[start + 2] === "<") return null
+  let index = start + 2
+  let stripTabs = false
+  if (line[index] === "-") {
+    stripTabs = true
+    index++
+  }
+  while (line[index] === " " || line[index] === "\t") index++
+
+  let delimiter = ""
+  while (index < line.length && !/[\s;&|()<>]/.test(line[index] as string)) {
+    const ch = line[index] as string
+    if (ch === "'" || ch === '"') {
+      const quote = ch
+      const close = line.indexOf(quote, index + 1)
+      if (close === -1) return null
+      delimiter += line.slice(index + 1, close)
+      index = close + 1
+      continue
+    }
+    if (ch === "\\") {
+      if (index + 1 >= line.length) return null
+      delimiter += line[index + 1] as string
+      index += 2
+      continue
+    }
+    delimiter += ch
+    index++
+  }
+
+  return delimiter === "" ? null : { delimiter, stripTabs, end: index }
+}
+
+const isShellCommentStart = (line: string, index: number): boolean =>
+  index === 0 || /[\s;|&()]/.test(line[index - 1] ?? "")
+
+export function extractHashComments(
+  text: string,
+  dialect: SourceDialect = "general",
+): ExtractedComments {
+  let multilineQuote: "'''" | '"""' | null = null
+  let shellQuote: "'" | '"' | null = null
   let parameterDepth = 0
   let arithmeticDepth = 0
   const heredocs: Heredoc[] = []
   const contentStarts: number[] = []
+  const shell = dialect === "shell"
 
   const lines = text.split("\n").map((line, lineIndex) => {
     const activeHeredoc = heredocs[0]
     if (activeHeredoc !== undefined) {
-      const candidate = activeHeredoc.stripTabs ? line.replace(/^\t+/, "") : line
+      const normalized = line.endsWith("\r") ? line.slice(0, -1) : line
+      const candidate = activeHeredoc.stripTabs ? normalized.replace(/^\t+/, "") : normalized
       if (candidate === activeHeredoc.delimiter) heredocs.shift()
       contentStarts.push(line.length)
       return blankLine(line)
@@ -148,77 +252,87 @@ export function extractHashComments(text: string): ExtractedComments {
     const out = new Array<string>(line.length).fill(" ")
     const pendingHeredocs: Heredoc[] = []
     let contentStart = line.length
+    let lineQuote: "'" | '"' | null = null
     let i = 0
 
     while (i < line.length) {
       const ch = line[i] as string
 
-      if (quote !== null) {
-        if (ch === "\\" && quote !== "'") {
-          i += 2
-          continue
-        }
-        if (quote === "'" && line.startsWith("''", i)) {
-          i += 2
-          continue
-        }
-        if (line.startsWith(quote, i)) {
-          i += quote.length
-          quote = null
+      if (multilineQuote !== null) {
+        if (line.startsWith(multilineQuote, i)) {
+          i += multilineQuote.length
+          multilineQuote = null
           continue
         }
         i++
         continue
       }
 
-      if (line.startsWith("'''", i) || line.startsWith('"""', i)) {
-        quote = line.slice(i, i + 3) as "'''" | '"""'
+      if (shellQuote !== null) {
+        if (ch === "\\" && shellQuote === '"') {
+          i += 2
+          continue
+        }
+        if (ch === shellQuote) shellQuote = null
+        i++
+        continue
+      }
+
+      if (lineQuote !== null) {
+        if (ch === "\\" && lineQuote === '"') {
+          i += 2
+          continue
+        }
+        if (ch === lineQuote) lineQuote = null
+        i++
+        continue
+      }
+
+      if (!shell && (line.startsWith("'''", i) || line.startsWith('"""', i))) {
+        multilineQuote = line.slice(i, i + 3) as "'''" | '"""'
         i += 3
         continue
       }
       if (ch === '"' || ch === "'") {
-        quote = ch
+        if (shell) shellQuote = ch
+        else lineQuote = ch
         i++
         continue
       }
-      if (line.startsWith("${", i)) {
+      if (shell && line.startsWith("${", i)) {
         parameterDepth++
         i += 2
         continue
       }
-      if (parameterDepth > 0 && ch === "}") {
+      if (shell && parameterDepth > 0 && ch === "}") {
         parameterDepth--
         i++
         continue
       }
-      if (line.startsWith("$((", i)) {
+      if (shell && line.startsWith("$((", i)) {
         arithmeticDepth++
         i += 3
         continue
       }
-      if (arithmeticDepth > 0 && line.startsWith("))", i)) {
+      if (shell && arithmeticDepth > 0 && line.startsWith("))", i)) {
         arithmeticDepth--
         i += 2
         continue
       }
-      if (parameterDepth === 0 && arithmeticDepth === 0 && line.startsWith("<<", i)) {
-        if (line[i + 2] !== "<") {
-          const match = line.slice(i).match(HEREDOC)
-          if (match !== null) {
-            pendingHeredocs.push({
-              delimiter: (match[2] ?? match[3] ?? match[4] ?? match[5]) as string,
-              stripTabs: match[1] !== undefined,
-            })
-            i += match[0].length
-            continue
-          }
+      if (shell && parameterDepth === 0 && arithmeticDepth === 0 && line.startsWith("<<", i)) {
+        const heredoc = parseHeredoc(line, i)
+        if (heredoc !== null) {
+          pendingHeredocs.push({ delimiter: heredoc.delimiter, stripTabs: heredoc.stripTabs })
+          i = heredoc.end
+          continue
         }
       }
       if (
         ch === "#" &&
         parameterDepth === 0 &&
         arithmeticDepth === 0 &&
-        line[i - 1] !== "$"
+        line[i - 1] !== "$" &&
+        (!shell || isShellCommentStart(line, i))
       ) {
         let j = i + 1
         while (line[j] === "#") j++

--- a/src/engine/comments.ts
+++ b/src/engine/comments.ts
@@ -1,0 +1,94 @@
+// Line-based comment extraction. Each function maps source text to lines of
+// the same length where only comment prose keeps its characters, so line and
+// column positions in the output match the original file. String-literal
+// state never carries across lines; that limit is pinned by tests.
+
+export function extractSlashComments(text: string): string[] {
+  let inBlock = false
+  return text.split("\n").map((line) => {
+    const out = new Array<string>(line.length).fill(" ")
+    let i = 0
+    let quote: string | null = null
+
+    if (inBlock) {
+      // Skip the decorative leading asterisk of doc comment continuation lines.
+      while (line[i] === " " || line[i] === "\t") i++
+      if (line[i] === "*" && line[i + 1] !== "/") i++
+    }
+
+    while (i < line.length) {
+      const ch = line[i]
+      const next = line[i + 1]
+      if (inBlock) {
+        if (ch === "*" && next === "/") {
+          inBlock = false
+          i += 2
+          continue
+        }
+        out[i] = ch as string
+        i++
+        continue
+      }
+      if (quote !== null) {
+        if (ch === "\\") {
+          i += 2
+          continue
+        }
+        if (ch === quote) quote = null
+        i++
+        continue
+      }
+      if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch
+        i++
+        continue
+      }
+      if (ch === "/" && next === "/") {
+        i += 2
+        while (line[i] === "/" || line[i] === "!") i++
+        for (; i < line.length; i++) out[i] = line[i] as string
+        break
+      }
+      if (ch === "/" && next === "*") {
+        inBlock = true
+        i += 2
+        while (line[i] === "*" && line[i + 1] !== "/") i++
+        continue
+      }
+      i++
+    }
+    return out.join("")
+  })
+}
+
+export function extractHashComments(text: string): string[] {
+  return text.split("\n").map((line, index) => {
+    if (index === 0 && line.startsWith("#!")) {
+      return ""
+    }
+    const out = new Array<string>(line.length).fill(" ")
+    let quote: string | null = null
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i]
+      if (quote !== null) {
+        if (ch === "\\") {
+          i++
+          continue
+        }
+        if (ch === quote) quote = null
+        continue
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch
+        continue
+      }
+      if (ch === "#") {
+        let j = i + 1
+        while (line[j] === "#") j++
+        for (; j < line.length; j++) out[j] = line[j] as string
+        break
+      }
+    }
+    return out.join("")
+  })
+}

--- a/src/engine/comments.ts
+++ b/src/engine/comments.ts
@@ -10,6 +10,16 @@ const blankLine = (line: string): string => " ".repeat(line.length)
 const consumeSeparator = (line: string, index: number): number =>
   line[index] === " " || line[index] === "\t" ? index + 1 : index
 
+const hasEscapedLineBreak = (line: string): boolean => {
+  let index = line.endsWith("\r") ? line.length - 1 : line.length
+  let backslashes = 0
+  while (line[index - 1] === "\\") {
+    backslashes++
+    index--
+  }
+  return backslashes % 2 !== 0
+}
+
 const isRustLifetime = (line: string, index: number): boolean => {
   if (line[index] !== "'" || !/[A-Za-z_]/.test(line[index + 1] ?? "")) return false
   let end = index + 2
@@ -58,12 +68,14 @@ const multilineLiteralAt = (
 export function extractSlashComments(text: string): ExtractedComments {
   let inBlock = false
   let multilineLiteral: MultilineLiteral | null = null
+  let continuedLineQuote: "'" | '"' | null = null
   const contentStarts: number[] = []
 
   const lines = text.split("\n").map((line) => {
     const out = new Array<string>(line.length).fill(" ")
     let contentStart = line.length
-    let lineQuote: "'" | '"' | null = null
+    let lineQuote = continuedLineQuote
+    continuedLineQuote = null
     let i = 0
 
     const markContentStart = (index: number) => {
@@ -169,6 +181,7 @@ export function extractSlashComments(text: string): ExtractedComments {
       i++
     }
 
+    if (lineQuote !== null && hasEscapedLineBreak(line)) continuedLineQuote = lineQuote
     contentStarts.push(contentStart)
     return out.join("")
   })
@@ -228,6 +241,7 @@ export function extractHashComments(
 ): ExtractedComments {
   let multilineQuote: "'''" | '"""' | null = null
   let shellQuote: "'" | '"' | null = null
+  let continuedLineQuote: "'" | '"' | null = null
   let parameterDepth = 0
   let arithmeticDepth = 0
   const heredocs: Heredoc[] = []
@@ -252,7 +266,8 @@ export function extractHashComments(
     const out = new Array<string>(line.length).fill(" ")
     const pendingHeredocs: Heredoc[] = []
     let contentStart = line.length
-    let lineQuote: "'" | '"' | null = null
+    let lineQuote = continuedLineQuote
+    continuedLineQuote = null
     let i = 0
 
     while (i < line.length) {
@@ -279,7 +294,7 @@ export function extractHashComments(
       }
 
       if (lineQuote !== null) {
-        if (ch === "\\" && lineQuote === '"') {
+        if (ch === "\\") {
           i += 2
           continue
         }
@@ -344,6 +359,7 @@ export function extractHashComments(
       i++
     }
 
+    if (lineQuote !== null && hasEscapedLineBreak(line)) continuedLineQuote = lineQuote
     heredocs.push(...pendingHeredocs)
     contentStarts.push(contentStart)
     return out.join("")

--- a/src/engine/comments.ts
+++ b/src/engine/comments.ts
@@ -1,8 +1,14 @@
 import type { SourceDialect } from "./types.ts"
 
+export interface ProseBreak {
+  readonly line: number
+  readonly column: number
+}
+
 export interface ExtractedComments {
   readonly lines: readonly string[]
   readonly contentStarts: readonly number[]
+  readonly proseBreaks: readonly ProseBreak[]
 }
 
 const blankLine = (line: string): string => " ".repeat(line.length)
@@ -69,9 +75,11 @@ export function extractSlashComments(text: string): ExtractedComments {
   let inBlock = false
   let multilineLiteral: MultilineLiteral | null = null
   let continuedLineQuote: "'" | '"' | null = null
+  let previousComment: "line" | "block" | null = null
   const contentStarts: number[] = []
+  const proseBreaks: ProseBreak[] = []
 
-  const lines = text.split("\n").map((line) => {
+  const lines = text.split("\n").map((line, lineIndex) => {
     const out = new Array<string>(line.length).fill(" ")
     let contentStart = line.length
     let lineQuote = continuedLineQuote
@@ -80,6 +88,13 @@ export function extractSlashComments(text: string): ExtractedComments {
 
     const markContentStart = (index: number) => {
       contentStart = Math.min(contentStart, index)
+    }
+
+    const beginComment = (kind: "line" | "block", index: number) => {
+      if (previousComment !== null && (kind === "block" || previousComment === "block")) {
+        proseBreaks.push({ line: lineIndex, column: index })
+      }
+      previousComment = kind
     }
 
     if (inBlock) {
@@ -166,6 +181,7 @@ export function extractSlashComments(text: string): ExtractedComments {
         i += 2
         while (line[i] === "/" || line[i] === "!") i++
         i = consumeSeparator(line, i)
+        beginComment("line", i)
         markContentStart(i)
         for (; i < line.length; i++) out[i] = line[i] as string
         break
@@ -175,6 +191,7 @@ export function extractSlashComments(text: string): ExtractedComments {
         i += 2
         while (line[i] === "*" && line[i + 1] !== "/") i++
         i = consumeSeparator(line, i)
+        beginComment("block", i)
         markContentStart(i)
         continue
       }
@@ -186,7 +203,7 @@ export function extractSlashComments(text: string): ExtractedComments {
     return out.join("")
   })
 
-  return { lines, contentStarts }
+  return { lines, contentStarts, proseBreaks }
 }
 
 interface Heredoc {
@@ -365,5 +382,5 @@ export function extractHashComments(
     return out.join("")
   })
 
-  return { lines, contentStarts }
+  return { lines, contentStarts, proseBreaks: [] }
 }

--- a/src/engine/comments.ts
+++ b/src/engine/comments.ts
@@ -1,50 +1,101 @@
-// Line-based comment extraction. Each function maps source text to lines of
-// the same length where only comment prose keeps its characters, so line and
-// column positions in the output match the original file.
+export interface ExtractedComments {
+  readonly lines: readonly string[]
+  readonly contentStarts: readonly number[]
+}
 
-export function extractSlashComments(text: string): string[] {
+const blankLine = (line: string): string => " ".repeat(line.length)
+
+const consumeSeparator = (line: string, index: number): number =>
+  line[index] === " " || line[index] === "\t" ? index + 1 : index
+
+const isRustLifetime = (line: string, index: number): boolean => {
+  if (line[index] !== "'" || !/[A-Za-z_]/.test(line[index + 1] ?? "")) return false
+  let end = index + 2
+  while (/[A-Za-z0-9_]/.test(line[end] ?? "")) end++
+  return line[end] !== "'"
+}
+
+export function extractSlashComments(text: string): ExtractedComments {
   let inBlock = false
-  let quote: string | null = null
+  let multilineQuote: "`" | '"""' | null = null
+  const contentStarts: number[] = []
 
-  return text.split("\n").map((line) => {
+  const lines = text.split("\n").map((line) => {
     const out = new Array<string>(line.length).fill(" ")
+    let contentStart = line.length
+    let lineQuote: "'" | '"' | null = null
     let i = 0
+
+    const markContentStart = (index: number) => {
+      contentStart = Math.min(contentStart, index)
+    }
 
     if (inBlock) {
       while (line[i] === " " || line[i] === "\t") i++
       if (line[i] === "*" && line[i + 1] !== "/") i++
+      i = consumeSeparator(line, i)
+      markContentStart(i)
     }
 
     while (i < line.length) {
-      const ch = line[i]
+      const ch = line[i] as string
       const next = line[i + 1]
+
       if (inBlock) {
         if (ch === "*" && next === "/") {
           inBlock = false
           i += 2
           continue
         }
-        out[i] = ch as string
+        out[i] = ch
         i++
         continue
       }
-      if (quote !== null) {
+
+      if (multilineQuote !== null) {
+        if (multilineQuote === "`" && ch === "\\") {
+          i += 2
+          continue
+        }
+        if (line.startsWith(multilineQuote, i)) {
+          i += multilineQuote.length
+          multilineQuote = null
+          continue
+        }
+        i++
+        continue
+      }
+
+      if (lineQuote !== null) {
         if (ch === "\\") {
           i += 2
           continue
         }
-        if (ch === quote) quote = null
+        if (ch === lineQuote) lineQuote = null
         i++
         continue
       }
-      if (ch === '"' || ch === "'" || ch === "`") {
-        quote = ch
+
+      if (line.startsWith('"""', i)) {
+        multilineQuote = '"""'
+        i += 3
+        continue
+      }
+      if (ch === "`") {
+        multilineQuote = "`"
+        i++
+        continue
+      }
+      if (ch === '"' || (ch === "'" && !isRustLifetime(line, i))) {
+        lineQuote = ch
         i++
         continue
       }
       if (ch === "/" && next === "/") {
         i += 2
         while (line[i] === "/" || line[i] === "!") i++
+        i = consumeSeparator(line, i)
+        markContentStart(i)
         for (; i < line.length; i++) out[i] = line[i] as string
         break
       }
@@ -52,27 +103,62 @@ export function extractSlashComments(text: string): string[] {
         inBlock = true
         i += 2
         while (line[i] === "*" && line[i + 1] !== "/") i++
+        i = consumeSeparator(line, i)
+        markContentStart(i)
         continue
       }
       i++
     }
+
+    contentStarts.push(contentStart)
     return out.join("")
   })
+
+  return { lines, contentStarts }
 }
 
-export function extractHashComments(text: string): string[] {
-  let quote: string | null = null
+interface Heredoc {
+  readonly delimiter: string
+  readonly stripTabs: boolean
+}
 
-  return text.split("\n").map((line, index) => {
-    if (index === 0 && line.startsWith("#!")) {
-      return " ".repeat(line.length)
+const HEREDOC = /^<<(-)?[ \t]*(?:'([^']+)'|"([^"]+)"|\\([A-Za-z_][\w]*)|([A-Za-z_][\w]*))/
+
+export function extractHashComments(text: string): ExtractedComments {
+  let quote: "'" | '"' | "'''" | '"""' | null = null
+  let parameterDepth = 0
+  let arithmeticDepth = 0
+  const heredocs: Heredoc[] = []
+  const contentStarts: number[] = []
+
+  const lines = text.split("\n").map((line, lineIndex) => {
+    const activeHeredoc = heredocs[0]
+    if (activeHeredoc !== undefined) {
+      const candidate = activeHeredoc.stripTabs ? line.replace(/^\t+/, "") : line
+      if (candidate === activeHeredoc.delimiter) heredocs.shift()
+      contentStarts.push(line.length)
+      return blankLine(line)
     }
+
+    if (lineIndex === 0 && line.startsWith("#!")) {
+      contentStarts.push(line.length)
+      return blankLine(line)
+    }
+
     const out = new Array<string>(line.length).fill(" ")
+    const pendingHeredocs: Heredoc[] = []
+    let contentStart = line.length
     let i = 0
+
     while (i < line.length) {
       const ch = line[i] as string
+
       if (quote !== null) {
-        if (ch === "\\") {
+        if (ch === "\\" && quote !== "'") {
+          i += 2
+          continue
+        }
+        if (quote === "'" && line.startsWith("''", i)) {
           i += 2
           continue
         }
@@ -84,19 +170,70 @@ export function extractHashComments(text: string): string[] {
         i++
         continue
       }
-      if (ch === '"' || ch === "'") {
-        quote = line.startsWith(ch.repeat(3), i) ? ch.repeat(3) : ch
-        i += quote.length
+
+      if (line.startsWith("'''", i) || line.startsWith('"""', i)) {
+        quote = line.slice(i, i + 3) as "'''" | '"""'
+        i += 3
         continue
       }
-      if (ch === "#" && (i === 0 || /\s/.test(line[i - 1] as string))) {
+      if (ch === '"' || ch === "'") {
+        quote = ch
+        i++
+        continue
+      }
+      if (line.startsWith("${", i)) {
+        parameterDepth++
+        i += 2
+        continue
+      }
+      if (parameterDepth > 0 && ch === "}") {
+        parameterDepth--
+        i++
+        continue
+      }
+      if (line.startsWith("$((", i)) {
+        arithmeticDepth++
+        i += 3
+        continue
+      }
+      if (arithmeticDepth > 0 && line.startsWith("))", i)) {
+        arithmeticDepth--
+        i += 2
+        continue
+      }
+      if (parameterDepth === 0 && arithmeticDepth === 0 && line.startsWith("<<", i)) {
+        if (line[i + 2] !== "<") {
+          const match = line.slice(i).match(HEREDOC)
+          if (match !== null) {
+            pendingHeredocs.push({
+              delimiter: (match[2] ?? match[3] ?? match[4] ?? match[5]) as string,
+              stripTabs: match[1] !== undefined,
+            })
+            i += match[0].length
+            continue
+          }
+        }
+      }
+      if (
+        ch === "#" &&
+        parameterDepth === 0 &&
+        arithmeticDepth === 0 &&
+        line[i - 1] !== "$"
+      ) {
         let j = i + 1
         while (line[j] === "#") j++
+        j = consumeSeparator(line, j)
+        contentStart = j
         for (; j < line.length; j++) out[j] = line[j] as string
         break
       }
       i++
     }
+
+    heredocs.push(...pendingHeredocs)
+    contentStarts.push(contentStart)
     return out.join("")
   })
+
+  return { lines, contentStarts }
 }

--- a/src/engine/comments.ts
+++ b/src/engine/comments.ts
@@ -1,17 +1,16 @@
 // Line-based comment extraction. Each function maps source text to lines of
 // the same length where only comment prose keeps its characters, so line and
-// column positions in the output match the original file. String-literal
-// state never carries across lines; that limit is pinned by tests.
+// column positions in the output match the original file.
 
 export function extractSlashComments(text: string): string[] {
   let inBlock = false
+  let quote: string | null = null
+
   return text.split("\n").map((line) => {
     const out = new Array<string>(line.length).fill(" ")
     let i = 0
-    let quote: string | null = null
 
     if (inBlock) {
-      // Skip the decorative leading asterisk of doc comment continuation lines.
       while (line[i] === " " || line[i] === "\t") i++
       if (line[i] === "*" && line[i + 1] !== "/") i++
     }
@@ -62,32 +61,41 @@ export function extractSlashComments(text: string): string[] {
 }
 
 export function extractHashComments(text: string): string[] {
+  let quote: string | null = null
+
   return text.split("\n").map((line, index) => {
     if (index === 0 && line.startsWith("#!")) {
-      return ""
+      return " ".repeat(line.length)
     }
     const out = new Array<string>(line.length).fill(" ")
-    let quote: string | null = null
-    for (let i = 0; i < line.length; i++) {
-      const ch = line[i]
+    let i = 0
+    while (i < line.length) {
+      const ch = line[i] as string
       if (quote !== null) {
         if (ch === "\\") {
-          i++
+          i += 2
           continue
         }
-        if (ch === quote) quote = null
+        if (line.startsWith(quote, i)) {
+          i += quote.length
+          quote = null
+          continue
+        }
+        i++
         continue
       }
       if (ch === '"' || ch === "'") {
-        quote = ch
+        quote = line.startsWith(ch.repeat(3), i) ? ch.repeat(3) : ch
+        i += quote.length
         continue
       }
-      if (ch === "#") {
+      if (ch === "#" && (i === 0 || /\s/.test(line[i - 1] as string))) {
         let j = i + 1
         while (line[j] === "#") j++
         for (; j < line.length; j++) out[j] = line[j] as string
         break
       }
+      i++
     }
     return out.join("")
   })

--- a/src/engine/identifiers.ts
+++ b/src/engine/identifiers.ts
@@ -2,7 +2,7 @@
 // words lack: a camelCase hump, an underscore, a dotted or :: path, or a
 // call suffix. Mixed-case prose words (brand names) are an accepted loss.
 const IDENTIFIER =
-  /(?:[A-Za-z_$][\w$]*(?:(?:\.|::)[A-Za-z_$][\w$]*)+|[\w$]*(?:[a-z][A-Z]|_)[\w$]*)(?:\(\))?/g
+  /(?:[A-Za-z_$][\w$]*\(\)|(?:[A-Za-z_$][\w$]*(?:(?:\.|::)[A-Za-z_$][\w$]*)+|[\w$]*(?:[a-z][A-Z]|_)[\w$]*)(?:\(\))?)/g
 
 export function blankIdentifiers(lines: readonly string[]): string[] {
   return lines.map((line) => line.replace(IDENTIFIER, (match) => " ".repeat(match.length)))

--- a/src/engine/identifiers.ts
+++ b/src/engine/identifiers.ts
@@ -1,0 +1,9 @@
+// A token is exempt as an identifier when it has an interior signal prose
+// words lack: a camelCase hump, an underscore, a dotted or :: path, or a
+// call suffix. Mixed-case prose words (brand names) are an accepted loss.
+const IDENTIFIER =
+  /(?:[A-Za-z_$][\w$]*(?:(?:\.|::)[A-Za-z_$][\w$]*)+|[\w$]*(?:[a-z][A-Z]|_)[\w$]*)(?:\(\))?/g
+
+export function blankIdentifiers(lines: readonly string[]): string[] {
+  return lines.map((line) => line.replace(IDENTIFIER, (match) => " ".repeat(match.length)))
+}

--- a/src/engine/identifiers.ts
+++ b/src/engine/identifiers.ts
@@ -2,7 +2,7 @@
 // words lack: a camelCase hump, an underscore, a dotted or :: path, or a
 // call suffix. Mixed-case prose words (brand names) are an accepted loss.
 const IDENTIFIER =
-  /(?:[A-Za-z_$][\w$]*\(\)|(?:[A-Za-z_$][\w$]*(?:(?:\.|::)[A-Za-z_$][\w$]*)+|[\w$]*(?:[a-z][A-Z]|_)[\w$]*)(?:\(\))?)/g
+  /(?:[A-Za-z_$][\w$]*\(\)|(?:[A-Za-z$][\w$]*|_[\w$]+)(?:(?:\.|::)(?:[A-Za-z$][\w$]*|_[\w$]+))+(?:\(\))?|[A-Za-z_$][\w$]*(?:[a-z][A-Z]|[A-Za-z0-9$]_[A-Za-z0-9_$])[\w$]*(?:\(\))?)/g
 
 export function blankIdentifiers(lines: readonly string[]): string[] {
   return lines.map((line) => line.replace(IDENTIFIER, (match) => " ".repeat(match.length)))

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,4 +1,6 @@
 import type { Dictionary } from "../dictionary/schema.ts"
+import { extractHashComments, extractSlashComments } from "./comments.ts"
+import { blankIdentifiers } from "./identifiers.ts"
 import { blankInlineCode, blankMarkdownCode } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
@@ -22,31 +24,39 @@ interface ResolvedOptions {
   readonly tagger?: Tagger
 }
 
-const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Violation[]> = {
-  "prose-file": (text, { maxSentenceWords, dictionary, tagger }) => {
-    const lines = blankMarkdownCode(text)
-    const proseLines = blankInlineCode(lines)
-    return [
-      ...sentenceLength(segmentSentences(proseLines), maxSentenceWords),
-      ...paragraphLength(segmentParagraphs(proseLines)),
-      ...contraction(proseLines),
-      ...semicolon(lines),
-      ...phrasalVerb(proseLines),
-      ...hedging(proseLines),
-      ...marketing(proseLines),
-      ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
-      ...(tagger === undefined ? [] : verbForm(lines, tagger)),
-    ]
-  },
+const extractors: Record<LintKind, (text: string) => string[]> = {
+  "prose-file": blankMarkdownCode,
+  "slash-source": extractSlashComments,
+  "hash-source": extractHashComments,
+  "commit-message": (text) => text.split("\n"),
+}
+
+const lintProse = (
+  lines: string[],
+  { maxSentenceWords, dictionary, tagger }: ResolvedOptions,
+) => {
+  const proseLines = blankInlineCode(lines)
+  return [
+    ...sentenceLength(segmentSentences(proseLines), maxSentenceWords),
+    ...paragraphLength(segmentParagraphs(proseLines)),
+    ...contraction(proseLines),
+    ...semicolon(lines),
+    ...phrasalVerb(proseLines),
+    ...hedging(proseLines),
+    ...marketing(proseLines),
+    ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
+    ...(tagger === undefined ? [] : verbForm(lines, tagger)),
+  ]
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const raw = linters[kind](text, {
+  const prose = blankIdentifiers(extractors[kind](text))
+  const raw = lintProse(prose, {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,
     tagger: options.tagger,
   })
-  const violations = raw
+  const violations: Violation[] = raw
     .flatMap((violation) => {
       const setting = options.rules?.[violation.ruleId]
       if (setting === undefined) {

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,7 +1,7 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { extractHashComments, extractSlashComments } from "./comments.ts"
 import { blankIdentifiers } from "./identifiers.ts"
-import { blankInlineCode, blankMarkdownCode } from "./markdown.ts"
+import { blankMarkdownCodeWithStructure } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
@@ -42,26 +42,31 @@ const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedP
 
 const lintProse = (
   lines: readonly string[],
+  mechanicalLines: readonly string[],
+  structuralBlanks: readonly boolean[],
   { maxSentenceWords, dictionary, tagger }: ResolvedOptions,
-) => {
-  const proseLines = blankInlineCode(lines)
-  return [
-    ...sentenceLength(segmentSentences(proseLines), maxSentenceWords),
-    ...paragraphLength(segmentParagraphs(proseLines)),
-    ...contraction(proseLines),
-    ...semicolon(lines),
-    ...phrasalVerb(proseLines),
-    ...hedging(proseLines),
-    ...marketing(proseLines),
-    ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
-    ...(tagger === undefined ? [] : verbForm(lines, tagger)),
-  ]
-}
+) => [
+  ...sentenceLength(segmentSentences(lines, structuralBlanks), maxSentenceWords),
+  ...paragraphLength(segmentParagraphs(lines)),
+  ...contraction(lines),
+  ...semicolon(mechanicalLines),
+  ...phrasalVerb(lines),
+  ...hedging(lines),
+  ...marketing(lines),
+  ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
+  ...(tagger === undefined ? [] : verbForm(lines, tagger)),
+]
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
   const extracted = extract(kind, text, options)
-  const prose = blankIdentifiers(blankMarkdownCode(extracted.lines, extracted.contentStarts))
-  const raw = lintProse(prose, {
+  const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
+  const prose = blankIdentifiers(markdown.lines)
+  const mechanical = blankIdentifiers(
+    extracted.lines.map((line, index) =>
+      markdown.structuralBlanks[index] ? " ".repeat(line.length) : line,
+    ),
+  )
+  const raw = lintProse(prose, mechanical, markdown.structuralBlanks, {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,
     tagger: options.tagger,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from "../dictionary/schema.ts"
-import { extractHashComments, extractSlashComments, type ProseBreak } from "./comments.ts"
+import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
 import { blankIdentifiers } from "./identifiers.ts"
 import { blankMarkdownCodeWithStructure } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
@@ -50,10 +50,7 @@ const splitProseRuns = (extracted: ExtractedProse): readonly ProseRun[] => {
     const end = boundaries[runIndex + 1]
     const firstLine = start?.line ?? 0
     const lastLine = end?.line ?? extracted.lines.length - 1
-    const firstColumnOffset = Math.min(
-      start?.column ?? 0,
-      extracted.lines[firstLine]?.length ?? 0,
-    )
+    const firstColumnOffset = Math.min(start?.column ?? 0, extracted.lines[firstLine]?.length ?? 0)
     const sourceLines = extracted.lines.slice(firstLine, lastLine + 1)
     const lines = sourceLines.map((line, index) => {
       const lineIndex = firstLine + index
@@ -139,8 +136,7 @@ export function lint(kind: LintKind, text: string, options: LintOptions = {}): L
     lintExtracted(run, resolved).map((violation) => ({
       ...violation,
       line: violation.line + run.lineOffset,
-      column:
-        violation.column + (violation.line === 1 ? run.firstColumnOffset : 0),
+      column: violation.column + (violation.line === 1 ? run.firstColumnOffset : 0),
     })),
   )
   const violations: Violation[] = raw

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -34,11 +34,10 @@ const wholeText = (text: string): ExtractedProse => {
   return { lines, contentStarts: lines.map(() => 0) }
 }
 
-const extractors: Record<LintKind, (text: string) => ExtractedProse> = {
-  "prose-file": wholeText,
-  "slash-source": extractSlashComments,
-  "hash-source": extractHashComments,
-  "commit-message": wholeText,
+const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedProse => {
+  if (kind === "slash-source") return extractSlashComments(text)
+  if (kind === "hash-source") return extractHashComments(text, options.sourceDialect)
+  return wholeText(text)
 }
 
 const lintProse = (
@@ -60,7 +59,7 @@ const lintProse = (
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const extracted = extractors[kind](text)
+  const extracted = extract(kind, text, options)
   const prose = blankIdentifiers(blankMarkdownCode(extracted.lines, extracted.contentStarts))
   const raw = lintProse(prose, {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from "../dictionary/schema.ts"
-import { extractHashComments, extractSlashComments } from "./comments.ts"
+import { extractHashComments, extractSlashComments, type ProseBreak } from "./comments.ts"
 import { blankIdentifiers } from "./identifiers.ts"
 import { blankMarkdownCodeWithStructure } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
@@ -27,11 +27,40 @@ interface ResolvedOptions {
 interface ExtractedProse {
   readonly lines: readonly string[]
   readonly contentStarts: readonly number[]
+  readonly proseBreaks: readonly ProseBreak[]
 }
 
 const wholeText = (text: string): ExtractedProse => {
   const lines = text.split("\n")
-  return { lines, contentStarts: lines.map(() => 0) }
+  return { lines, contentStarts: lines.map(() => 0), proseBreaks: [] }
+}
+
+const splitProseRuns = (extracted: ExtractedProse): readonly ExtractedProse[] => {
+  if (extracted.proseBreaks.length === 0) return [extracted]
+
+  const boundaries: readonly (ProseBreak | undefined)[] = [
+    undefined,
+    ...extracted.proseBreaks,
+    undefined,
+  ]
+  return boundaries.slice(0, -1).map((start, runIndex) => {
+    const end = boundaries[runIndex + 1]
+    const lines = extracted.lines.map((line, lineIndex) => {
+      if (start !== undefined && lineIndex < start.line) return " ".repeat(line.length)
+      if (end !== undefined && lineIndex > end.line) return " ".repeat(line.length)
+
+      const from = start?.line === lineIndex ? Math.min(start.column, line.length) : 0
+      const to = end?.line === lineIndex ? Math.min(end.column, line.length) : line.length
+      if (from >= to) return " ".repeat(line.length)
+      return `${" ".repeat(from)}${line.slice(from, to)}${" ".repeat(line.length - to)}`
+    })
+    const contentStarts = extracted.contentStarts.map((contentStart, lineIndex) => {
+      if (start !== undefined && lineIndex < start.line) return extracted.lines[lineIndex]?.length ?? 0
+      if (end !== undefined && lineIndex > end.line) return extracted.lines[lineIndex]?.length ?? 0
+      return start?.line === lineIndex ? Math.max(contentStart, start.column) : contentStart
+    })
+    return { lines, contentStarts, proseBreaks: [] }
+  })
 }
 
 const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedProse => {
@@ -42,35 +71,54 @@ const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedP
 
 const lintProse = (
   lines: readonly string[],
+  structuralLines: readonly string[],
   mechanicalLines: readonly string[],
+  contentStarts: readonly number[],
   structuralBlanks: readonly boolean[],
   { maxSentenceWords, dictionary, tagger }: ResolvedOptions,
 ) => [
   ...sentenceLength(segmentSentences(lines, structuralBlanks), maxSentenceWords),
-  ...paragraphLength(segmentParagraphs(lines)),
+  ...paragraphLength(
+    segmentParagraphs(structuralLines.map((line, index) => line.slice(contentStarts[index] ?? 0))),
+  ),
   ...contraction(lines),
   ...semicolon(mechanicalLines),
   ...phrasalVerb(lines),
   ...hedging(lines),
   ...marketing(lines),
-  ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
+  ...(dictionary === undefined
+    ? []
+    : dictionaryRule(structuralLines, dictionary, tagger, contentStarts)),
   ...(tagger === undefined ? [] : verbForm(lines, tagger)),
 ]
 
-export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const extracted = extract(kind, text, options)
+const lintExtracted = (extracted: ExtractedProse, options: ResolvedOptions): Violation[] => {
   const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
   const prose = blankIdentifiers(markdown.lines)
+  const structuralProse = blankIdentifiers(markdown.structuralLines)
   const mechanical = blankIdentifiers(
     extracted.lines.map((line, index) =>
       markdown.structuralBlanks[index] ? " ".repeat(line.length) : line,
     ),
   )
-  const raw = lintProse(prose, mechanical, markdown.structuralBlanks, {
+  return lintProse(
+    prose,
+    structuralProse,
+    mechanical,
+    extracted.contentStarts,
+    markdown.structuralBlanks,
+    options,
+  )
+}
+
+export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
+  const extracted = extract(kind, text, options)
+  const resolved = {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,
     tagger: options.tagger,
-  })
+  }
+  const raw = splitProseRuns(extracted).flatMap((run) => lintExtracted(run, resolved))
   const violations: Violation[] = raw
     .flatMap((violation) => {
       const setting = options.rules?.[violation.ruleId]

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -24,15 +24,25 @@ interface ResolvedOptions {
   readonly tagger?: Tagger
 }
 
-const extractors: Record<LintKind, (text: string) => string[]> = {
-  "prose-file": blankMarkdownCode,
+interface ExtractedProse {
+  readonly lines: readonly string[]
+  readonly contentStarts: readonly number[]
+}
+
+const wholeText = (text: string): ExtractedProse => {
+  const lines = text.split("\n")
+  return { lines, contentStarts: lines.map(() => 0) }
+}
+
+const extractors: Record<LintKind, (text: string) => ExtractedProse> = {
+  "prose-file": wholeText,
   "slash-source": extractSlashComments,
   "hash-source": extractHashComments,
-  "commit-message": (text) => text.split("\n"),
+  "commit-message": wholeText,
 }
 
 const lintProse = (
-  lines: string[],
+  lines: readonly string[],
   { maxSentenceWords, dictionary, tagger }: ResolvedOptions,
 ) => {
   const proseLines = blankInlineCode(lines)
@@ -50,7 +60,8 @@ const lintProse = (
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const prose = blankIdentifiers(extractors[kind](text))
+  const extracted = extractors[kind](text)
+  const prose = blankIdentifiers(blankMarkdownCode(extracted.lines, extracted.contentStarts))
   const raw = lintProse(prose, {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -30,14 +30,17 @@ interface ExtractedProse {
   readonly proseBreaks: readonly ProseBreak[]
 }
 
+interface ProseRun extends ExtractedProse {
+  readonly lineOffset: number
+  readonly firstColumnOffset: number
+}
+
 const wholeText = (text: string): ExtractedProse => {
   const lines = text.split("\n")
   return { lines, contentStarts: lines.map(() => 0), proseBreaks: [] }
 }
 
-const splitProseRuns = (extracted: ExtractedProse): readonly ExtractedProse[] => {
-  if (extracted.proseBreaks.length === 0) return [extracted]
-
+const splitProseRuns = (extracted: ExtractedProse): readonly ProseRun[] => {
   const boundaries: readonly (ProseBreak | undefined)[] = [
     undefined,
     ...extracted.proseBreaks,
@@ -45,21 +48,32 @@ const splitProseRuns = (extracted: ExtractedProse): readonly ExtractedProse[] =>
   ]
   return boundaries.slice(0, -1).map((start, runIndex) => {
     const end = boundaries[runIndex + 1]
-    const lines = extracted.lines.map((line, lineIndex) => {
-      if (start !== undefined && lineIndex < start.line) return " ".repeat(line.length)
-      if (end !== undefined && lineIndex > end.line) return " ".repeat(line.length)
-
-      const from = start?.line === lineIndex ? Math.min(start.column, line.length) : 0
+    const firstLine = start?.line ?? 0
+    const lastLine = end?.line ?? extracted.lines.length - 1
+    const firstColumnOffset = Math.min(
+      start?.column ?? 0,
+      extracted.lines[firstLine]?.length ?? 0,
+    )
+    const sourceLines = extracted.lines.slice(firstLine, lastLine + 1)
+    const lines = sourceLines.map((line, index) => {
+      const lineIndex = firstLine + index
+      const from = lineIndex === firstLine ? firstColumnOffset : 0
       const to = end?.line === lineIndex ? Math.min(end.column, line.length) : line.length
-      if (from >= to) return " ".repeat(line.length)
-      return `${" ".repeat(from)}${line.slice(from, to)}${" ".repeat(line.length - to)}`
+      return line.slice(from, to)
     })
-    const contentStarts = extracted.contentStarts.map((contentStart, lineIndex) => {
-      if (start !== undefined && lineIndex < start.line) return extracted.lines[lineIndex]?.length ?? 0
-      if (end !== undefined && lineIndex > end.line) return extracted.lines[lineIndex]?.length ?? 0
-      return start?.line === lineIndex ? Math.max(contentStart, start.column) : contentStart
+    const contentStarts = lines.map((line, index) => {
+      const lineIndex = firstLine + index
+      const from = lineIndex === firstLine ? firstColumnOffset : 0
+      const contentStart = extracted.contentStarts[lineIndex] ?? from
+      return Math.min(Math.max(contentStart - from, 0), line.length)
     })
-    return { lines, contentStarts, proseBreaks: [] }
+    return {
+      lines,
+      contentStarts,
+      proseBreaks: [],
+      lineOffset: firstLine,
+      firstColumnOffset,
+    }
   })
 }
 
@@ -79,7 +93,10 @@ const lintProse = (
 ) => [
   ...sentenceLength(segmentSentences(lines, structuralBlanks), maxSentenceWords),
   ...paragraphLength(
-    segmentParagraphs(structuralLines.map((line, index) => line.slice(contentStarts[index] ?? 0))),
+    segmentParagraphs(
+      structuralLines.map((line, index) => line.slice(contentStarts[index] ?? 0)),
+      contentStarts.map((contentStart) => contentStart + 1),
+    ),
   ),
   ...contraction(lines),
   ...semicolon(mechanicalLines),
@@ -118,7 +135,14 @@ export function lint(kind: LintKind, text: string, options: LintOptions = {}): L
     dictionary: options.dictionary,
     tagger: options.tagger,
   }
-  const raw = splitProseRuns(extracted).flatMap((run) => lintExtracted(run, resolved))
+  const raw = splitProseRuns(extracted).flatMap((run) =>
+    lintExtracted(run, resolved).map((violation) => ({
+      ...violation,
+      line: violation.line + run.lineOffset,
+      column:
+        violation.column + (violation.line === 1 ? run.firstColumnOffset : 0),
+    })),
+  )
   const violations: Violation[] = raw
     .flatMap((violation) => {
       const setting = options.rules?.[violation.ruleId]

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,18 +1,29 @@
 const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
 const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const INDENTED = /^(?: {4,}|\t)/
+const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])([ \t]{1,4})/
 
 const blankLine = (line: string): string => " ".repeat(line.length)
+
+interface Container {
+  readonly quoteDepth: number
+  readonly listIndent: number
+}
 
 interface MarkdownContent {
   readonly text: string
   readonly start: number
+  readonly container: Container
 }
 
-const markdownContent = (line: string, contentStart: number): MarkdownContent => {
-  let index = Math.min(contentStart, line.length)
-
-  while (index < line.length) {
+const consumeBlockquotes = (
+  line: string,
+  initial: number,
+  requiredDepth?: number,
+): { index: number; depth: number } => {
+  let index = initial
+  let depth = 0
+  while (index < line.length && (requiredDepth === undefined || depth < requiredDepth)) {
     let marker = index
     let spaces = 0
     while (spaces < 3 && line[marker] === " ") {
@@ -20,11 +31,57 @@ const markdownContent = (line: string, contentStart: number): MarkdownContent =>
       spaces++
     }
     if (line[marker] !== ">") break
+    depth++
     index = marker + 1
     if (line[index] === " " || line[index] === "\t") index++
   }
+  return { index, depth }
+}
 
-  return { text: line.slice(index), start: index }
+const markdownContent = (line: string, contentStart: number): MarkdownContent => {
+  const base = Math.min(contentStart, line.length)
+  const blockquotes = consumeBlockquotes(line, base)
+  let index = blockquotes.index
+  let listIndent = 0
+
+  while (index < line.length) {
+    const match = line.slice(index).match(LIST_MARKER)
+    if (match === null) break
+    const width = match[0].length
+    listIndent += width
+    index += width
+  }
+
+  return {
+    text: line.slice(index),
+    start: index,
+    container: { quoteDepth: blockquotes.depth, listIndent },
+  }
+}
+
+const contentWithin = (
+  line: string,
+  contentStart: number,
+  container: Container,
+): MarkdownContent | null => {
+  const base = Math.min(contentStart, line.length)
+  if (line.slice(base).trim() === "") {
+    return { text: "", start: line.length, container }
+  }
+
+  const blockquotes = consumeBlockquotes(line, base, container.quoteDepth)
+  if (blockquotes.depth !== container.quoteDepth) return null
+  if (container.quoteDepth === 0 && line.slice(base).match(/^ {0,3}>/) !== null) return null
+
+  let index = blockquotes.index
+  let remaining = container.listIndent
+  while (remaining > 0 && (line[index] === " " || line[index] === "\t")) {
+    index++
+    remaining--
+  }
+  if (remaining > 0) return null
+
+  return { text: line.slice(index), start: index, container }
 }
 
 const openingFence = (line: string): string | null => {
@@ -87,27 +144,37 @@ const blankInlineCode = (text: string): string => {
   return output.join("")
 }
 
+interface FenceState {
+  readonly marker: string
+  readonly container: Container
+}
+
 export function blankMarkdownCode(
   inputLines: readonly string[],
   contentStarts: readonly number[] = inputLines.map(() => 0),
 ): string[] {
-  let fence: string | null = null
+  let fence: FenceState | null = null
   let afterBlank = true
   let inIndented = false
   const inlineEligible: boolean[] = []
   const lines = inputLines.map((line, index) => {
-    const content = markdownContent(line, contentStarts[index] ?? 0)
-    const visibleLine = `${" ".repeat(content.start)}${line.slice(content.start)}`
+    const contentStart = contentStarts[index] ?? 0
 
     if (fence !== null) {
-      if (closesFence(content.text, fence)) fence = null
-      inlineEligible.push(false)
-      return blankLine(line)
+      const contained = contentWithin(line, contentStart, fence.container)
+      if (contained !== null) {
+        if (closesFence(contained.text, fence.marker)) fence = null
+        inlineEligible.push(false)
+        return blankLine(line)
+      }
+      fence = null
     }
 
+    const content = markdownContent(line, contentStart)
+    const visibleLine = `${" ".repeat(content.start)}${line.slice(content.start)}`
     const marker = openingFence(content.text)
     if (marker !== null) {
-      fence = marker
+      fence = { marker, container: content.container }
       afterBlank = false
       inIndented = false
       inlineEligible.push(false)

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,6 +1,7 @@
 const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
 const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const INDENTED = /^(?: {4,}|\t)/
+const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
 const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])([ \t]{1,4})/
 
 const blankLine = (line: string): string => " ".repeat(line.length)
@@ -68,14 +69,14 @@ const contentWithin = (
   if (container.quoteDepth === 0 && container.listIndent === 0) {
     return { text: line.slice(base), start: base, container }
   }
-  if (line.slice(base).trim() === "") {
-    return { text: "", start: line.length, container }
-  }
 
   const blockquotes = consumeBlockquotes(line, base, container.quoteDepth)
   if (blockquotes.depth !== container.quoteDepth) return null
 
   let index = blockquotes.index
+  if (line.slice(index).trim() === "") {
+    return { text: "", start: line.length, container }
+  }
   let remaining = container.listIndent
   while (remaining > 0 && (line[index] === " " || line[index] === "\t")) {
     index++
@@ -167,7 +168,7 @@ export function blankMarkdownCodeWithStructure(
 ): MarkdownCodeResult {
   let fence: FenceState | null = null
   let activeList: Container | null = null
-  let afterBlank = true
+  let paragraphCanContinue = false
   let inIndented = false
   const inlineEligible: boolean[] = []
   const structuralBlanks: boolean[] = []
@@ -179,7 +180,7 @@ export function blankMarkdownCodeWithStructure(
       if (contained !== null) {
         if (closesFence(contained.text, fence.marker)) {
           fence = null
-          afterBlank = true
+          paragraphCanContinue = false
           inIndented = false
         }
         inlineEligible.push(false)
@@ -187,7 +188,7 @@ export function blankMarkdownCodeWithStructure(
         return blankLine(line)
       }
       fence = null
-      afterBlank = true
+      paragraphCanContinue = false
       inIndented = false
     }
 
@@ -207,27 +208,27 @@ export function blankMarkdownCodeWithStructure(
     const marker = openingFence(content.text)
     if (marker !== null) {
       fence = { marker, container: content.container }
-      afterBlank = false
+      paragraphCanContinue = false
       inIndented = false
       inlineEligible.push(false)
       structuralBlanks.push(true)
       return blankLine(line)
     }
     if (content.text.trim() === "") {
-      afterBlank = true
+      paragraphCanContinue = false
       inIndented = false
       inlineEligible.push(false)
       structuralBlanks.push(true)
       return visibleLine
     }
-    if (INDENTED.test(content.text) && (afterBlank || inIndented)) {
-      afterBlank = false
+    if (INDENTED.test(content.text) && (!paragraphCanContinue || inIndented)) {
+      paragraphCanContinue = false
       inIndented = true
       inlineEligible.push(false)
       structuralBlanks.push(true)
       return blankLine(line)
     }
-    afterBlank = false
+    paragraphCanContinue = !ATX_HEADING.test(content.text)
     inIndented = false
     inlineEligible.push(true)
     structuralBlanks.push(false)

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -65,13 +65,15 @@ const contentWithin = (
   container: Container,
 ): MarkdownContent | null => {
   const base = Math.min(contentStart, line.length)
+  if (container.quoteDepth === 0 && container.listIndent === 0) {
+    return { text: line.slice(base), start: base, container }
+  }
   if (line.slice(base).trim() === "") {
     return { text: "", start: line.length, container }
   }
 
   const blockquotes = consumeBlockquotes(line, base, container.quoteDepth)
   if (blockquotes.depth !== container.quoteDepth) return null
-  if (container.quoteDepth === 0 && line.slice(base).match(/^ {0,3}>/) !== null) return null
 
   let index = blockquotes.index
   let remaining = container.listIndent
@@ -84,8 +86,10 @@ const contentWithin = (
   return { text: line.slice(index), start: index, container }
 }
 
+const fenceLine = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line)
+
 const openingFence = (line: string): string | null => {
-  const match = line.match(OPENING_FENCE)
+  const match = fenceLine(line).match(OPENING_FENCE)
   if (match === null) return null
   const marker = match[1] as string
   const info = match[2] as string
@@ -93,7 +97,7 @@ const openingFence = (line: string): string | null => {
 }
 
 const closesFence = (line: string, fence: string): boolean => {
-  const marker = line.match(CLOSING_FENCE)?.[1]
+  const marker = fenceLine(line).match(CLOSING_FENCE)?.[1]
   return marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length
 }
 
@@ -114,7 +118,9 @@ const blankInlineCode = (text: string): string => {
     }
     let end = i + 1
     while (text[end] === "`") end++
-    runs.push({ start: i, end, length: end - i })
+    let backslashes = 0
+    for (let j = i - 1; j >= 0 && text[j] === "\\"; j--) backslashes++
+    if (backslashes % 2 === 0) runs.push({ start: i, end, length: end - i })
     i = end
   }
 
@@ -154,6 +160,7 @@ export function blankMarkdownCode(
   contentStarts: readonly number[] = inputLines.map(() => 0),
 ): string[] {
   let fence: FenceState | null = null
+  let activeList: Container | null = null
   let afterBlank = true
   let inIndented = false
   const inlineEligible: boolean[] = []
@@ -170,7 +177,18 @@ export function blankMarkdownCode(
       fence = null
     }
 
-    const content = markdownContent(line, contentStart)
+    let content = markdownContent(line, contentStart)
+    if (content.container.listIndent > 0) {
+      activeList = content.container
+    } else if (content.text.trim() !== "" && activeList !== null) {
+      const continued = contentWithin(line, contentStart, activeList)
+      if (continued === null) {
+        activeList = null
+      } else {
+        content = continued
+      }
+    }
+
     const visibleLine = `${" ".repeat(content.start)}${line.slice(content.start)}`
     const marker = openingFence(content.text)
     if (marker !== null) {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -2,7 +2,7 @@ const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
 const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const INDENTED = /^(?: {4,}|\t)/
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
-const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])([ \t]{1,4})/
+const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])(?:([ \t]{1,4})(?![ \t])|[ \t])/
 
 const blankLine = (line: string): string => " ".repeat(line.length)
 
@@ -270,13 +270,13 @@ export function blankMarkdownCode(
   return blankMarkdownCodeWithStructure(inputLines, contentStarts).lines
 }
 
-interface BacktickRun {
+interface InlineBacktickRun {
   readonly start: number
   readonly length: number
 }
 
 function blankInlineCodeLine(line: string): string {
-  const runs: BacktickRun[] = []
+  const runs: InlineBacktickRun[] = []
   for (let index = 0; index < line.length; index += 1) {
     if (line[index] !== "`") continue
     const start = index

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -105,6 +105,7 @@ interface BacktickRun {
   readonly start: number
   readonly end: number
   readonly length: number
+  readonly escaped: boolean
 }
 
 const blankInlineCode = (text: string): string => {
@@ -120,7 +121,7 @@ const blankInlineCode = (text: string): string => {
     while (text[end] === "`") end++
     let backslashes = 0
     for (let j = i - 1; j >= 0 && text[j] === "\\"; j--) backslashes++
-    if (backslashes % 2 === 0) runs.push({ start: i, end, length: end - i })
+    runs.push({ start: i, end, length: end - i, escaped: backslashes % 2 !== 0 })
     i = end
   }
 
@@ -134,12 +135,12 @@ const blankInlineCode = (text: string): string => {
   }
 
   for (let i = 0; i < runs.length; ) {
+    const opener = runs[i] as BacktickRun
     const closerIndex = nextMatchingRun[i]
-    if (closerIndex === undefined) {
+    if (opener.escaped || closerIndex === undefined) {
       i++
       continue
     }
-    const opener = runs[i] as BacktickRun
     const closer = runs[closerIndex] as BacktickRun
     for (let j = opener.start; j < closer.end; j++) {
       if (output[j] !== "\n") output[j] = " "
@@ -155,26 +156,39 @@ interface FenceState {
   readonly container: Container
 }
 
-export function blankMarkdownCode(
+export interface MarkdownCodeResult {
+  readonly lines: string[]
+  readonly structuralBlanks: boolean[]
+}
+
+export function blankMarkdownCodeWithStructure(
   inputLines: readonly string[],
   contentStarts: readonly number[] = inputLines.map(() => 0),
-): string[] {
+): MarkdownCodeResult {
   let fence: FenceState | null = null
   let activeList: Container | null = null
   let afterBlank = true
   let inIndented = false
   const inlineEligible: boolean[] = []
+  const structuralBlanks: boolean[] = []
   const lines = inputLines.map((line, index) => {
     const contentStart = contentStarts[index] ?? 0
 
     if (fence !== null) {
       const contained = contentWithin(line, contentStart, fence.container)
       if (contained !== null) {
-        if (closesFence(contained.text, fence.marker)) fence = null
+        if (closesFence(contained.text, fence.marker)) {
+          fence = null
+          afterBlank = true
+          inIndented = false
+        }
         inlineEligible.push(false)
+        structuralBlanks.push(true)
         return blankLine(line)
       }
       fence = null
+      afterBlank = true
+      inIndented = false
     }
 
     let content = markdownContent(line, contentStart)
@@ -196,23 +210,27 @@ export function blankMarkdownCode(
       afterBlank = false
       inIndented = false
       inlineEligible.push(false)
+      structuralBlanks.push(true)
       return blankLine(line)
     }
     if (content.text.trim() === "") {
       afterBlank = true
       inIndented = false
       inlineEligible.push(false)
+      structuralBlanks.push(true)
       return visibleLine
     }
     if (INDENTED.test(content.text) && (afterBlank || inIndented)) {
       afterBlank = false
       inIndented = true
       inlineEligible.push(false)
+      structuralBlanks.push(true)
       return blankLine(line)
     }
     afterBlank = false
     inIndented = false
     inlineEligible.push(true)
+    structuralBlanks.push(false)
     return visibleLine
   })
 
@@ -229,7 +247,14 @@ export function blankMarkdownCode(
     start = end
   }
 
-  return lines
+  return { lines, structuralBlanks }
+}
+
+export function blankMarkdownCode(
+  inputLines: readonly string[],
+  contentStarts: readonly number[] = inputLines.map(() => 0),
+): string[] {
+  return blankMarkdownCodeWithStructure(inputLines, contentStarts).lines
 }
 
 interface BacktickRun {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -109,7 +109,7 @@ interface BacktickRun {
   readonly escaped: boolean
 }
 
-const blankInlineCode = (text: string): string => {
+const blankInlineCodeSpans = (text: string): string => {
   const output = text.split("")
   const runs: BacktickRun[] = []
 
@@ -159,6 +159,7 @@ interface FenceState {
 
 export interface MarkdownCodeResult {
   readonly lines: string[]
+  readonly structuralLines: string[]
   readonly structuralBlanks: boolean[]
 }
 
@@ -171,6 +172,7 @@ export function blankMarkdownCodeWithStructure(
   let paragraphCanContinue = false
   let inIndented = false
   const inlineEligible: boolean[] = []
+  const structuralLines: string[] = []
   const structuralBlanks: boolean[] = []
   const lines = inputLines.map((line, index) => {
     const contentStart = contentStarts[index] ?? 0
@@ -184,6 +186,7 @@ export function blankMarkdownCodeWithStructure(
           inIndented = false
         }
         inlineEligible.push(false)
+        structuralLines.push(blankLine(line))
         structuralBlanks.push(true)
         return blankLine(line)
       }
@@ -211,6 +214,7 @@ export function blankMarkdownCodeWithStructure(
       paragraphCanContinue = false
       inIndented = false
       inlineEligible.push(false)
+      structuralLines.push(blankLine(line))
       structuralBlanks.push(true)
       return blankLine(line)
     }
@@ -218,6 +222,7 @@ export function blankMarkdownCodeWithStructure(
       paragraphCanContinue = false
       inIndented = false
       inlineEligible.push(false)
+      structuralLines.push(line)
       structuralBlanks.push(true)
       return visibleLine
     }
@@ -225,30 +230,37 @@ export function blankMarkdownCodeWithStructure(
       paragraphCanContinue = false
       inIndented = true
       inlineEligible.push(false)
+      structuralLines.push(blankLine(line))
       structuralBlanks.push(true)
       return blankLine(line)
     }
     paragraphCanContinue = !ATX_HEADING.test(content.text)
     inIndented = false
     inlineEligible.push(true)
+    structuralLines.push(line)
     structuralBlanks.push(false)
     return visibleLine
   })
 
-  let start = 0
-  while (start < lines.length) {
-    if (!inlineEligible[start]) {
-      start++
-      continue
+  const blankEligibleInlineCode = (target: string[]) => {
+    let start = 0
+    while (start < target.length) {
+      if (!inlineEligible[start]) {
+        start++
+        continue
+      }
+      let end = start + 1
+      while (end < target.length && inlineEligible[end]) end++
+      const blanked = blankInlineCodeSpans(target.slice(start, end).join("\n")).split("\n")
+      for (let i = start; i < end; i++) target[i] = blanked[i - start] as string
+      start = end
     }
-    let end = start + 1
-    while (end < lines.length && inlineEligible[end]) end++
-    const blanked = blankInlineCode(lines.slice(start, end).join("\n")).split("\n")
-    for (let i = start; i < end; i++) lines[i] = blanked[i - start] as string
-    start = end
   }
 
-  return { lines, structuralBlanks }
+  blankEligibleInlineCode(lines)
+  blankEligibleInlineCode(structuralLines)
+
+  return { lines, structuralLines, structuralBlanks }
 }
 
 export function blankMarkdownCode(

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,181 +1,43 @@
-interface MarkdownContext {
-  readonly contentStart: number
-  readonly quoteDepth: number
-}
+const FENCE = /^\s{0,3}(`{3,}|~{3,})/
+const INLINE_CODE = /(`+)[^`]*?\1/g
+const INDENTED = /^(?: {4,}|\t)/
 
-interface ActiveParagraph {
-  readonly quoteDepth: number
-}
-
-interface ActiveFence {
-  readonly marker: "`" | "~"
-  readonly length: number
-  readonly quoteDepth: number
-  readonly listIndent: number
-}
-
-interface ListContent {
-  readonly content: string
-  readonly indent: number
-}
-
-const ATX_HEADING = /^ {0,3}#{1,6}(?:[\t ]+|$)/
-const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[\t ]*\r?$/
-const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[\t ]*){3,}|(?:_[\t ]*){3,}|(?:-[\t ]*){3,})\r?$/
-const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])([\t ]+|$)/
-const FENCE_OPENER = /^ {0,3}(`{3,}|~{3,})(.*)\r?$/
-
-const markdownContext = (
-  line: string,
-  maximumDepth = Number.POSITIVE_INFINITY,
-): MarkdownContext => {
-  let contentStart = 0
-  let quoteDepth = 0
-
-  while (contentStart < line.length && quoteDepth < maximumDepth) {
-    let marker = contentStart
-    let spaces = 0
-    while (spaces < 4 && line[marker] === " ") {
-      marker++
-      spaces++
-    }
-    if (spaces > 3 || line[marker] !== ">") {
-      break
-    }
-    contentStart = marker + 1
-    if (line[contentStart] === " " || line[contentStart] === "\t") {
-      contentStart++
-    }
-    quoteDepth++
-  }
-
-  return { contentStart, quoteDepth }
-}
-
-const listContent = (content: string): ListContent => {
-  let contentStart = 0
-
-  while (true) {
-    const match = content.slice(contentStart).match(LIST_MARKER)
-    if (match === null) {
-      break
-    }
-    const whitespace = match[2] ?? ""
-    const consumedWhitespace = whitespace.length > 4 ? 1 : whitespace.length
-    contentStart += match[0].length - whitespace.length + consumedWhitespace
-  }
-
-  return { content: content.slice(contentStart), indent: contentStart }
-}
-
-const isBlank = (content: string): boolean => /^[\t ]*\r?$/.test(content)
-const isIndentedCode = (content: string): boolean => /^(?: {4}|\t)/.test(content)
-const startsNewBlock = (content: string): boolean =>
-  ATX_HEADING.test(content) ||
-  LIST_MARKER.test(content) ||
-  SETEXT_UNDERLINE.test(content) ||
-  THEMATIC_BREAK.test(content)
-const startsParagraph = (content: string): boolean =>
-  !ATX_HEADING.test(content) && !SETEXT_UNDERLINE.test(content) && !THEMATIC_BREAK.test(content)
-const blank = (line: string): string => line.replace(/[^\r]/g, " ")
-
-const fenceOpener = (content: string): Pick<ActiveFence, "marker" | "length"> | undefined => {
-  const match = content.match(FENCE_OPENER)
-  const delimiter = match?.[1]
-  const info = match?.[2] ?? ""
-  if (delimiter === undefined || (delimiter[0] === "`" && info.includes("`"))) {
-    return undefined
-  }
-  const marker = delimiter[0]
-  if (marker !== "`" && marker !== "~") {
-    return undefined
-  }
-  return { marker, length: delimiter.length }
-}
-
-const isFenceCloser = (content: string, fence: ActiveFence): boolean => {
-  const match = content.match(/^ {0,3}(`+|~+)[\t ]*\r?$/)
-  const delimiter = match?.[1]
-  return delimiter?.[0] === fence.marker && delimiter.length >= fence.length
-}
-
-const fenceContainerContent = (line: string, fence: ActiveFence): string | undefined => {
-  const context = markdownContext(line, fence.quoteDepth)
-  if (context.quoteDepth !== fence.quoteDepth) {
-    return isBlank(line) ? "" : undefined
-  }
-  const content = line.slice(context.contentStart)
-  if (fence.listIndent === 0 || isBlank(content)) {
-    return content
-  }
-  if (!content.startsWith(" ".repeat(fence.listIndent))) {
-    return undefined
-  }
-  return content.slice(fence.listIndent)
-}
-
+// Blanks fenced blocks, indented blocks, and inline code spans, preserving
+// line count and the columns of the remaining prose. A fence closes only on
+// a fence of the same character at least as long as the opener. An indented
+// line counts as code only after a blank line or another indented code line.
 export function blankMarkdownCode(text: string): string[] {
-  let activeFence: ActiveFence | undefined
-  let inIndentedCode = false
-  let activeParagraph: ActiveParagraph | undefined
-
+  let fence: string | null = null
+  let afterBlank = true
+  let inIndented = false
   return text.split("\n").map((line) => {
-    if (activeFence !== undefined) {
-      const content = fenceContainerContent(line, activeFence)
-      if (content !== undefined) {
-        if (isFenceCloser(content, activeFence)) {
-          activeFence = undefined
-        }
-        return blank(line)
+    if (fence !== null) {
+      const marker = line.match(FENCE)?.[1]
+      if (marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length) {
+        fence = null
       }
-      activeFence = undefined
+      return ""
     }
-
-    const context = markdownContext(line)
-    const content = line.slice(context.contentStart)
-    const nested = listContent(content)
-    const opener = fenceOpener(nested.content)
-    if (opener !== undefined) {
-      activeFence = {
-        ...opener,
-        quoteDepth: context.quoteDepth,
-        listIndent: nested.indent,
-      }
-      inIndentedCode = false
-      activeParagraph = undefined
-      return blank(line)
+    const marker = line.match(FENCE)?.[1]
+    if (marker !== undefined) {
+      fence = marker
+      afterBlank = false
+      inIndented = false
+      return ""
     }
-
-    if (isBlank(content)) {
-      activeParagraph = undefined
-      return inIndentedCode ? blank(line) : line
-    }
-
-    if (inIndentedCode) {
-      if (isIndentedCode(content)) {
-        return blank(line)
-      }
-      inIndentedCode = false
-    }
-
-    if (
-      activeParagraph !== undefined &&
-      context.quoteDepth <= activeParagraph.quoteDepth &&
-      !startsNewBlock(content)
-    ) {
+    if (line.trim() === "") {
+      afterBlank = true
+      inIndented = false
       return line
     }
-
-    if (isIndentedCode(nested.content)) {
-      activeParagraph = undefined
-      inIndentedCode = true
-      return blank(line)
+    if (INDENTED.test(line) && (afterBlank || inIndented)) {
+      afterBlank = false
+      inIndented = true
+      return ""
     }
-
-    activeParagraph = startsParagraph(nested.content)
-      ? { quoteDepth: context.quoteDepth }
-      : undefined
-    return line
+    afterBlank = false
+    inIndented = false
+    return line.replace(INLINE_CODE, (match) => " ".repeat(match.length))
   })
 }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,44 +1,117 @@
-const FENCE = /^\s{0,3}(`{3,}|~{3,})/
-const INLINE_CODE = /(`+)[^`]*?\1/g
+const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
+const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const INDENTED = /^(?: {4,}|\t)/
 
-// Blanks fenced blocks, indented blocks, and inline code spans, preserving
-// line count and the columns of the remaining prose. A fence closes only on
-// a fence of the same character at least as long as the opener. An indented
-// line counts as code only after a blank line or another indented code line.
+const blankLine = (line: string): string => " ".repeat(line.length)
+
+const openingFence = (line: string): string | null => {
+  const match = line.match(OPENING_FENCE)
+  if (match === null) return null
+  const marker = match[1] as string
+  const info = match[2] as string
+  return marker[0] === "`" && info.includes("`") ? null : marker
+}
+
+const closesFence = (line: string, fence: string): boolean => {
+  const marker = line.match(CLOSING_FENCE)?.[1]
+  return marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length
+}
+
+const blankInlineCode = (text: string): string => {
+  const output = text.split("")
+  let i = 0
+
+  while (i < text.length) {
+    if (text[i] !== "`") {
+      i++
+      continue
+    }
+
+    let openerEnd = i + 1
+    while (text[openerEnd] === "`") openerEnd++
+    const delimiterLength = openerEnd - i
+    let candidate = openerEnd
+    let closerEnd: number | null = null
+
+    while (candidate < text.length) {
+      if (text[candidate] !== "`") {
+        candidate++
+        continue
+      }
+      let runEnd = candidate + 1
+      while (text[runEnd] === "`") runEnd++
+      if (runEnd - candidate === delimiterLength) {
+        closerEnd = runEnd
+        break
+      }
+      candidate = runEnd
+    }
+
+    if (closerEnd === null) {
+      i = openerEnd
+      continue
+    }
+    for (let j = i; j < closerEnd; j++) {
+      if (output[j] !== "\n") output[j] = " "
+    }
+    i = closerEnd
+  }
+
+  return output.join("")
+}
+
 export function blankMarkdownCode(text: string): string[] {
   let fence: string | null = null
   let afterBlank = true
   let inIndented = false
-  return text.split("\n").map((line) => {
+  const inlineEligible: boolean[] = []
+  const lines = text.split("\n").map((line) => {
     if (fence !== null) {
-      const marker = line.match(FENCE)?.[1]
-      if (marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length) {
-        fence = null
-      }
-      return ""
+      if (closesFence(line, fence)) fence = null
+      inlineEligible.push(false)
+      return blankLine(line)
     }
-    const marker = line.match(FENCE)?.[1]
-    if (marker !== undefined) {
+
+    const marker = openingFence(line)
+    if (marker !== null) {
       fence = marker
       afterBlank = false
       inIndented = false
-      return ""
+      inlineEligible.push(false)
+      return blankLine(line)
     }
     if (line.trim() === "") {
       afterBlank = true
       inIndented = false
+      inlineEligible.push(false)
       return line
     }
     if (INDENTED.test(line) && (afterBlank || inIndented)) {
       afterBlank = false
       inIndented = true
-      return ""
+      inlineEligible.push(false)
+      return blankLine(line)
     }
     afterBlank = false
     inIndented = false
-    return line.replace(INLINE_CODE, (match) => " ".repeat(match.length))
+    inlineEligible.push(true)
+    return line
   })
+
+  let start = 0
+  while (start < lines.length) {
+    if (!inlineEligible[start]) {
+      start++
+      continue
+    }
+    let end = start + 1
+    while (end < lines.length && inlineEligible[end]) end++
+    const blanked = blankInlineCode(lines.slice(start, end).join("\n")).split("\n")
+    for (let i = start; i < end; i++) lines[i] = blanked[i - start] as string
+    start = end
+  }
+
+  return lines
 }
 
 interface BacktickRun {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -4,6 +4,29 @@ const INDENTED = /^(?: {4,}|\t)/
 
 const blankLine = (line: string): string => " ".repeat(line.length)
 
+interface MarkdownContent {
+  readonly text: string
+  readonly start: number
+}
+
+const markdownContent = (line: string, contentStart: number): MarkdownContent => {
+  let index = Math.min(contentStart, line.length)
+
+  while (index < line.length) {
+    let marker = index
+    let spaces = 0
+    while (spaces < 3 && line[marker] === " ") {
+      marker++
+      spaces++
+    }
+    if (line[marker] !== ">") break
+    index = marker + 1
+    if (line[index] === " " || line[index] === "\t") index++
+  }
+
+  return { text: line.slice(index), start: index }
+}
+
 const openingFence = (line: string): string | null => {
   const match = line.match(OPENING_FENCE)
   if (match === null) return null
@@ -17,62 +40,72 @@ const closesFence = (line: string, fence: string): boolean => {
   return marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length
 }
 
+interface BacktickRun {
+  readonly start: number
+  readonly end: number
+  readonly length: number
+}
+
 const blankInlineCode = (text: string): string => {
   const output = text.split("")
-  let i = 0
+  const runs: BacktickRun[] = []
 
-  while (i < text.length) {
+  for (let i = 0; i < text.length; ) {
     if (text[i] !== "`") {
       i++
       continue
     }
+    let end = i + 1
+    while (text[end] === "`") end++
+    runs.push({ start: i, end, length: end - i })
+    i = end
+  }
 
-    let openerEnd = i + 1
-    while (text[openerEnd] === "`") openerEnd++
-    const delimiterLength = openerEnd - i
-    let candidate = openerEnd
-    let closerEnd: number | null = null
+  const nextMatchingRun = new Array<number | undefined>(runs.length)
+  const previousByLength = new Map<number, number>()
+  for (let i = 0; i < runs.length; i++) {
+    const run = runs[i] as BacktickRun
+    const previous = previousByLength.get(run.length)
+    if (previous !== undefined) nextMatchingRun[previous] = i
+    previousByLength.set(run.length, i)
+  }
 
-    while (candidate < text.length) {
-      if (text[candidate] !== "`") {
-        candidate++
-        continue
-      }
-      let runEnd = candidate + 1
-      while (text[runEnd] === "`") runEnd++
-      if (runEnd - candidate === delimiterLength) {
-        closerEnd = runEnd
-        break
-      }
-      candidate = runEnd
-    }
-
-    if (closerEnd === null) {
-      i = openerEnd
+  for (let i = 0; i < runs.length; ) {
+    const closerIndex = nextMatchingRun[i]
+    if (closerIndex === undefined) {
+      i++
       continue
     }
-    for (let j = i; j < closerEnd; j++) {
+    const opener = runs[i] as BacktickRun
+    const closer = runs[closerIndex] as BacktickRun
+    for (let j = opener.start; j < closer.end; j++) {
       if (output[j] !== "\n") output[j] = " "
     }
-    i = closerEnd
+    i = closerIndex + 1
   }
 
   return output.join("")
 }
 
-export function blankMarkdownCode(text: string): string[] {
+export function blankMarkdownCode(
+  inputLines: readonly string[],
+  contentStarts: readonly number[] = inputLines.map(() => 0),
+): string[] {
   let fence: string | null = null
   let afterBlank = true
   let inIndented = false
   const inlineEligible: boolean[] = []
-  const lines = text.split("\n").map((line) => {
+  const lines = inputLines.map((line, index) => {
+    const content = markdownContent(line, contentStarts[index] ?? 0)
+    const visibleLine = `${" ".repeat(content.start)}${line.slice(content.start)}`
+
     if (fence !== null) {
-      if (closesFence(line, fence)) fence = null
+      if (closesFence(content.text, fence)) fence = null
       inlineEligible.push(false)
       return blankLine(line)
     }
 
-    const marker = openingFence(line)
+    const marker = openingFence(content.text)
     if (marker !== null) {
       fence = marker
       afterBlank = false
@@ -80,13 +113,13 @@ export function blankMarkdownCode(text: string): string[] {
       inlineEligible.push(false)
       return blankLine(line)
     }
-    if (line.trim() === "") {
+    if (content.text.trim() === "") {
       afterBlank = true
       inIndented = false
       inlineEligible.push(false)
-      return line
+      return visibleLine
     }
-    if (INDENTED.test(line) && (afterBlank || inIndented)) {
+    if (INDENTED.test(content.text) && (afterBlank || inIndented)) {
       afterBlank = false
       inIndented = true
       inlineEligible.push(false)
@@ -95,7 +128,7 @@ export function blankMarkdownCode(text: string): string[] {
     afterBlank = false
     inIndented = false
     inlineEligible.push(true)
-    return line
+    return visibleLine
   })
 
   let start = 0

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -1,6 +1,7 @@
 export interface Paragraph {
   readonly lines: readonly string[]
   readonly line: number
+  readonly column: number
 }
 
 const LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/
@@ -31,13 +32,16 @@ function classify(line: string): LineKind {
   return "prose"
 }
 
-export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
+export function segmentParagraphs(
+  lines: readonly string[],
+  columns: readonly number[] = lines.map(() => 1),
+): Paragraph[] {
   const paragraphs: Paragraph[] = []
-  let open: { line: number; lines: string[]; kind: ParagraphKind } | null = null
+  let open: { line: number; column: number; lines: string[]; kind: ParagraphKind } | null = null
 
   const close = () => {
     if (open) {
-      paragraphs.push({ lines: open.lines, line: open.line })
+      paragraphs.push({ lines: open.lines, line: open.line, column: open.column })
       open = null
     }
   }
@@ -59,6 +63,7 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
           close()
           open = {
             line: index + 1,
+            column: columns[index] ?? 1,
             lines: [listItemContent(content) ?? ""],
             kind: "blockquote-list-item",
           }
@@ -66,7 +71,7 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
         }
         if (open?.kind !== "blockquote" && open?.kind !== "blockquote-list-item") close()
         if (!open) {
-          open = { line: index + 1, lines: [], kind: "blockquote" }
+          open = { line: index + 1, column: columns[index] ?? 1, lines: [], kind: "blockquote" }
         }
         open.lines.push(open.kind === "blockquote-list-item" ? content.trimStart() : content)
         break
@@ -75,13 +80,19 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
         close()
         open = {
           line: index + 1,
+          column: columns[index] ?? 1,
           lines: [listItemContent(raw) ?? ""],
           kind: "list-item",
         }
         break
       case "prose": {
         if (!open) {
-          open = { line: index + 1, lines: [], kind: "prose" }
+          open = {
+            line: index + 1,
+            column: columns[index] ?? 1,
+            lines: [],
+            kind: "prose",
+          }
         }
         open.lines.push(open.kind === "list-item" ? raw.trimStart() : raw)
         break

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -50,8 +50,8 @@ const compileForms = (dictionary: Dictionary): readonly Form[] =>
     )
     .sort((left, right) => right.words.length - left.words.length)
 
-const markdownContext = (line: string): MarkdownContext => {
-  let contentStart = 0
+const markdownContext = (line: string, initialContentStart = 0): MarkdownContext => {
+  let contentStart = Math.min(initialContentStart, line.length)
   let quoteDepth = 0
 
   while (contentStart < line.length) {
@@ -94,12 +94,15 @@ const isParagraphBlock = (content: string): boolean =>
 
 const isIndentedCode = (content: string): boolean => /^(?: {4}|\t)/.test(content)
 
-const markdownContexts = (lines: readonly string[]): readonly MarkdownContext[] => {
+const markdownContexts = (
+  lines: readonly string[],
+  contentStarts: readonly number[],
+): readonly MarkdownContext[] => {
   let activeParagraph: ActiveParagraph | undefined
   let nextParagraphId = 0
 
-  return lines.map((line) => {
-    const context = markdownContext(line)
+  return lines.map((line, lineIndex) => {
+    const context = markdownContext(line, contentStarts[lineIndex] ?? 0)
     const content = blockContent(line, context)
     if (/^[\t ]*\r?$/.test(content)) {
       activeParagraph = undefined
@@ -213,10 +216,11 @@ export function dictionaryRule(
   lines: readonly string[],
   dictionary: Dictionary,
   tagger?: Tagger,
+  contentStarts: readonly number[] = lines.map(() => 0),
 ): Violation[] {
   const forms = compileForms(dictionary)
   const violations: Violation[] = []
-  const contexts = markdownContexts(lines)
+  const contexts = markdownContexts(lines, contentStarts)
   const tokens = tokenize(lines)
   const taggedTokensByLine = new Map<number, readonly TaggedToken[]>()
 

--- a/src/engine/rules/paragraph-length.ts
+++ b/src/engine/rules/paragraph-length.ts
@@ -16,7 +16,7 @@ export function paragraphLength(paragraphs: readonly Paragraph[]): Violation[] {
         severity: "hard" as const,
         message: `Paragraph has ${count} sentences; the maximum is ${MAX_SENTENCES}.`,
         line: paragraph.line,
-        column: 1,
+        column: paragraph.column,
       },
     ]
   })

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -177,7 +177,10 @@ function sentenceTerminatorEnds(text: string): number[] {
 // A sentence starts at the first non-whitespace character and ends at
 // terminal punctuation and closing delimiters, at a blank line, or at EOF.
 // Sentences may span lines; position is where the sentence starts (1-based).
-export function segmentSentences(lines: readonly string[]): Sentence[] {
+export function segmentSentences(
+  lines: readonly string[],
+  structuralBlanks: readonly boolean[] = lines.map((line) => line.trim() === ""),
+): Sentence[] {
   const sentences: Sentence[] = []
   let open: { line: number; column: number; parts: string[] } | null = null
 
@@ -192,7 +195,7 @@ export function segmentSentences(lines: readonly string[]): Sentence[] {
 
   lines.forEach((raw, index) => {
     if (raw.trim() === "") {
-      close()
+      if (structuralBlanks[index] ?? true) close()
       return
     }
     let offset = 0

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -18,12 +18,15 @@ export interface Violation {
   readonly suggestion?: string
 }
 
+export type SourceDialect = "general" | "shell"
+
 export interface LintOptions {
   readonly rules?: Partial<Record<RuleId, RuleSetting>>
   readonly maxSentenceWords?: number
   readonly dictionary?: Dictionary
   // POS tagger for the verb-form rules and POS-aware dictionary entries.
   readonly tagger?: Tagger
+  readonly sourceDialect?: SourceDialect
 }
 
 export interface LintReport {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -2,7 +2,7 @@ import type { Dictionary } from "../dictionary/schema.ts"
 import type { RuleId } from "./rules/registry.ts"
 import type { Tagger } from "./tagger.ts"
 
-export type LintKind = "prose-file"
+export type LintKind = "prose-file" | "slash-source" | "hash-source" | "commit-message"
 
 export type Severity = "hard" | "soft"
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -255,6 +255,13 @@ describe("simple-english CLI", () => {
     expect(result.stderr).toContain("--kind requires a value")
   })
 
+  test("rejects an option token as a --kind value", async () => {
+    const result = await runCli(["--kind", "--json"], { stdin: "Short." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("--kind requires a value")
+  })
+
   test("maps a dotless path to prose-file, not a source kind", async () => {
     const result = await runCli(["go"], { cwd: fixturesPath })
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -245,6 +245,21 @@ describe("simple-english CLI", () => {
     expect(result.stderr).toContain("nonsense")
   })
 
+  test("rejects --kind without a value with exit code 2", async () => {
+    const result = await runCli(["--kind"], { stdin: "Short." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("--kind requires a value")
+  })
+
+  test("maps a dotless path to prose-file, not a source kind", async () => {
+    const result = await runCli(["test/fixtures/go"])
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("test/fixtures/go:1:1")
+    expect(result.stdout).toContain("sentence-length")
+  })
+
   test("errors with exit code 2 on an unreadable file", async () => {
     const result = await runCli(["test/fixtures/does-not-exist.md"])
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -196,6 +196,55 @@ describe("simple-english CLI", () => {
     ])
   })
 
+  test("maps .ts to slash-source: flags only the comment, not the string literal", async () => {
+    const result = await runCli(["test/fixtures/comment-violation.ts"])
+
+    expect(result.code).toBe(1)
+    const lines = result.stdout.trim().split("\n")
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain("test/fixtures/comment-violation.ts:2:4")
+    expect(lines[0]).toContain("sentence-length")
+  })
+
+  test("maps .sh to hash-source: flags only the comment, not the string literal", async () => {
+    const result = await runCli(["test/fixtures/comment-violation.sh"])
+
+    expect(result.code).toBe(1)
+    const lines = result.stdout.trim().split("\n")
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain("test/fixtures/comment-violation.sh:3:3")
+  })
+
+  test("--kind commit-message lints the full stdin text", async () => {
+    const message = [
+      "feat: add the widget",
+      "",
+      `${Array.from({ length: 30 }, (_, i) => `word${i}`).join(" ")}.`,
+    ].join("\n")
+    const result = await runCli(["--kind", "commit-message"], { stdin: message })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("<stdin>:3:1")
+  })
+
+  test("--kind overrides the extension mapping", async () => {
+    const longSentence = `${Array.from({ length: 30 }, (_, i) => `word${i}`).join(" ")}.`
+
+    const asProse = await runCli([], { stdin: longSentence })
+    expect(asProse.code).toBe(1)
+
+    const asSlashSource = await runCli(["--kind", "slash-source"], { stdin: longSentence })
+    expect(asSlashSource.code).toBe(0)
+    expect(asSlashSource.stdout.trim()).toBe("")
+  })
+
+  test("rejects an unknown kind with exit code 2", async () => {
+    const result = await runCli(["--kind", "nonsense"], { stdin: "Short." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("nonsense")
+  })
+
   test("errors with exit code 2 on an unreadable file", async () => {
     const result = await runCli(["test/fixtures/does-not-exist.md"])
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,5 +1,8 @@
+import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
 import { type CliOptions, runCli as runCliBase } from "./run-cli.ts"
+
+const fixturesPath = fileURLToPath(new URL("../fixtures", import.meta.url))
 
 interface DictionaryCliOptions extends CliOptions {
   readonly dictionaryPath?: string
@@ -253,10 +256,10 @@ describe("simple-english CLI", () => {
   })
 
   test("maps a dotless path to prose-file, not a source kind", async () => {
-    const result = await runCli(["test/fixtures/go"])
+    const result = await runCli(["go"], { cwd: fixturesPath })
 
     expect(result.code).toBe(1)
-    expect(result.stdout).toContain("test/fixtures/go:1:1")
+    expect(result.stdout).toContain("go:1:1")
     expect(result.stdout).toContain("sentence-length")
   })
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -215,7 +215,7 @@ describe("simple-english CLI", () => {
     expect(result.code).toBe(1)
     const lines = result.stdout.trim().split("\n")
     expect(lines).toHaveLength(1)
-    expect(lines[0]).toContain("test/fixtures/comment-violation.sh:3:3")
+    expect(lines[0]).toContain("test/fixtures/comment-violation.sh:4:3")
   })
 
   test("--kind commit-message lints the full stdin text", async () => {

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -141,6 +141,16 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", "> # In order\nto continue", { dictionary }).violations).toEqual([])
   })
 
+  test("preserves Markdown phrase boundaries in extracted comments", () => {
+    const separated = "run() // Use this prior\nnext() // > to assembly."
+    const continuous = "run() // > Use this prior\nnext() // > to assembly."
+
+    expect(lint("slash-source", separated, { dictionary }).violations).toEqual([])
+    expect(lint("slash-source", continuous, { dictionary }).violations).toContainEqual(
+      expect.objectContaining({ ruleId: "dictionary-not-approved-word", line: 1, column: 21 }),
+    )
+  })
+
   test("does not match phrases across Markdown indented code boundaries", () => {
     expect(lint("prose-file", "    in order\nto continue", { dictionary }).violations).toEqual([])
     expect(lint("prose-file", "\tin order\nto continue", { dictionary }).violations).toEqual([])

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -36,6 +36,14 @@ describe("lint slash-source: comment extraction", () => {
     expect(report.violations[0]).toMatchObject({ line: 1, column: 38 })
   })
 
+  test("does not lint comment markers in backslash-continued string literals", () => {
+    const text = [`const value = "prefix\\`, `// ${words(30)}.";`, `// ${words(30)}.`].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 4 })
+  })
+
   test("flags a long sentence spanning a block comment", () => {
     const text = ["const a = 1", `/* ${words(15)}`, `${words(15)}. */`, "const b = 2"].join("\n")
     const report = lint("slash-source", text)
@@ -168,6 +176,14 @@ describe("lint hash-source: comment extraction", () => {
     expect(lint("hash-source", text).violations).toHaveLength(0)
   })
 
+  test("a hash after an escaped single quote stays inside the string literal", () => {
+    const text = [`value = 'it\\'s # ${words(30)}.'`, `# ${words(30)}.`].join("\n")
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 3 })
+  })
+
   test("a shebang line is not prose", () => {
     const text = [`#!/usr/bin/env bash ${words(30)}.`, "echo hi"].join("\n")
 
@@ -186,6 +202,14 @@ describe("lint hash-source: comment extraction", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 4, column: 3 })
+  })
+
+  test("does not lint comment markers in backslash-continued string literals", () => {
+    const text = [`value = "prefix\\`, `# ${words(30)}."`, `# ${words(30)}.`].join("\n")
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 3 })
   })
 
   test("does not treat a shell parameter operator as a comment", () => {

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
+
+describe("lint slash-source: comment extraction", () => {
+  test("flags a long sentence in a line comment, at the comment text position", () => {
+    const text = ["const x = 1", `const y = 2 // ${words(30)}.`].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "sentence-length",
+      line: 2,
+      column: 16,
+    })
+  })
+
+  test("never lints code outside comments", () => {
+    const text = [`const sentence = call(${words(40)})`, `${words(40)}`].join("\n")
+
+    expect(lint("slash-source", text).violations).toHaveLength(0)
+  })
+
+  test("a comment marker inside a string literal does not start a comment", () => {
+    const text = `const url = "https://example.com/${words(30)}."`
+
+    expect(lint("slash-source", text).violations).toHaveLength(0)
+  })
+
+  test("a trailing comment after a string containing slashes is still linted", () => {
+    const text = `const url = "https://example.com" // ${words(30)}.`
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 38 })
+  })
+
+  test("flags a long sentence spanning a block comment", () => {
+    const text = ["const a = 1", `/* ${words(15)}`, `${words(15)}. */`, "const b = 2"].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 4 })
+  })
+
+  test("strips the leading asterisk decoration of doc comment lines", () => {
+    const text = ["/**", ` * ${words(15)}`, ` * ${words(15)}.`, " */"].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 4 })
+  })
+
+  test("code between two block comments on one line is not linted", () => {
+    const text = `/* short one. */ call(${words(30)}) /* another short. */`
+
+    expect(lint("slash-source", text).violations).toHaveLength(0)
+  })
+
+  test("triple-slash doc comment markers are not part of the prose", () => {
+    const text = `/// ${words(30)}.`
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 5 })
+  })
+
+  // Accepted verdict: extraction is line-based, so string state does not
+  // carry across lines and template literal bodies may be scanned as code.
+  test("accepted: a comment marker inside a multi-line template literal is treated as a comment", () => {
+    const text = ["const s = `first line", `// ${words(30)}.`, "`"].join("\n")
+
+    expect(lint("slash-source", text).violations).toHaveLength(1)
+  })
+})
+
+describe("lint hash-source: comment extraction", () => {
+  test("flags a long sentence in a hash comment", () => {
+    const text = ["x = 1", `# ${words(30)}.`].join("\n")
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 3 })
+  })
+
+  test("flags a long trailing comment at its position in the original line", () => {
+    const text = `x = compute()  # ${words(30)}.`
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 18 })
+  })
+
+  test("a hash inside a string literal does not start a comment", () => {
+    const text = `color = "#fffff ${words(30)}."`
+
+    expect(lint("hash-source", text).violations).toHaveLength(0)
+  })
+
+  test("a shebang line is not prose", () => {
+    const text = [`#!/usr/bin/env bash ${words(30)}.`, "echo hi"].join("\n")
+
+    expect(lint("hash-source", text).violations).toHaveLength(0)
+  })
+
+  test("never lints code outside comments", () => {
+    const text = `run ${words(40)}.`
+
+    expect(lint("hash-source", text).violations).toHaveLength(0)
+  })
+})
+
+describe("lint commit-message", () => {
+  test("lints the full message text", () => {
+    const text = ["feat: short subject", "", `${words(30)}.`].join("\n")
+    const report = lint("commit-message", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
+  })
+
+  test("a clean message passes", () => {
+    const text = ["fix: remove the bolt", "", "Turn the handle to the left."].join("\n")
+
+    expect(lint("commit-message", text).violations).toHaveLength(0)
+  })
+})
+
+describe("identifier exemption", () => {
+  test("identifiers in comments never count as prose words", () => {
+    const identifiers = Array.from({ length: 12 }, () => "doNotUse").join(" ")
+    const text = `// ${words(20)} ${identifiers}.`
+
+    expect(lint("slash-source", text).violations).toHaveLength(0)
+  })
+
+  test("snake_case and dotted identifiers are exempt in prose files", () => {
+    const identifiers = Array.from({ length: 12 }, () => "config.max_value").join(" ")
+    const text = `${words(20)} ${identifiers}.`
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("identifiers are exempt in commit messages", () => {
+    const identifiers = Array.from({ length: 12 }, () => "handle_input()").join(" ")
+    const text = `${words(20)} ${identifiers}.`
+
+    expect(lint("commit-message", text).violations).toHaveLength(0)
+  })
+
+  test("plain words still count", () => {
+    expect(lint("commit-message", `${words(26)}.`).violations).toHaveLength(1)
+  })
+})
+
+describe("lint prose-file: hardened markdown stripping", () => {
+  test("inline code spans never produce violations", () => {
+    const text = `Run \`${words(30)}\` to start.`
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("indented code blocks never produce violations", () => {
+    const text = ["A short sentence.", "", `    ${words(40)}.`, "", "Another one."].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("a tilde fence is not closed by a backtick fence", () => {
+    const text = ["~~~", "```", `${words(40)}.`, "~~~"].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("prose after an indented code block is still flagged with the correct position", () => {
+    const text = ["Intro.", "", `    code(${words(30)})`, "", `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
+  })
+})

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -66,6 +66,16 @@ describe("lint slash-source: comment extraction", () => {
     expect(lint("slash-source", text).violations).toHaveLength(0)
   })
 
+  test("separate block comments cannot form a phrasal verb", () => {
+    const separated = "/* Carry */ execute() /* out */"
+    const continuous = "/* Carry out */"
+
+    expect(lint("slash-source", separated).violations).toHaveLength(0)
+    expect(lint("slash-source", continuous).violations).toContainEqual(
+      expect.objectContaining({ ruleId: "phrasal-verb", line: 1, column: 4 }),
+    )
+  })
+
   test("triple-slash doc comment markers are not part of the prose", () => {
     const text = `/// ${words(30)}.`
     const report = lint("slash-source", text)
@@ -150,6 +160,24 @@ describe("lint slash-source: comment extraction", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 4, column: 5 })
+  })
+
+  test("preserves Markdown paragraph boundaries in extracted comments", () => {
+    const separated = [
+      "const a = 1 // One. Two. Three.",
+      "const b = 2 // > Four. Five. Six. Seven.",
+    ].join("\n")
+    const continuous = [
+      "const a = 1 // > One. Two. Three.",
+      "const b = 2 // > Four. Five. Six. Seven.",
+    ].join("\n")
+
+    expect(lint("slash-source", separated).violations.map((item) => item.ruleId)).not.toContain(
+      "paragraph-length",
+    )
+    expect(lint("slash-source", continuous).violations.map((item) => item.ruleId)).toContain(
+      "paragraph-length",
+    )
   })
 })
 

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -384,6 +384,12 @@ describe("lint prose-file: hardened markdown stripping", () => {
     expect(lint("prose-file", text).violations).toHaveLength(0)
   })
 
+  test("recognizes indented code immediately after a heading", () => {
+    const text = ["# Heading", `    ${words(30)}.`].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
   test("recognizes indented code when a fence container ends", () => {
     const text = ["> ~~~", `> ${words(30)}.`, `    ${words(30)}.`].join("\n")
 
@@ -396,6 +402,14 @@ describe("lint prose-file: hardened markdown stripping", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
+  })
+
+  test("ends an unclosed fence at an unmarked blockquote blank", () => {
+    const text = ["> ~~~", "", `> ${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 3 })
   })
 
   test("ends an unclosed fence when its blockquote container ends", () => {

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -179,6 +179,23 @@ describe("lint slash-source: comment extraction", () => {
       "paragraph-length",
     )
   })
+
+  test("reports a long paragraph at its original comment column", () => {
+    const report = lint("slash-source", "x // One. Two. Three. Four. Five. Six. Seven.")
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "paragraph-length", line: 1, column: 6 }),
+    ])
+  })
+
+  test("handles many separate block-comment prose runs", () => {
+    const text = Array.from(
+      { length: 5_000 },
+      () => "/* Carry */ execute() /* out */ execute()",
+    ).join(" ")
+
+    expect(lint("slash-source", text).violations).toHaveLength(0)
+  })
 })
 
 describe("lint hash-source: comment extraction", () => {

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -78,6 +78,41 @@ describe("lint slash-source: comment extraction", () => {
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 4, column: 4 })
   })
+
+  test("distinguishes Rust lifetimes from multi-line string literals", () => {
+    const text = ["fn borrow(value: &'static str) {}", `// ${words(30)}.`].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 4 })
+  })
+
+  test("keeps Java text blocks open across embedded quotes", () => {
+    const text = [
+      'String text = """',
+      'embedded " quote',
+      `// ${words(30)}.`,
+      '""";',
+      `// ${words(30)}.`,
+    ].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 4 })
+  })
+
+  test("applies Markdown fences after extracting doc comments", () => {
+    const text = [
+      "/// ```text",
+      `/// ${words(30)}.`,
+      "/// ```",
+      `/// ${words(30)}.`,
+    ].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 5 })
+  })
 })
 
 describe("lint hash-source: comment extraction", () => {
@@ -133,6 +168,41 @@ describe("lint hash-source: comment extraction", () => {
 
     expect(lint("hash-source", text).violations).toHaveLength(0)
   })
+
+  test("recognizes a trailing comment without leading whitespace", () => {
+    const text = `x=1# ${words(30)}.`
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 6 })
+  })
+
+  test("does not lint hash markers in shell heredoc payloads", () => {
+    const text = [
+      "cat <<'EOF'",
+      `# ${words(30)}.`,
+      "EOF",
+      `# ${words(30)}.`,
+    ].join("\n")
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 3 })
+  })
+
+  test("applies Markdown indented blocks after extracting comments", () => {
+    const text = [
+      "# Intro.",
+      "#",
+      `#     ${words(30)}.`,
+      "#",
+      `# ${words(30)}.`,
+    ].join("\n")
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 3 })
+  })
 })
 
 describe("lint commit-message", () => {
@@ -146,6 +216,12 @@ describe("lint commit-message", () => {
 
   test("a clean message passes", () => {
     const text = ["fix: remove the bolt", "", "Turn the handle to the left."].join("\n")
+
+    expect(lint("commit-message", text).violations).toHaveLength(0)
+  })
+
+  test("does not lint Markdown inline code", () => {
+    const text = `Run \`${words(30)}\` to update the file.`
 
     expect(lint("commit-message", text).violations).toHaveLength(0)
   })
@@ -230,5 +306,34 @@ describe("lint prose-file: hardened markdown stripping", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
+  })
+
+  test("recognizes fenced code inside blockquote containers", () => {
+    const text = [
+      "> ```text",
+      `> ${words(30)}.`,
+      "> ```",
+      `${words(30)}.`,
+    ].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
+  })
+
+  test("recognizes indented code inside blockquote containers", () => {
+    const text = ["> Intro.", ">", `>     ${words(30)}.`, ">", `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
+  })
+
+  test("does not pair unmatched backtick runs of different lengths", () => {
+    const text = `\` \`\` ${words(30)}.`
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
   })
 })

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -66,12 +66,17 @@ describe("lint slash-source: comment extraction", () => {
     expect(report.violations[0]).toMatchObject({ line: 1, column: 5 })
   })
 
-  // Accepted verdict: extraction is line-based, so string state does not
-  // carry across lines and template literal bodies may be scanned as code.
-  test("accepted: a comment marker inside a multi-line template literal is treated as a comment", () => {
-    const text = ["const s = `first line", `// ${words(30)}.`, "`"].join("\n")
+  test("does not lint comment markers inside multi-line template literals", () => {
+    const text = [
+      "const s = `first line",
+      `// ${words(30)}.`,
+      "`",
+      `// ${words(30)}.`,
+    ].join("\n")
+    const report = lint("slash-source", text)
 
-    expect(lint("slash-source", text).violations).toHaveLength(1)
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 4 })
   })
 })
 
@@ -106,6 +111,25 @@ describe("lint hash-source: comment extraction", () => {
 
   test("never lints code outside comments", () => {
     const text = `run ${words(40)}.`
+
+    expect(lint("hash-source", text).violations).toHaveLength(0)
+  })
+
+  test("does not lint comment markers inside multi-line string literals", () => {
+    const text = [
+      'value = """first line',
+      `# ${words(30)}.`,
+      '"""',
+      `# ${words(30)}.`,
+    ].join("\n")
+    const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 3 })
+  })
+
+  test("does not treat a shell parameter operator as a comment", () => {
+    const text = `trimmed=\${name#${words(30)}}`
 
     expect(lint("hash-source", text).violations).toHaveLength(0)
   })
@@ -149,6 +173,13 @@ describe("identifier exemption", () => {
     expect(lint("commit-message", text).violations).toHaveLength(0)
   })
 
+  test("plain function calls are exempt in prose", () => {
+    const identifiers = Array.from({ length: 12 }, () => "parse()").join(" ")
+    const text = `${words(20)} ${identifiers}.`
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
   test("plain words still count", () => {
     expect(lint("commit-message", `${words(26)}.`).violations).toHaveLength(1)
   })
@@ -167,10 +198,30 @@ describe("lint prose-file: hardened markdown stripping", () => {
     expect(lint("prose-file", text).violations).toHaveLength(0)
   })
 
+  test("inline code spans can cross line boundaries", () => {
+    const text = ["Run `the command", `${words(30)}`, "to finish` now."].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
   test("a tilde fence is not closed by a backtick fence", () => {
     const text = ["~~~", "```", `${words(40)}.`, "~~~"].join("\n")
 
     expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("a fence marker with trailing text does not close a fence", () => {
+    const text = [
+      "~~~",
+      "~~~not-a-close",
+      `${words(40)}.`,
+      "~~~",
+      `${words(30)}.`,
+    ].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
   })
 
   test("prose after an indented code block is still flagged with the correct position", () => {

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -346,6 +346,22 @@ describe("lint prose-file: hardened markdown stripping", () => {
     expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
   })
 
+  test("keeps a root fence open across blockquote-looking content", () => {
+    const text = ["~~~", `> ${words(30)}.`, "~~~", `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
+  })
+
+  test("recognizes a closing fence before a CRLF line ending", () => {
+    const text = ["~~~\r", `${words(30)}.\r`, "~~~\r", `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
+  })
+
   test("recognizes indented code inside blockquote containers", () => {
     const text = ["> Intro.", ">", `>     ${words(30)}.`, ">", `${words(30)}.`].join("\n")
     const report = lint("prose-file", text)
@@ -378,8 +394,24 @@ describe("lint prose-file: hardened markdown stripping", () => {
     expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
   })
 
+  test("retains list scope for a fence on a continuation line", () => {
+    const text = ["- item", "", "  ~~~", `  ${words(30)}.`, `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
+  })
+
   test("does not pair unmatched backtick runs of different lengths", () => {
     const text = `\` \`\` ${words(30)}.`
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("does not treat escaped backticks as inline code delimiters", () => {
+    const text = `\\\`${words(30)}.\\\``
     const report = lint("prose-file", text)
 
     expect(report.violations).toHaveLength(1)

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -292,6 +292,14 @@ describe("identifier exemption", () => {
     expect(lint("prose-file", text).violations).toHaveLength(0)
   })
 
+  test("identifier-only lines do not split prose sentences", () => {
+    const text = [words(20), "doNotUse", `${words(10)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
   test("plain words still count", () => {
     expect(lint("commit-message", `${words(26)}.`).violations).toHaveLength(1)
   })
@@ -314,6 +322,14 @@ describe("lint prose-file: hardened markdown stripping", () => {
     const text = ["Run `the command", `${words(30)}`, "to finish` now."].join("\n")
 
     expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("inline-code-only lines do not split prose sentences", () => {
+    const text = [words(20), "`doNotUse`", `${words(10)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
   })
 
   test("a tilde fence is not closed by a backtick fence", () => {
@@ -360,6 +376,18 @@ describe("lint prose-file: hardened markdown stripping", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
+  })
+
+  test("recognizes indented code immediately after a closing fence", () => {
+    const text = ["~~~", `${words(30)}.`, "~~~", `    ${words(30)}.`].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
+  test("recognizes indented code when a fence container ends", () => {
+    const text = ["> ~~~", `> ${words(30)}.`, `    ${words(30)}.`].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
   })
 
   test("recognizes indented code inside blockquote containers", () => {
@@ -416,5 +444,11 @@ describe("lint prose-file: hardened markdown stripping", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("allows an escaped matching run to close inline code", () => {
+    const text = `Run \`${words(30)}\\\` now.`
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
   })
 })

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -67,12 +67,7 @@ describe("lint slash-source: comment extraction", () => {
   })
 
   test("does not lint comment markers inside multi-line template literals", () => {
-    const text = [
-      "const s = `first line",
-      `// ${words(30)}.`,
-      "`",
-      `// ${words(30)}.`,
-    ].join("\n")
+    const text = ["const s = `first line", `// ${words(30)}.`, "`", `// ${words(30)}.`].join("\n")
     const report = lint("slash-source", text)
 
     expect(report.violations).toHaveLength(1)
@@ -101,13 +96,48 @@ describe("lint slash-source: comment extraction", () => {
     expect(report.violations[0]).toMatchObject({ line: 5, column: 4 })
   })
 
-  test("applies Markdown fences after extracting doc comments", () => {
+  test("does not lint comment markers inside C# verbatim strings", () => {
     const text = [
-      "/// ```text",
-      `/// ${words(30)}.`,
-      "/// ```",
-      `/// ${words(30)}.`,
+      'var value = @"first line',
+      `// ${words(30)}.`,
+      'embedded "" quote',
+      '";',
+      `// ${words(30)}.`,
     ].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 5, column: 4 })
+  })
+
+  test("does not lint comment markers inside Rust raw strings", () => {
+    const text = [
+      'let value = r##"first line',
+      `// ${words(30)}.`,
+      '"##;',
+      `// ${words(30)}.`,
+    ].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 4 })
+  })
+
+  test("does not lint comment markers inside C++ raw strings", () => {
+    const text = [
+      'auto value = R"tag(first line',
+      `// ${words(30)}.`,
+      ')tag";',
+      `// ${words(30)}.`,
+    ].join("\n")
+    const report = lint("slash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 4 })
+  })
+
+  test("applies Markdown fences after extracting doc comments", () => {
+    const text = ["/// ```text", `/// ${words(30)}.`, "/// ```", `/// ${words(30)}.`].join("\n")
     const report = lint("slash-source", text)
 
     expect(report.violations).toHaveLength(1)
@@ -151,12 +181,7 @@ describe("lint hash-source: comment extraction", () => {
   })
 
   test("does not lint comment markers inside multi-line string literals", () => {
-    const text = [
-      'value = """first line',
-      `# ${words(30)}.`,
-      '"""',
-      `# ${words(30)}.`,
-    ].join("\n")
+    const text = ['value = """first line', `# ${words(30)}.`, '"""', `# ${words(30)}.`].join("\n")
     const report = lint("hash-source", text)
 
     expect(report.violations).toHaveLength(1)
@@ -166,7 +191,13 @@ describe("lint hash-source: comment extraction", () => {
   test("does not treat a shell parameter operator as a comment", () => {
     const text = `trimmed=\${name#${words(30)}}`
 
-    expect(lint("hash-source", text).violations).toHaveLength(0)
+    expect(lint("hash-source", text, { sourceDialect: "shell" }).violations).toHaveLength(0)
+  })
+
+  test("does not treat a mid-token shell hash as a comment", () => {
+    const text = `echo prefix# ${words(30)}.`
+
+    expect(lint("hash-source", text, { sourceDialect: "shell" }).violations).toHaveLength(0)
   })
 
   test("recognizes a trailing comment without leading whitespace", () => {
@@ -178,26 +209,31 @@ describe("lint hash-source: comment extraction", () => {
   })
 
   test("does not lint hash markers in shell heredoc payloads", () => {
-    const text = [
-      "cat <<'EOF'",
-      `# ${words(30)}.`,
-      "EOF",
-      `# ${words(30)}.`,
-    ].join("\n")
+    const text = ["cat <<'EOF'", `# ${words(30)}.`, "EOF", `# ${words(30)}.`].join("\n")
+    const report = lint("hash-source", text, { sourceDialect: "shell" })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 3 })
+  })
+
+  test("does not infer a shell heredoc from Python shift syntax", () => {
+    const text = ["result = value << LIMIT", `# ${words(30)}.`].join("\n")
     const report = lint("hash-source", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 3 })
+  })
+
+  test("recognizes numeric shell heredocs and CRLF terminators", () => {
+    const text = ["cat <<123\r", `# ${words(30)}.\r`, "123\r", `# ${words(30)}.`].join("\n")
+    const report = lint("hash-source", text, { sourceDialect: "shell" })
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 4, column: 3 })
   })
 
   test("applies Markdown indented blocks after extracting comments", () => {
-    const text = [
-      "# Intro.",
-      "#",
-      `#     ${words(30)}.`,
-      "#",
-      `# ${words(30)}.`,
-    ].join("\n")
+    const text = ["# Intro.", "#", `#     ${words(30)}.`, "#", `# ${words(30)}.`].join("\n")
     const report = lint("hash-source", text)
 
     expect(report.violations).toHaveLength(1)
@@ -287,13 +323,7 @@ describe("lint prose-file: hardened markdown stripping", () => {
   })
 
   test("a fence marker with trailing text does not close a fence", () => {
-    const text = [
-      "~~~",
-      "~~~not-a-close",
-      `${words(40)}.`,
-      "~~~",
-      `${words(30)}.`,
-    ].join("\n")
+    const text = ["~~~", "~~~not-a-close", `${words(40)}.`, "~~~", `${words(30)}.`].join("\n")
     const report = lint("prose-file", text)
 
     expect(report.violations).toHaveLength(1)
@@ -309,12 +339,7 @@ describe("lint prose-file: hardened markdown stripping", () => {
   })
 
   test("recognizes fenced code inside blockquote containers", () => {
-    const text = [
-      "> ```text",
-      `> ${words(30)}.`,
-      "> ```",
-      `${words(30)}.`,
-    ].join("\n")
+    const text = ["> ```text", `> ${words(30)}.`, "> ```", `${words(30)}.`].join("\n")
     const report = lint("prose-file", text)
 
     expect(report.violations).toHaveLength(1)
@@ -327,6 +352,30 @@ describe("lint prose-file: hardened markdown stripping", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 5, column: 1 })
+  })
+
+  test("ends an unclosed fence when its blockquote container ends", () => {
+    const text = ["> ~~~", `> ${words(30)}.`, `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
+  })
+
+  test("recognizes fenced code inside list containers", () => {
+    const text = ["- ~~~", `  ${words(30)}.`, "  ~~~", `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 4, column: 1 })
+  })
+
+  test("ends an unclosed fence when its list container ends", () => {
+    const text = ["- ~~~", `  ${words(30)}.`, `${words(30)}.`].join("\n")
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
   })
 
   test("does not pair unmatched backtick runs of different lengths", () => {

--- a/test/fixtures/comment-violation.sh
+++ b/test/fixtures/comment-violation.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 echo "the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again."
+echo prefix# the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.
 # The quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.

--- a/test/fixtures/comment-violation.sh
+++ b/test/fixtures/comment-violation.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+echo "the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again."
+# The quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.

--- a/test/fixtures/comment-violation.ts
+++ b/test/fixtures/comment-violation.ts
@@ -1,0 +1,3 @@
+const banner = "the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again."
+// The quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.
+const done = banner.length > 0

--- a/test/fixtures/go
+++ b/test/fixtures/go
@@ -1,0 +1,1 @@
+word0 word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12 word13 word14 word15 word16 word17 word18 word19 word20 word21 word22 word23 word24 word25 word26 word27 word28 word29.


### PR DESCRIPTION
## Intent

The developer wanted to implement HUF-134 so the lint engine extracts prose from slash-family comments, hash-family comments, commit messages, and prose files while exempting identifiers and code. They required accurate original line and column reporting, string-literal awareness, hardened Markdown code stripping, extension-based CLI kind selection, and an explicit kind override for commit-message stdin. The implementation had to remain pure and synchronous inside the lint seam, use TDD, stay self-contained from parallel tickets, and be committed on a non-default branch after tests, lint, typechecking, and CLI acceptance checks passed.

## What Changed

- Add slash-source, hash-source, and commit-message lint kinds with dialect-aware comment extraction and original source coordinates.
- Infer file kinds from extensions and add a validated `--kind` override for files and standard input.
- Exempt identifiers and code while preserving Markdown structure and prose boundaries across comments and containers.

## Risk Assessment

✅ Low: The latest changes correctly preserve comment offsets and bound prose-run processing without introducing a new material source risk.

## Testing

After installing missing locked dependencies, focused tests exposed and verified a fix for Markdown list indentation; all targeted tests passed, and an end-to-end CLI transcript confirmed extension-selected comments, accurate coordinates, Markdown code exclusion, commit-message stdin override, and the repaired list-code exemption.

<details>
<summary>Evidence: End-to-end CLI acceptance transcript</summary>

```text
$ nl -ba test/fixtures/comment-violation.ts
     1	const banner = "the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again."
     2	// The quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.
     3	const done = banner.length > 0
$ simple-english test/fixtures/comment-violation.ts
test/fixtures/comment-violation.ts:2:4 [hard] sentence-length Sentence has 29 words; the maximum is 25.
[exit 1]

$ nl -ba test/fixtures/comment-violation.sh
     1	#!/usr/bin/env bash
     2	echo "the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again."
     3	echo prefix# the quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.
     4	# The quick brown fox jumps over the lazy dog and then the quick brown fox jumps over the lazy dog and then the dog jumps over the fox again.
$ simple-english test/fixtures/comment-violation.sh
test/fixtures/comment-violation.sh:4:3 [hard] sentence-length Sentence has 29 words; the maximum is 25.
[exit 1]

$ nl -ba /tmp/no-mistakes-evidence/01KYVKTENE4XE7RF08DKR09TF7/markdown-code-exemption.md
     1	A short introduction.
     2	
     3	    one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty.
     4	
     5	one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone twentytwo twentythree twentyfour twentyfive twentysix twentyseven twentyeight twentynine thirty.
$ simple-english /tmp/no-mistakes-evidence/01KYVKTENE4XE7RF08DKR09TF7/markdown-code-exemption.md
/tmp/no-mistakes-evidence/01KYVKTENE4XE7RF08DKR09TF7/markdown-code-exemption.md:5:1 [hard] sentence-length Sentence has 30 words; the maximum is 25.
[exit 1]

$ printf <commit-message> | simple-english --kind commit-message
<stdin>:3:1 [hard] sentence-length Sentence has 30 words; the maximum is 25.
[exit 1]

$ printf -- "-     approximately\n" | simple-english
[exit 0]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `src/engine/lint.ts` - merge conflict rebasing onto origin/main
- ⚠️ `test/cli/cli.test.ts` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed (2) ✅</summary>

- 🚨 `src/engine/markdown.ts:207` - List and blockquote markers are replaced with spaces before segmentParagraphs and dictionaryRule receive the prose. For example, `One. Two. Three.\n&gt; Four. Five. Six. Seven.` becomes one paragraph and incorrectly triggers paragraph-length. Preserve container markers in the prose view or pass equivalent block structure separately.
- 🚨 `src/engine/markdown.ts:5` - LIST_MARKER consumes four spaces from a five-space run after a list marker, leaving only one space, so `-     approximately` is linted instead of recognized as indented code. Parse the complete padding run and consume only one separator when it exceeds four spaces.
- 🚨 `src/engine/markdown.ts:231` - Indented-code state treats every non-ATX line as a continuing paragraph. A thematic break or Setext underline followed by an indented line therefore exposes code as prose. Reset paragraph continuation for all Markdown block boundaries, including thematic breaks and Setext headings.
- 🚨 `src/engine/comments.ts:102` - Separate block-comment runs on one line are joined through space-blanked code. For example, `/* Carry */ execute() /* out */` becomes `Carry ... out` and falsely triggers phrasal-verb. Return and honor prose-run boundaries at the shared extraction seam instead of representing intervening source code only as whitespace.
- 🚨 `src/cli/main.ts:44` - All slash-family extensions use one language-neutral lexer despite conflicting syntax. A real `//` comment inside a JavaScript template interpolation is suppressed as string text, while a nested Rust block comment closes at the inner terminator and hides the remaining outer comment. Classify and pass a slash dialect at this boundary so template interpolation and nested comments follow the selected language.
- 🚨 `src/cli/main.ts:46` - All non-shell hash extensions share the general dialect despite incompatible comment and string rules. YAML `value# word1 ... word30.` is a plain scalar but is linted as a comment, and a valid multiline Ruby quoted string loses quote state at the newline and exposes an internal `#` line. Add dialect classification for these supported extensions and enforce their syntax in extractHashComments.

🔧 Fix: Preserve prose boundaries across Markdown containers and block comments
3 issues (2 errors, 1 warning) still open:
- 🚨 `src/engine/lint.ts:82` - Paragraph analysis slices away each comment prefix but never restores its offset. For `x // One. Two. Three. Four. Five. Six. Seven.`, paragraph-length reports column 1 instead of the comment content at column 6, contradicting the original-position guarantee. Preserve the starting column in Paragraph or remap the violation at this seam.
- 🚨 `src/engine/markdown.ts:253` - Inline spans are paired across every contiguous inline-eligible line, including Markdown block boundaries. For example, an unmatched backtick in an ATX heading can pair with one after prose on the next line and suppress violations in that prose. Group eligible lines by actual Markdown inline block or paragraph identity so delimiters cannot cross headings, list items, or other block boundaries.
- ⚠️ `src/engine/lint.ts:46` - Each block-comment prose break creates and fully lints another file-sized masked copy. A file with B separate block comments and L lines now performs O(B*L) allocation and scanning, becoming quadratic when comments scale with file size. Carry run boundaries through one lint pass or lint bounded ranges without copying the complete file per run.

🔧 Fix: Preserve comment offsets with linear prose-run slicing
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` to restore missing locked test dependencies</code>
- `bun run test -- test/engine/dictionary.test.ts -t 'ignores indented code in Markdown list containers'`
- `bun run test -- test/engine/kinds.test.ts test/engine/dictionary.test.ts test/cli/cli.test.ts`
- <code>CLI acceptance checks for `.ts` and `.sh` comment extraction, Markdown code exclusion, `--kind commit-message` stdin handling, original coordinates, and list-indented code exemption</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
