### PR TITLE
feat(engine): add diff-only linting

### DIFF
--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -1,0 +1,69 @@
+// Longest-common-subsequence line diff. Returns the 1-based line numbers of
+// the current text that are new or changed relative to the previous text.
+// Deleted lines have no counterpart in the current text, so they never appear.
+export function changedLineNumbers(previousText: string, currentText: string): Set<number> {
+  const previous = previousText.split("\n")
+  const current = currentText.split("\n")
+
+  let start = 0
+  while (start < previous.length && start < current.length && previous[start] === current[start]) {
+    start++
+  }
+
+  let previousEnd = previous.length
+  let currentEnd = current.length
+  while (
+    previousEnd > start &&
+    currentEnd > start &&
+    previous[previousEnd - 1] === current[currentEnd - 1]
+  ) {
+    previousEnd--
+    currentEnd--
+  }
+
+  const a = previous.slice(start, previousEnd)
+  const b = current.slice(start, currentEnd)
+
+  const changed = new Set<number>()
+  const markAll = () => {
+    for (let i = 0; i < b.length; i++) {
+      changed.add(start + i + 1)
+    }
+  }
+
+  // The DP table is quadratic; past this bound, conservatively treat the whole
+  // middle as changed rather than risk pathological memory use on huge edits.
+  if (a.length * b.length > 1_000_000) {
+    markAll()
+    return changed
+  }
+
+  const width = b.length + 1
+  const table = new Int32Array((a.length + 1) * width)
+  const lcs = (i: number, j: number) => table[i * width + j] ?? 0
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      table[i * width + j] =
+        a[i] === b[j] ? lcs(i + 1, j + 1) + 1 : Math.max(lcs(i + 1, j), lcs(i, j + 1))
+    }
+  }
+
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      i++
+      j++
+    } else if (lcs(i + 1, j) >= lcs(i, j + 1)) {
+      i++
+    } else {
+      changed.add(start + j + 1)
+      j++
+    }
+  }
+  for (; j < b.length; j++) {
+    changed.add(start + j + 1)
+  }
+
+  return changed
+}

--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -16,6 +16,17 @@ export interface TextChanges {
 
 const DIFF_CELL_LIMIT = 1_000_000
 
+interface DiffBudget {
+  remaining: number
+}
+
+function reserveCells(budget: DiffBudget, previousLength: number, currentLength: number): boolean {
+  const cells = previousLength * currentLength
+  if (cells > budget.remaining) return false
+  budget.remaining -= cells
+  return true
+}
+
 function lineTokens(text: string): string[] {
   const tokens: string[] = []
   let start = 0
@@ -48,6 +59,7 @@ function diffCharacters(
   currentOffset: number,
   ranges: ChangedRange[],
   deletions: Deletion[],
+  budget: DiffBudget,
 ): void {
   let prefix = 0
   while (
@@ -86,7 +98,7 @@ function diffCharacters(
     })
     return
   }
-  if (oldText.length * newText.length > DIFF_CELL_LIMIT) {
+  if (!reserveCells(budget, oldText.length, newText.length)) {
     addRange(ranges, newBase, newBase + newText.length)
     return
   }
@@ -173,8 +185,9 @@ export function changedText(previousText: string, currentText: string): TextChan
   const newLines = current.slice(start, currentEnd)
   const ranges: ChangedRange[] = []
   const deletions: Deletion[] = []
+  const budget: DiffBudget = { remaining: DIFF_CELL_LIMIT }
 
-  if (oldLines.length * newLines.length > DIFF_CELL_LIMIT) {
+  if (!reserveCells(budget, oldLines.length, newLines.length)) {
     const oldText = oldLines.join("")
     const newText = newLines.join("")
     if (newText.length > 0) {
@@ -216,6 +229,7 @@ export function changedText(previousText: string, currentText: string): TextChan
       newChunkOffset,
       ranges,
       deletions,
+      budget,
     )
     oldChunk = ""
     newChunk = ""

--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -1,6 +1,9 @@
 // Longest-common-subsequence line diff. Returns the 1-based line numbers of
 // the current text that are new or changed relative to the previous text.
-// Deleted lines have no counterpart in the current text, so they never appear.
+// Deleted lines have no counterpart in the current text, but a pure deletion
+// between two retained lines can merge their sentences (for example when the
+// removed line carried the terminator), so both neighbours of such a
+// deletion point also count as changed.
 export function changedLineNumbers(previousText: string, currentText: string): Set<number> {
   const previous = previousText.split("\n")
   const current = currentText.split("\n")
@@ -25,6 +28,13 @@ export function changedLineNumbers(previousText: string, currentText: string): S
   const b = current.slice(start, currentEnd)
 
   const changed = new Set<number>()
+  const markDeletionPoint = (j: number) => {
+    const before = start + j
+    if (before >= 1 && before < current.length) {
+      changed.add(before)
+      changed.add(before + 1)
+    }
+  }
   const markAll = () => {
     for (let i = 0; i < b.length; i++) {
       changed.add(start + i + 1)
@@ -55,11 +65,15 @@ export function changedLineNumbers(previousText: string, currentText: string): S
       i++
       j++
     } else if (lcs(i + 1, j) >= lcs(i, j + 1)) {
+      markDeletionPoint(j)
       i++
     } else {
       changed.add(start + j + 1)
       j++
     }
+  }
+  if (i < a.length) {
+    markDeletionPoint(j)
   }
   for (; j < b.length; j++) {
     changed.add(start + j + 1)

--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -1,15 +1,160 @@
-// Longest-common-subsequence line diff. Returns the 1-based line numbers of
-// the current text that are new or changed relative to the previous text.
-// Deleted lines have no counterpart in the current text, but a pure deletion
-// between two retained lines can merge their sentences (for example when the
-// removed line carried the terminator), so both neighbours of such a
-// deletion point also count as changed.
-export function changedLineNumbers(previousText: string, currentText: string): Set<number> {
-  const previous = previousText.split("\n")
-  const current = currentText.split("\n")
+export interface ChangedRange {
+  readonly start: number
+  readonly end: number
+}
+
+export interface Deletion {
+  readonly previousStart: number
+  readonly previousEnd: number
+  readonly currentOffset: number
+}
+
+export interface TextChanges {
+  readonly ranges: readonly ChangedRange[]
+  readonly deletions: readonly Deletion[]
+}
+
+const DIFF_CELL_LIMIT = 1_000_000
+
+function lineTokens(text: string): string[] {
+  const tokens: string[] = []
+  let start = 0
+  for (let index = 0; index < text.length; index++) {
+    if (text[index] === "\n") {
+      tokens.push(text.slice(start, index + 1))
+      start = index + 1
+    }
+  }
+  if (start < text.length) {
+    tokens.push(text.slice(start))
+  }
+  return tokens
+}
+
+function addRange(ranges: ChangedRange[], start: number, end: number): void {
+  if (start === end) return
+  const last = ranges.at(-1)
+  if (last && start <= last.end) {
+    ranges[ranges.length - 1] = { start: last.start, end: Math.max(last.end, end) }
+    return
+  }
+  ranges.push({ start, end })
+}
+
+function diffCharacters(
+  previous: string,
+  current: string,
+  previousOffset: number,
+  currentOffset: number,
+  ranges: ChangedRange[],
+  deletions: Deletion[],
+): void {
+  let prefix = 0
+  while (
+    prefix < previous.length &&
+    prefix < current.length &&
+    previous[prefix] === current[prefix]
+  ) {
+    prefix++
+  }
+
+  let previousEnd = previous.length
+  let currentEnd = current.length
+  while (
+    previousEnd > prefix &&
+    currentEnd > prefix &&
+    previous[previousEnd - 1] === current[currentEnd - 1]
+  ) {
+    previousEnd--
+    currentEnd--
+  }
+
+  const oldText = previous.slice(prefix, previousEnd)
+  const newText = current.slice(prefix, currentEnd)
+  const oldBase = previousOffset + prefix
+  const newBase = currentOffset + prefix
+
+  if (oldText.length === 0) {
+    addRange(ranges, newBase, newBase + newText.length)
+    return
+  }
+  if (newText.length === 0) {
+    deletions.push({
+      previousStart: oldBase,
+      previousEnd: oldBase + oldText.length,
+      currentOffset: newBase,
+    })
+    return
+  }
+  if (oldText.length * newText.length > DIFF_CELL_LIMIT) {
+    addRange(ranges, newBase, newBase + newText.length)
+    return
+  }
+
+  const width = newText.length + 1
+  const table = new Int32Array((oldText.length + 1) * width)
+  const lcs = (oldIndex: number, newIndex: number) => table[oldIndex * width + newIndex] ?? 0
+  for (let oldIndex = oldText.length - 1; oldIndex >= 0; oldIndex--) {
+    for (let newIndex = newText.length - 1; newIndex >= 0; newIndex--) {
+      table[oldIndex * width + newIndex] =
+        oldText[oldIndex] === newText[newIndex]
+          ? lcs(oldIndex + 1, newIndex + 1) + 1
+          : Math.max(lcs(oldIndex + 1, newIndex), lcs(oldIndex, newIndex + 1))
+    }
+  }
+
+  let oldIndex = 0
+  let newIndex = 0
+  let deletionStart: number | undefined
+  let deletionPoint = 0
+  const flushDeletion = () => {
+    if (deletionStart === undefined) return
+    deletions.push({
+      previousStart: oldBase + deletionStart,
+      previousEnd: oldBase + oldIndex,
+      currentOffset: newBase + deletionPoint,
+    })
+    deletionStart = undefined
+  }
+
+  while (oldIndex < oldText.length && newIndex < newText.length) {
+    if (oldText[oldIndex] === newText[newIndex]) {
+      flushDeletion()
+      oldIndex++
+      newIndex++
+    } else if (lcs(oldIndex + 1, newIndex) >= lcs(oldIndex, newIndex + 1)) {
+      if (deletionStart === undefined) {
+        deletionStart = oldIndex
+        deletionPoint = newIndex
+      }
+      oldIndex++
+    } else {
+      flushDeletion()
+      addRange(ranges, newBase + newIndex, newBase + newIndex + 1)
+      newIndex++
+    }
+  }
+  while (oldIndex < oldText.length) {
+    if (deletionStart === undefined) {
+      deletionStart = oldIndex
+      deletionPoint = newIndex
+    }
+    oldIndex++
+  }
+  flushDeletion()
+  addRange(ranges, newBase + newIndex, newBase + newText.length)
+}
+
+export function changedText(previousText: string, currentText: string): TextChanges {
+  const previous = lineTokens(previousText)
+  const current = lineTokens(currentText)
 
   let start = 0
+  let previousOffset = 0
+  let currentOffset = 0
   while (start < previous.length && start < current.length && previous[start] === current[start]) {
+    previousOffset += previous[start]?.length ?? 0
+    currentOffset += current[start]?.length ?? 0
     start++
   }
 
@@ -24,60 +169,88 @@ export function changedLineNumbers(previousText: string, currentText: string): S
     currentEnd--
   }
 
-  const a = previous.slice(start, previousEnd)
-  const b = current.slice(start, currentEnd)
+  const oldLines = previous.slice(start, previousEnd)
+  const newLines = current.slice(start, currentEnd)
+  const ranges: ChangedRange[] = []
+  const deletions: Deletion[] = []
 
-  const changed = new Set<number>()
-  const markDeletionPoint = (j: number) => {
-    const before = start + j
-    if (before >= 1 && before < current.length) {
-      changed.add(before)
-      changed.add(before + 1)
+  if (oldLines.length * newLines.length > DIFF_CELL_LIMIT) {
+    const oldText = oldLines.join("")
+    const newText = newLines.join("")
+    if (newText.length > 0) {
+      addRange(ranges, currentOffset, currentOffset + newText.length)
+    } else if (oldText.length > 0) {
+      deletions.push({
+        previousStart: previousOffset,
+        previousEnd: previousOffset + oldText.length,
+        currentOffset,
+      })
+    }
+    return { ranges, deletions }
+  }
+
+  const width = newLines.length + 1
+  const table = new Int32Array((oldLines.length + 1) * width)
+  const lcs = (oldIndex: number, newIndex: number) => table[oldIndex * width + newIndex] ?? 0
+  for (let oldIndex = oldLines.length - 1; oldIndex >= 0; oldIndex--) {
+    for (let newIndex = newLines.length - 1; newIndex >= 0; newIndex--) {
+      table[oldIndex * width + newIndex] =
+        oldLines[oldIndex] === newLines[newIndex]
+          ? lcs(oldIndex + 1, newIndex + 1) + 1
+          : Math.max(lcs(oldIndex + 1, newIndex), lcs(oldIndex, newIndex + 1))
     }
   }
-  const markAll = () => {
-    for (let i = 0; i < b.length; i++) {
-      changed.add(start + i + 1)
-    }
+
+  let oldIndex = 0
+  let newIndex = 0
+  let oldChunk = ""
+  let newChunk = ""
+  let oldChunkOffset = previousOffset
+  let newChunkOffset = currentOffset
+  const flushChunk = () => {
+    if (oldChunk === "" && newChunk === "") return
+    diffCharacters(
+      oldChunk,
+      newChunk,
+      oldChunkOffset,
+      newChunkOffset,
+      ranges,
+      deletions,
+    )
+    oldChunk = ""
+    newChunk = ""
   }
 
-  // The DP table is quadratic; past this bound, conservatively treat the whole
-  // middle as changed rather than risk pathological memory use on huge edits.
-  if (a.length * b.length > 1_000_000) {
-    markAll()
-    return changed
-  }
-
-  const width = b.length + 1
-  const table = new Int32Array((a.length + 1) * width)
-  const lcs = (i: number, j: number) => table[i * width + j] ?? 0
-  for (let i = a.length - 1; i >= 0; i--) {
-    for (let j = b.length - 1; j >= 0; j--) {
-      table[i * width + j] =
-        a[i] === b[j] ? lcs(i + 1, j + 1) + 1 : Math.max(lcs(i + 1, j), lcs(i, j + 1))
-    }
-  }
-
-  let i = 0
-  let j = 0
-  while (i < a.length && j < b.length) {
-    if (a[i] === b[j]) {
-      i++
-      j++
-    } else if (lcs(i + 1, j) >= lcs(i, j + 1)) {
-      markDeletionPoint(j)
-      i++
+  while (oldIndex < oldLines.length && newIndex < newLines.length) {
+    if (oldLines[oldIndex] === newLines[newIndex]) {
+      flushChunk()
+      previousOffset += oldLines[oldIndex]?.length ?? 0
+      currentOffset += newLines[newIndex]?.length ?? 0
+      oldIndex++
+      newIndex++
+      oldChunkOffset = previousOffset
+      newChunkOffset = currentOffset
+    } else if (lcs(oldIndex + 1, newIndex) >= lcs(oldIndex, newIndex + 1)) {
+      oldChunk += oldLines[oldIndex] ?? ""
+      previousOffset += oldLines[oldIndex]?.length ?? 0
+      oldIndex++
     } else {
-      changed.add(start + j + 1)
-      j++
+      newChunk += newLines[newIndex] ?? ""
+      currentOffset += newLines[newIndex]?.length ?? 0
+      newIndex++
     }
   }
-  if (i < a.length) {
-    markDeletionPoint(j)
+  while (oldIndex < oldLines.length) {
+    oldChunk += oldLines[oldIndex] ?? ""
+    previousOffset += oldLines[oldIndex]?.length ?? 0
+    oldIndex++
   }
-  for (; j < b.length; j++) {
-    changed.add(start + j + 1)
+  while (newIndex < newLines.length) {
+    newChunk += newLines[newIndex] ?? ""
+    currentOffset += newLines[newIndex]?.length ?? 0
+    newIndex++
   }
+  flushChunk()
 
-  return changed
+  return { ranges, deletions }
 }

--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -115,23 +115,13 @@ function diffCharacters(
   const suffixLength = previous.length - previousEnd
   const retainEdges = () => {
     addRetained(retained, previousOffset, currentOffset, prefix)
-    addRetained(
-      retained,
-      previousOffset + previousEnd,
-      currentOffset + currentEnd,
-      suffixLength,
-    )
+    addRetained(retained, previousOffset + previousEnd, currentOffset + currentEnd, suffixLength)
   }
 
   if (oldText.length === 0) {
     addRetained(retained, previousOffset, currentOffset, prefix)
     addRange(ranges, newBase, newBase + newText.length)
-    addRetained(
-      retained,
-      previousOffset + previousEnd,
-      currentOffset + currentEnd,
-      suffixLength,
-    )
+    addRetained(retained, previousOffset + previousEnd, currentOffset + currentEnd, suffixLength)
     return
   }
   if (newText.length === 0) {
@@ -141,12 +131,7 @@ function diffCharacters(
       previousEnd: oldBase + oldText.length,
       currentOffset: newBase,
     })
-    addRetained(
-      retained,
-      previousOffset + previousEnd,
-      currentOffset + currentEnd,
-      suffixLength,
-    )
+    addRetained(retained, previousOffset + previousEnd, currentOffset + currentEnd, suffixLength)
     return
   }
   if (!reserveCells(budget, oldText.length, newText.length)) {
@@ -215,12 +200,7 @@ function diffCharacters(
   }
   flushDeletion()
   addRange(ranges, newBase + newIndex, newBase + newText.length)
-  addRetained(
-    retained,
-    previousOffset + previousEnd,
-    currentOffset + currentEnd,
-    suffixLength,
-  )
+  addRetained(retained, previousOffset + previousEnd, currentOffset + currentEnd, suffixLength)
 }
 
 export function changedText(previousText: string, currentText: string): TextChanges {

--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -9,9 +9,16 @@ export interface Deletion {
   readonly currentOffset: number
 }
 
+export interface RetainedRange {
+  readonly previousStart: number
+  readonly currentStart: number
+  readonly length: number
+}
+
 export interface TextChanges {
   readonly ranges: readonly ChangedRange[]
   readonly deletions: readonly Deletion[]
+  readonly retained: readonly RetainedRange[]
 }
 
 const DIFF_CELL_LIMIT = 1_000_000
@@ -52,6 +59,25 @@ function addRange(ranges: ChangedRange[], start: number, end: number): void {
   ranges.push({ start, end })
 }
 
+function addRetained(
+  retained: RetainedRange[],
+  previousStart: number,
+  currentStart: number,
+  length: number,
+): void {
+  if (length === 0) return
+  const last = retained.at(-1)
+  if (
+    last &&
+    last.previousStart + last.length === previousStart &&
+    last.currentStart + last.length === currentStart
+  ) {
+    retained[retained.length - 1] = { ...last, length: last.length + length }
+    return
+  }
+  retained.push({ previousStart, currentStart, length })
+}
+
 function diffCharacters(
   previous: string,
   current: string,
@@ -59,6 +85,7 @@ function diffCharacters(
   currentOffset: number,
   ranges: ChangedRange[],
   deletions: Deletion[],
+  retained: RetainedRange[],
   budget: DiffBudget,
 ): void {
   let prefix = 0
@@ -85,23 +112,50 @@ function diffCharacters(
   const newText = current.slice(prefix, currentEnd)
   const oldBase = previousOffset + prefix
   const newBase = currentOffset + prefix
+  const suffixLength = previous.length - previousEnd
+  const retainEdges = () => {
+    addRetained(retained, previousOffset, currentOffset, prefix)
+    addRetained(
+      retained,
+      previousOffset + previousEnd,
+      currentOffset + currentEnd,
+      suffixLength,
+    )
+  }
 
   if (oldText.length === 0) {
+    addRetained(retained, previousOffset, currentOffset, prefix)
     addRange(ranges, newBase, newBase + newText.length)
+    addRetained(
+      retained,
+      previousOffset + previousEnd,
+      currentOffset + currentEnd,
+      suffixLength,
+    )
     return
   }
   if (newText.length === 0) {
+    addRetained(retained, previousOffset, currentOffset, prefix)
     deletions.push({
       previousStart: oldBase,
       previousEnd: oldBase + oldText.length,
       currentOffset: newBase,
     })
+    addRetained(
+      retained,
+      previousOffset + previousEnd,
+      currentOffset + currentEnd,
+      suffixLength,
+    )
     return
   }
   if (!reserveCells(budget, oldText.length, newText.length)) {
+    retainEdges()
     addRange(ranges, newBase, newBase + newText.length)
     return
   }
+
+  addRetained(retained, previousOffset, currentOffset, prefix)
 
   const width = newText.length + 1
   const table = new Int32Array((oldText.length + 1) * width)
@@ -132,6 +186,7 @@ function diffCharacters(
   while (oldIndex < oldText.length && newIndex < newText.length) {
     if (oldText[oldIndex] === newText[newIndex]) {
       flushDeletion()
+      addRetained(retained, oldBase + oldIndex, newBase + newIndex, 1)
       oldIndex++
       newIndex++
     } else if (lcs(oldIndex + 1, newIndex) >= lcs(oldIndex, newIndex + 1)) {
@@ -155,6 +210,12 @@ function diffCharacters(
   }
   flushDeletion()
   addRange(ranges, newBase + newIndex, newBase + newText.length)
+  addRetained(
+    retained,
+    previousOffset + previousEnd,
+    currentOffset + currentEnd,
+    suffixLength,
+  )
 }
 
 export function changedText(previousText: string, currentText: string): TextChanges {
@@ -185,7 +246,9 @@ export function changedText(previousText: string, currentText: string): TextChan
   const newLines = current.slice(start, currentEnd)
   const ranges: ChangedRange[] = []
   const deletions: Deletion[] = []
+  const retained: RetainedRange[] = []
   const budget: DiffBudget = { remaining: DIFF_CELL_LIMIT }
+  addRetained(retained, 0, 0, currentOffset)
 
   if (!reserveCells(budget, oldLines.length, newLines.length)) {
     const oldText = oldLines.join("")
@@ -199,7 +262,13 @@ export function changedText(previousText: string, currentText: string): TextChan
         currentOffset,
       })
     }
-    return { ranges, deletions }
+    addRetained(
+      retained,
+      previousOffset + oldText.length,
+      currentOffset + newText.length,
+      previousText.length - previousOffset - oldText.length,
+    )
+    return { ranges, deletions, retained }
   }
 
   const width = newLines.length + 1
@@ -229,6 +298,7 @@ export function changedText(previousText: string, currentText: string): TextChan
       newChunkOffset,
       ranges,
       deletions,
+      retained,
       budget,
     )
     oldChunk = ""
@@ -238,8 +308,10 @@ export function changedText(previousText: string, currentText: string): TextChan
   while (oldIndex < oldLines.length && newIndex < newLines.length) {
     if (oldLines[oldIndex] === newLines[newIndex]) {
       flushChunk()
-      previousOffset += oldLines[oldIndex]?.length ?? 0
-      currentOffset += newLines[newIndex]?.length ?? 0
+      const lineLength = oldLines[oldIndex]?.length ?? 0
+      addRetained(retained, previousOffset, currentOffset, lineLength)
+      previousOffset += lineLength
+      currentOffset += lineLength
       oldIndex++
       newIndex++
       oldChunkOffset = previousOffset
@@ -265,6 +337,7 @@ export function changedText(previousText: string, currentText: string): TextChan
     newIndex++
   }
   flushChunk()
+  addRetained(retained, previousOffset, currentOffset, previousText.length - previousOffset)
 
-  return { ranges, deletions }
+  return { ranges, deletions, retained }
 }

--- a/src/engine/diff.ts
+++ b/src/engine/diff.ts
@@ -152,6 +152,11 @@ function diffCharacters(
   if (!reserveCells(budget, oldText.length, newText.length)) {
     retainEdges()
     addRange(ranges, newBase, newBase + newText.length)
+    deletions.push({
+      previousStart: oldBase,
+      previousEnd: oldBase + oldText.length,
+      currentOffset: newBase,
+    })
     return
   }
 

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -35,6 +35,21 @@ interface ResolvedOptions {
   readonly dictionary?: Dictionary
   readonly tagger?: Tagger
   readonly selectSentences: SentenceSelector
+  readonly diffOnly: boolean
+}
+
+function selectedProseLines(text: string, sentences: readonly Sentence[]): string[] {
+  const selected: string[] = Array.from(text, (character) =>
+    character === "\n" || character === "\r" ? character : " ",
+  )
+  for (const sentence of sentences) {
+    for (const range of sentence.contentRanges) {
+      for (let offset = range.start; offset < range.end; offset++) {
+        selected[offset] = text[offset] ?? " "
+      }
+    }
+  }
+  return selected.join("").split("\n")
 }
 
 interface ExtractedProse {
@@ -99,28 +114,37 @@ const lintProse = (
   mechanicalLines: readonly string[],
   contentStarts: readonly number[],
   structuralBlanks: readonly boolean[],
-  { maxSentenceWords, dictionary, tagger, selectSentences }: ResolvedOptions,
-) => [
-  ...sentenceLength(
-    selectSentences(segmentSentences(lines, lines.join("\n"), structuralBlanks)),
-    maxSentenceWords,
-  ),
-  ...paragraphLength(
-    segmentParagraphs(
-      structuralLines.map((line, index) => line.slice(contentStarts[index] ?? 0)),
-      contentStarts.map((contentStart) => contentStart + 1),
+  { maxSentenceWords, dictionary, tagger, selectSentences, diffOnly }: ResolvedOptions,
+) => {
+  const sentences = selectSentences(
+    segmentSentences(lines, lines.join("\n"), structuralBlanks),
+  )
+  const selectedProse = diffOnly ? selectedProseLines(lines.join("\n"), sentences) : lines
+  const selectedStructural = diffOnly
+    ? selectedProseLines(structuralLines.join("\n"), sentences)
+    : structuralLines
+  const selectedMechanical = diffOnly
+    ? selectedProseLines(mechanicalLines.join("\n"), sentences)
+    : mechanicalLines
+  return [
+    ...sentenceLength(sentences, maxSentenceWords),
+    ...paragraphLength(
+      segmentParagraphs(
+        selectedStructural.map((line, index) => line.slice(contentStarts[index] ?? 0)),
+        contentStarts.map((contentStart) => contentStart + 1),
+      ),
     ),
-  ),
-  ...contraction(lines),
-  ...semicolon(mechanicalLines),
-  ...phrasalVerb(lines),
-  ...hedging(lines),
-  ...marketing(lines),
-  ...(dictionary === undefined
-    ? []
-    : dictionaryRule(structuralLines, dictionary, tagger, contentStarts)),
-  ...(tagger === undefined ? [] : verbForm(lines, tagger)),
-]
+    ...contraction(selectedProse),
+    ...semicolon(selectedMechanical),
+    ...phrasalVerb(selectedProse),
+    ...hedging(selectedProse),
+    ...marketing(selectedProse),
+    ...(dictionary === undefined
+      ? []
+      : dictionaryRule(selectedStructural, dictionary, tagger, contentStarts)),
+    ...(tagger === undefined ? [] : verbForm(selectedProse, tagger)),
+  ]
+}
 
 const lintExtracted = (extracted: ExtractedProse, options: ResolvedOptions): Violation[] => {
   const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
@@ -617,6 +641,7 @@ export function lint(kind: LintKind, text: string, options: LintOptions = {}): L
     dictionary: options.dictionary,
     tagger: options.tagger,
     selectSentences: sentenceSelector(text, options.previousText),
+    diffOnly: options.previousText !== undefined,
   }
   const raw = splitProseRuns(extracted).flatMap((run) =>
     lintExtracted(run, resolved).map((violation) => ({
@@ -628,12 +653,10 @@ export function lint(kind: LintKind, text: string, options: LintOptions = {}): L
   const violations: Violation[] = raw
     .flatMap((violation) => {
       const setting = options.rules?.[violation.ruleId]
-      if (setting === undefined) {
-        return [violation]
-      }
+      if (setting === undefined) return [violation]
       return setting === "off" ? [] : [{ ...violation, severity: setting }]
     })
-    .sort((a, b) => a.line - b.line || a.column - b.column)
+    .sort((left, right) => left.line - right.line || left.column - right.column)
   return {
     violations,
     summary: {

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -6,6 +6,7 @@ import {
   blankInlineCode,
   blankMarkdownCode,
   blankMarkdownCodeWithStructure,
+  maskMarkdownCode,
 } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
@@ -159,7 +160,7 @@ function sentenceFilter(text: string, previousText: string | undefined): Sentenc
     return () => true
   }
 
-  const changes = changedText(previousText, text)
+  const changes = changedText(maskMarkdownCode(previousText), maskMarkdownCode(text))
   const previousLines = blankInlineCode(blankMarkdownCode(previousText.split("\n")))
   const previousSentences = segmentSentences(previousLines, previousText)
   const mergedBoundaries = changes.deletions.flatMap((deletion) => {

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,6 +1,11 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
-import { type ChangedRange, changedText, type TextChanges } from "./diff.ts"
+import {
+  type ChangedRange,
+  changedText,
+  type RetainedRange,
+  type TextChanges,
+} from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
 import {
   blankMarkdownCodeWithStructure,
@@ -180,6 +185,95 @@ function nearestNonWhitespaceAfter(
   return result
 }
 
+interface CorrespondingOffset {
+  readonly current: number
+  readonly previous: number
+}
+
+function nearestRetainedProseBefore(
+  text: string,
+  retained: readonly RetainedRange[],
+  offsets: readonly number[],
+): Array<CorrespondingOffset | undefined> {
+  const ordered = offsets
+    .map((offset, index) => ({ offset, index }))
+    .sort((left, right) => left.offset - right.offset)
+  const result: Array<CorrespondingOffset | undefined> = new Array(offsets.length)
+  let cursor = 0
+  let retainedIndex = 0
+  let nearest: CorrespondingOffset | undefined
+
+  for (const query of ordered) {
+    while (cursor < query.offset && cursor < text.length) {
+      while (
+        retainedIndex < retained.length &&
+        (retained[retainedIndex]?.currentStart ?? 0) +
+          (retained[retainedIndex]?.length ?? 0) <=
+          cursor
+      ) {
+        retainedIndex++
+      }
+      const range = retained[retainedIndex]
+      if (
+        range &&
+        range.currentStart <= cursor &&
+        cursor < range.currentStart + range.length &&
+        !/\s/u.test(text[cursor] ?? "")
+      ) {
+        nearest = {
+          current: cursor,
+          previous: range.previousStart + cursor - range.currentStart,
+        }
+      }
+      cursor++
+    }
+    result[query.index] = nearest
+  }
+
+  return result
+}
+
+function nearestRetainedProseAfter(
+  text: string,
+  retained: readonly RetainedRange[],
+  offsets: readonly number[],
+): Array<CorrespondingOffset | undefined> {
+  const ordered = offsets
+    .map((offset, index) => ({ offset, index }))
+    .sort((left, right) => right.offset - left.offset)
+  const result: Array<CorrespondingOffset | undefined> = new Array(offsets.length)
+  let cursor = text.length - 1
+  let retainedIndex = retained.length - 1
+  let nearest: CorrespondingOffset | undefined
+
+  for (const query of ordered) {
+    while (cursor >= query.offset) {
+      while (
+        retainedIndex >= 0 &&
+        cursor < (retained[retainedIndex]?.currentStart ?? Number.POSITIVE_INFINITY)
+      ) {
+        retainedIndex--
+      }
+      const range = retained[retainedIndex]
+      if (
+        range &&
+        range.currentStart <= cursor &&
+        cursor < range.currentStart + range.length &&
+        !/\s/u.test(text[cursor] ?? "")
+      ) {
+        nearest = {
+          current: cursor,
+          previous: range.previousStart + cursor - range.currentStart,
+        }
+      }
+      cursor--
+    }
+    result[query.index] = nearest
+  }
+
+  return result
+}
+
 function contains(sentence: Sentence, offset: number): boolean {
   return sentence.startOffset <= offset && offset < sentence.endOffset
 }
@@ -302,16 +396,77 @@ function normalizeRanges(ranges: readonly ChangedRange[]): ChangedRange[] {
   return normalized
 }
 
+function insertionSplitSentenceIndexes(
+  previousSentences: readonly Sentence[],
+  currentSentences: readonly Sentence[],
+  currentProse: string,
+  changes: TextChanges,
+): ReadonlySet<number> {
+  const insertions = normalizeRanges(changes.ranges)
+  const before = nearestRetainedProseBefore(
+    currentProse,
+    changes.retained,
+    insertions.map((range) => range.start),
+  )
+  const after = nearestRetainedProseAfter(
+    currentProse,
+    changes.retained,
+    insertions.map((range) => range.end),
+  )
+  const previousBefore = containingSentenceIndexes(
+    previousSentences,
+    before.map((offset) => offset?.previous),
+  )
+  const previousAfter = containingSentenceIndexes(
+    previousSentences,
+    after.map((offset) => offset?.previous),
+  )
+  const currentBefore = containingSentenceIndexes(
+    currentSentences,
+    before.map((offset) => offset?.current),
+  )
+  const currentAfter = containingSentenceIndexes(
+    currentSentences,
+    after.map((offset) => offset?.current),
+  )
+  const affected = new Set<number>()
+
+  for (let index = 0; index < insertions.length; index++) {
+    const oldBefore = previousBefore[index]
+    const oldAfter = previousAfter[index]
+    const newBefore = currentBefore[index]
+    const newAfter = currentAfter[index]
+    if (
+      oldBefore !== undefined &&
+      oldBefore !== -1 &&
+      oldBefore === oldAfter &&
+      newBefore !== undefined &&
+      newBefore !== -1 &&
+      newAfter !== undefined &&
+      newAfter !== -1 &&
+      newBefore !== newAfter
+    ) {
+      affected.add(newBefore)
+      affected.add(newAfter)
+    }
+  }
+
+  return affected
+}
+
 function selectChangedSentences(
   sentences: readonly Sentence[],
   changedRanges: readonly ChangedRange[],
   mergedBoundaries: readonly MergedBoundary[],
+  splitSentenceIndexes: ReadonlySet<number>,
 ): Sentence[] {
   const selected: Sentence[] = []
   let rangeIndex = 0
   let boundaryIndex = 0
 
-  for (const sentence of sentences) {
+  for (let sentenceIndex = 0; sentenceIndex < sentences.length; sentenceIndex++) {
+    const sentence = sentences[sentenceIndex]
+    if (!sentence) continue
     while (
       rangeIndex < changedRanges.length &&
       (changedRanges[rangeIndex]?.end ?? 0) <= sentence.startOffset
@@ -353,7 +508,9 @@ function selectChangedSentences(
     }
     boundaryIndex = nextBoundary
 
-    if (intersectsRange || containsBoundary) selected.push(sentence)
+    if (intersectsRange || containsBoundary || splitSentenceIndexes.has(sentenceIndex)) {
+      selected.push(sentence)
+    }
   }
 
   return selected
@@ -377,7 +534,13 @@ function sentenceSelector(text: string, previousText: string | undefined): Sente
     changes,
   )
 
-  return (sentences) => selectChangedSentences(sentences, changedRanges, mergedBoundaries)
+  return (sentences) =>
+    selectChangedSentences(
+      sentences,
+      changedRanges,
+      mergedBoundaries,
+      insertionSplitSentenceIndexes(previousSentences, sentences, currentProse, changes),
+    )
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -358,12 +358,12 @@ function containingSentenceIndexes(
   return result
 }
 
-interface MergedBoundary {
+interface DeletionBoundary {
   readonly before: number
   readonly after: number
 }
 
-function deletionMergeBoundaries(
+function deletionBoundaries(
   previousProse: string,
   currentProse: string,
   previousSentences: readonly Sentence[],
@@ -378,12 +378,14 @@ function deletionMergeBoundaries(
   const newAfter = nearestNonWhitespaceAfter(currentProse, currentOffsets)
   const oldBeforeSentences = containingSentenceIndexes(previousSentences, oldBefore)
   const oldAfterSentences = containingSentenceIndexes(previousSentences, oldAfter)
-  const boundaries: MergedBoundary[] = []
+  const boundaries: DeletionBoundary[] = []
 
   for (let index = 0; index < changes.deletions.length; index++) {
+    const deletion = changes.deletions[index]
     const before = newBefore[index]
     const after = newAfter[index]
     if (
+      deletion === undefined ||
       oldBefore[index] === undefined ||
       oldAfter[index] === undefined ||
       before === undefined ||
@@ -392,7 +394,9 @@ function deletionMergeBoundaries(
       continue
     }
     const beforeSentence = oldBeforeSentences[index]
-    if (beforeSentence !== -1 && beforeSentence === oldAfterSentences[index]) continue
+    const previousTogether = beforeSentence !== -1 && beforeSentence === oldAfterSentences[index]
+    const deletedProse = previousProse.slice(deletion.previousStart, deletion.previousEnd)
+    if (previousTogether && !/\S/u.test(deletedProse) && before + 1 < after) continue
     boundaries.push({ before, after })
   }
 
@@ -542,7 +546,7 @@ function changedSentenceIdentityIndexes(
 function selectChangedSentences(
   sentences: readonly Sentence[],
   changedRanges: readonly ChangedRange[],
-  mergedBoundaries: readonly MergedBoundary[],
+  deletionBoundaries: readonly DeletionBoundary[],
   changedSentenceIndexes: ReadonlySet<number>,
 ): Sentence[] {
   const selected: Sentence[] = []
@@ -574,18 +578,18 @@ function selectChangedSentences(
     }
 
     while (
-      boundaryIndex < mergedBoundaries.length &&
-      (mergedBoundaries[boundaryIndex]?.before ?? 0) < sentence.startOffset
+      boundaryIndex < deletionBoundaries.length &&
+      (deletionBoundaries[boundaryIndex]?.before ?? 0) < sentence.startOffset
     ) {
       boundaryIndex++
     }
     let nextBoundary = boundaryIndex
     let containsBoundary = false
     while (
-      nextBoundary < mergedBoundaries.length &&
-      (mergedBoundaries[nextBoundary]?.before ?? Number.POSITIVE_INFINITY) < sentence.endOffset
+      nextBoundary < deletionBoundaries.length &&
+      (deletionBoundaries[nextBoundary]?.before ?? Number.POSITIVE_INFINITY) < sentence.endOffset
     ) {
-      const boundary = mergedBoundaries[nextBoundary]
+      const boundary = deletionBoundaries[nextBoundary]
       if (boundary && contains(sentence, boundary.before) && contains(sentence, boundary.after)) {
         containsBoundary = true
       }
@@ -612,7 +616,7 @@ function sentenceSelector(text: string, previousText: string | undefined): Sente
     ...newlyVisibleRanges(previousText, text, changes),
   ])
   const previousSentences = segmentSentences(previousProse.split("\n"), previousText)
-  const mergedBoundaries = deletionMergeBoundaries(
+  const changedDeletionBoundaries = deletionBoundaries(
     previousProse,
     currentProse,
     previousSentences,
@@ -623,7 +627,7 @@ function sentenceSelector(text: string, previousText: string | undefined): Sente
     selectChangedSentences(
       sentences,
       changedRanges,
-      mergedBoundaries,
+      changedDeletionBoundaries,
       changedSentenceIdentityIndexes(
         previousSentences,
         sentences,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -2,11 +2,7 @@ import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
 import { type ChangedRange, type RetainedRange, type TextChanges, changedText } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
-import {
-  blankMarkdownCodeWithStructure,
-  maskMarkdownCode,
-  proseVisibility,
-} from "./markdown.ts"
+import { blankMarkdownCodeWithStructure, maskMarkdownCode, proseVisibility } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
@@ -112,9 +108,7 @@ const lintProse = (
   structuralBlanks: readonly boolean[],
   { maxSentenceWords, dictionary, tagger, selectSentences, diffOnly }: ResolvedOptions,
 ) => {
-  const sentences = selectSentences(
-    segmentSentences(lines, lines.join("\n"), structuralBlanks),
-  )
+  const sentences = selectSentences(segmentSentences(lines, lines.join("\n"), structuralBlanks))
   const selectedProse = diffOnly ? selectedProseLines(lines.join("\n"), sentences) : lines
   const selectedStructural = diffOnly
     ? selectedProseLines(structuralLines.join("\n"), sentences)

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -318,9 +318,20 @@ function selectChangedSentences(
     ) {
       rangeIndex++
     }
-    const range = changedRanges[rangeIndex]
-    const intersectsRange =
-      range !== undefined && range.start < sentence.endOffset && range.end > sentence.startOffset
+    let intersectsRange = false
+    for (const contentRange of sentence.contentRanges) {
+      while (
+        rangeIndex < changedRanges.length &&
+        (changedRanges[rangeIndex]?.end ?? 0) <= contentRange.start
+      ) {
+        rangeIndex++
+      }
+      const range = changedRanges[rangeIndex]
+      if (range && range.start < contentRange.end && range.end > contentRange.start) {
+        intersectsRange = true
+        break
+      }
+    }
 
     while (
       boundaryIndex < mergedBoundaries.length &&

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,11 +1,6 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
-import {
-  type ChangedRange,
-  changedText,
-  type RetainedRange,
-  type TextChanges,
-} from "./diff.ts"
+import { type ChangedRange, type RetainedRange, type TextChanges, changedText } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
 import {
   blankMarkdownCodeWithStructure,
@@ -232,8 +227,7 @@ function nearestRetainedProseBefore(
     while (cursor < query.offset && cursor < text.length) {
       while (
         retainedIndex < retained.length &&
-        (retained[retainedIndex]?.currentStart ?? 0) +
-          (retained[retainedIndex]?.length ?? 0) <=
+        (retained[retainedIndex]?.currentStart ?? 0) + (retained[retainedIndex]?.length ?? 0) <=
           cursor
       ) {
         retainedIndex++
@@ -511,10 +505,7 @@ function changedSentenceIdentityIndexes(
       ? offset
       : undefined,
   )
-  const deletionBeforeIndexes = containingSentenceIndexes(
-    previousSentences,
-    deletionBeforeOffsets,
-  )
+  const deletionBeforeIndexes = containingSentenceIndexes(previousSentences, deletionBeforeOffsets)
   const deletionAfterIndexes = containingSentenceIndexes(previousSentences, deletionAfterOffsets)
   const deletionEdges = changes.deletions
     .map((deletion, index) => ({

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,12 +1,11 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
-import { changedText } from "./diff.ts"
+import { type ChangedRange, changedText, type TextChanges } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
 import {
-  blankInlineCode,
-  blankMarkdownCode,
   blankMarkdownCodeWithStructure,
   maskMarkdownCode,
+  proseVisibility,
 } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
@@ -155,19 +154,51 @@ function contains(sentence: Sentence, offset: number): boolean {
   return sentence.startOffset <= offset && offset < sentence.endOffset
 }
 
+function newlyVisibleRanges(
+  previousText: string,
+  text: string,
+  changes: TextChanges,
+): ChangedRange[] {
+  const previousVisibility = proseVisibility(previousText)
+  const currentVisibility = proseVisibility(text)
+  const ranges: ChangedRange[] = []
+
+  for (const retained of changes.retained) {
+    let rangeStart: number | undefined
+    for (let index = 0; index < retained.length; index++) {
+      const previousOffset = retained.previousStart + index
+      const currentOffset = retained.currentStart + index
+      const newlyVisible =
+        previousVisibility[previousOffset] === 0 && currentVisibility[currentOffset] === 1
+      if (newlyVisible && rangeStart === undefined) rangeStart = currentOffset
+      if (!newlyVisible && rangeStart !== undefined) {
+        ranges.push({ start: rangeStart, end: currentOffset })
+        rangeStart = undefined
+      }
+    }
+    if (rangeStart !== undefined) {
+      ranges.push({ start: rangeStart, end: retained.currentStart + retained.length })
+    }
+  }
+
+  return ranges
+}
+
 function sentenceFilter(text: string, previousText: string | undefined): SentenceFilter {
   if (previousText === undefined) {
     return () => true
   }
 
-  const changes = changedText(maskMarkdownCode(previousText), maskMarkdownCode(text))
-  const previousLines = blankInlineCode(blankMarkdownCode(previousText.split("\n")))
-  const previousSentences = segmentSentences(previousLines, previousText)
+  const changes = changedText(previousText, text)
+  const previousProse = maskMarkdownCode(previousText)
+  const currentProse = maskMarkdownCode(text)
+  const changedRanges = [...changes.ranges, ...newlyVisibleRanges(previousText, text, changes)]
+  const previousSentences = segmentSentences(previousProse.split("\n"), previousText)
   const mergedBoundaries = changes.deletions.flatMap((deletion) => {
-    const oldBefore = nearestNonWhitespaceBefore(previousText, deletion.previousStart)
-    const oldAfter = nearestNonWhitespaceAfter(previousText, deletion.previousEnd)
-    const newBefore = nearestNonWhitespaceBefore(text, deletion.currentOffset)
-    const newAfter = nearestNonWhitespaceAfter(text, deletion.currentOffset)
+    const oldBefore = nearestNonWhitespaceBefore(previousProse, deletion.previousStart)
+    const oldAfter = nearestNonWhitespaceAfter(previousProse, deletion.previousEnd)
+    const newBefore = nearestNonWhitespaceBefore(currentProse, deletion.currentOffset)
+    const newAfter = nearestNonWhitespaceAfter(currentProse, deletion.currentOffset)
     if (
       oldBefore === undefined ||
       oldAfter === undefined ||
@@ -183,7 +214,7 @@ function sentenceFilter(text: string, previousText: string | undefined): Sentenc
   })
 
   return (sentence) =>
-    changes.ranges.some(
+    changedRanges.some(
       (range) => range.start < sentence.endOffset && range.end > sentence.startOffset,
     ) ||
     mergedBoundaries.some(

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -23,13 +23,13 @@ import type { LintKind, LintOptions, LintReport, Violation } from "./types.ts"
 
 export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
-type SentenceFilter = (sentence: Sentence) => boolean
+type SentenceSelector = (sentences: readonly Sentence[]) => readonly Sentence[]
 
 interface ResolvedOptions {
   readonly maxSentenceWords: number
   readonly dictionary?: Dictionary
   readonly tagger?: Tagger
-  readonly includeSentence: SentenceFilter
+  readonly selectSentences: SentenceSelector
 }
 
 interface ExtractedProse {
@@ -94,10 +94,10 @@ const lintProse = (
   mechanicalLines: readonly string[],
   contentStarts: readonly number[],
   structuralBlanks: readonly boolean[],
-  { maxSentenceWords, dictionary, tagger, includeSentence }: ResolvedOptions,
+  { maxSentenceWords, dictionary, tagger, selectSentences }: ResolvedOptions,
 ) => [
   ...sentenceLength(
-    segmentSentences(lines, lines.join("\n"), structuralBlanks).filter(includeSentence),
+    selectSentences(segmentSentences(lines, lines.join("\n"), structuralBlanks)),
     maxSentenceWords,
   ),
   ...paragraphLength(
@@ -136,18 +136,48 @@ const lintExtracted = (extracted: ExtractedProse, options: ResolvedOptions): Vio
   )
 }
 
-function nearestNonWhitespaceBefore(text: string, offset: number): number | undefined {
-  for (let index = offset - 1; index >= 0; index--) {
-    if (!/\s/u.test(text[index] ?? "")) return index
+function nearestNonWhitespaceBefore(
+  text: string,
+  offsets: readonly number[],
+): Array<number | undefined> {
+  const ordered = offsets
+    .map((offset, index) => ({ offset, index }))
+    .sort((left, right) => left.offset - right.offset)
+  const result: Array<number | undefined> = new Array(offsets.length)
+  let cursor = 0
+  let nearest: number | undefined
+
+  for (const query of ordered) {
+    while (cursor < query.offset && cursor < text.length) {
+      if (!/\s/u.test(text[cursor] ?? "")) nearest = cursor
+      cursor++
+    }
+    result[query.index] = nearest
   }
-  return undefined
+
+  return result
 }
 
-function nearestNonWhitespaceAfter(text: string, offset: number): number | undefined {
-  for (let index = offset; index < text.length; index++) {
-    if (!/\s/u.test(text[index] ?? "")) return index
+function nearestNonWhitespaceAfter(
+  text: string,
+  offsets: readonly number[],
+): Array<number | undefined> {
+  const ordered = offsets
+    .map((offset, index) => ({ offset, index }))
+    .sort((left, right) => right.offset - left.offset)
+  const result: Array<number | undefined> = new Array(offsets.length)
+  let cursor = text.length - 1
+  let nearest: number | undefined
+
+  for (const query of ordered) {
+    while (cursor >= query.offset) {
+      if (!/\s/u.test(text[cursor] ?? "")) nearest = cursor
+      cursor--
+    }
+    result[query.index] = nearest
   }
-  return undefined
+
+  return result
 }
 
 function contains(sentence: Sentence, offset: number): boolean {
@@ -184,42 +214,159 @@ function newlyVisibleRanges(
   return ranges
 }
 
-function sentenceFilter(text: string, previousText: string | undefined): SentenceFilter {
-  if (previousText === undefined) {
-    return () => true
+function containingSentenceIndexes(
+  sentences: readonly Sentence[],
+  offsets: readonly (number | undefined)[],
+): number[] {
+  const ordered: Array<{ offset: number; index: number }> = []
+  for (let index = 0; index < offsets.length; index++) {
+    const offset = offsets[index]
+    if (offset !== undefined) ordered.push({ offset, index })
   }
+  ordered.sort((left, right) => left.offset - right.offset)
+
+  const result = new Array<number>(offsets.length).fill(-1)
+  let sentenceIndex = 0
+  for (const query of ordered) {
+    while (
+      sentenceIndex < sentences.length &&
+      (sentences[sentenceIndex]?.endOffset ?? 0) <= query.offset
+    ) {
+      sentenceIndex++
+    }
+    const sentence = sentences[sentenceIndex]
+    if (sentence && contains(sentence, query.offset)) result[query.index] = sentenceIndex
+  }
+  return result
+}
+
+interface MergedBoundary {
+  readonly before: number
+  readonly after: number
+}
+
+function deletionMergeBoundaries(
+  previousProse: string,
+  currentProse: string,
+  previousSentences: readonly Sentence[],
+  changes: TextChanges,
+): MergedBoundary[] {
+  const previousStarts = changes.deletions.map((deletion) => deletion.previousStart)
+  const previousEnds = changes.deletions.map((deletion) => deletion.previousEnd)
+  const currentOffsets = changes.deletions.map((deletion) => deletion.currentOffset)
+  const oldBefore = nearestNonWhitespaceBefore(previousProse, previousStarts)
+  const oldAfter = nearestNonWhitespaceAfter(previousProse, previousEnds)
+  const newBefore = nearestNonWhitespaceBefore(currentProse, currentOffsets)
+  const newAfter = nearestNonWhitespaceAfter(currentProse, currentOffsets)
+  const oldBeforeSentences = containingSentenceIndexes(previousSentences, oldBefore)
+  const oldAfterSentences = containingSentenceIndexes(previousSentences, oldAfter)
+  const boundaries: MergedBoundary[] = []
+
+  for (let index = 0; index < changes.deletions.length; index++) {
+    const before = newBefore[index]
+    const after = newAfter[index]
+    if (
+      oldBefore[index] === undefined ||
+      oldAfter[index] === undefined ||
+      before === undefined ||
+      after === undefined
+    ) {
+      continue
+    }
+    const beforeSentence = oldBeforeSentences[index]
+    if (beforeSentence !== -1 && beforeSentence === oldAfterSentences[index]) continue
+    boundaries.push({ before, after })
+  }
+
+  return boundaries.sort((left, right) => left.before - right.before || left.after - right.after)
+}
+
+function normalizeRanges(ranges: readonly ChangedRange[]): ChangedRange[] {
+  const ordered = ranges
+    .filter((range) => range.start < range.end)
+    .sort((left, right) => left.start - right.start || left.end - right.end)
+  const normalized: ChangedRange[] = []
+
+  for (const range of ordered) {
+    const last = normalized.at(-1)
+    if (last && range.start <= last.end) {
+      normalized[normalized.length - 1] = {
+        start: last.start,
+        end: Math.max(last.end, range.end),
+      }
+    } else {
+      normalized.push(range)
+    }
+  }
+
+  return normalized
+}
+
+function selectChangedSentences(
+  sentences: readonly Sentence[],
+  changedRanges: readonly ChangedRange[],
+  mergedBoundaries: readonly MergedBoundary[],
+): Sentence[] {
+  const selected: Sentence[] = []
+  let rangeIndex = 0
+  let boundaryIndex = 0
+
+  for (const sentence of sentences) {
+    while (
+      rangeIndex < changedRanges.length &&
+      (changedRanges[rangeIndex]?.end ?? 0) <= sentence.startOffset
+    ) {
+      rangeIndex++
+    }
+    const range = changedRanges[rangeIndex]
+    const intersectsRange =
+      range !== undefined && range.start < sentence.endOffset && range.end > sentence.startOffset
+
+    while (
+      boundaryIndex < mergedBoundaries.length &&
+      (mergedBoundaries[boundaryIndex]?.before ?? 0) < sentence.startOffset
+    ) {
+      boundaryIndex++
+    }
+    let nextBoundary = boundaryIndex
+    let containsBoundary = false
+    while (
+      nextBoundary < mergedBoundaries.length &&
+      (mergedBoundaries[nextBoundary]?.before ?? Number.POSITIVE_INFINITY) < sentence.endOffset
+    ) {
+      const boundary = mergedBoundaries[nextBoundary]
+      if (boundary && contains(sentence, boundary.before) && contains(sentence, boundary.after)) {
+        containsBoundary = true
+      }
+      nextBoundary++
+    }
+    boundaryIndex = nextBoundary
+
+    if (intersectsRange || containsBoundary) selected.push(sentence)
+  }
+
+  return selected
+}
+
+function sentenceSelector(text: string, previousText: string | undefined): SentenceSelector {
+  if (previousText === undefined) return (sentences) => sentences
 
   const changes = changedText(previousText, text)
   const previousProse = maskMarkdownCode(previousText)
   const currentProse = maskMarkdownCode(text)
-  const changedRanges = [...changes.ranges, ...newlyVisibleRanges(previousText, text, changes)]
+  const changedRanges = normalizeRanges([
+    ...changes.ranges,
+    ...newlyVisibleRanges(previousText, text, changes),
+  ])
   const previousSentences = segmentSentences(previousProse.split("\n"), previousText)
-  const mergedBoundaries = changes.deletions.flatMap((deletion) => {
-    const oldBefore = nearestNonWhitespaceBefore(previousProse, deletion.previousStart)
-    const oldAfter = nearestNonWhitespaceAfter(previousProse, deletion.previousEnd)
-    const newBefore = nearestNonWhitespaceBefore(currentProse, deletion.currentOffset)
-    const newAfter = nearestNonWhitespaceAfter(currentProse, deletion.currentOffset)
-    if (
-      oldBefore === undefined ||
-      oldAfter === undefined ||
-      newBefore === undefined ||
-      newAfter === undefined
-    ) {
-      return []
-    }
-    const wasOneSentence = previousSentences.some(
-      (sentence) => contains(sentence, oldBefore) && contains(sentence, oldAfter),
-    )
-    return wasOneSentence ? [] : [{ before: newBefore, after: newAfter }]
-  })
+  const mergedBoundaries = deletionMergeBoundaries(
+    previousProse,
+    currentProse,
+    previousSentences,
+    changes,
+  )
 
-  return (sentence) =>
-    changedRanges.some(
-      (range) => range.start < sentence.endOffset && range.end > sentence.startOffset,
-    ) ||
-    mergedBoundaries.some(
-      (boundary) => contains(sentence, boundary.before) && contains(sentence, boundary.after),
-    )
+  return (sentences) => selectChangedSentences(sentences, changedRanges, mergedBoundaries)
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
@@ -228,7 +375,7 @@ export function lint(kind: LintKind, text: string, options: LintOptions = {}): L
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,
     tagger: options.tagger,
-    includeSentence: sentenceFilter(text, options.previousText),
+    selectSentences: sentenceSelector(text, options.previousText),
   }
   const raw = splitProseRuns(extracted).flatMap((run) =>
     lintExtracted(run, resolved).map((violation) => ({

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,8 +1,12 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
-import { changedLineNumbers } from "./diff.ts"
+import { changedText } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
-import { blankMarkdownCodeWithStructure } from "./markdown.ts"
+import {
+  blankInlineCode,
+  blankMarkdownCode,
+  blankMarkdownCodeWithStructure,
+} from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
@@ -93,7 +97,7 @@ const lintProse = (
   { maxSentenceWords, dictionary, tagger, includeSentence }: ResolvedOptions,
 ) => [
   ...sentenceLength(
-    segmentSentences(lines, structuralBlanks).filter(includeSentence),
+    segmentSentences(lines, lines.join("\n"), structuralBlanks).filter(includeSentence),
     maxSentenceWords,
   ),
   ...paragraphLength(
@@ -132,21 +136,58 @@ const lintExtracted = (extracted: ExtractedProse, options: ResolvedOptions): Vio
   )
 }
 
-// With a previousText, only sentences that touch a changed line are linted,
-// so pre-existing prose the author did not edit never blocks the edit.
+function nearestNonWhitespaceBefore(text: string, offset: number): number | undefined {
+  for (let index = offset - 1; index >= 0; index--) {
+    if (!/\s/u.test(text[index] ?? "")) return index
+  }
+  return undefined
+}
+
+function nearestNonWhitespaceAfter(text: string, offset: number): number | undefined {
+  for (let index = offset; index < text.length; index++) {
+    if (!/\s/u.test(text[index] ?? "")) return index
+  }
+  return undefined
+}
+
+function contains(sentence: Sentence, offset: number): boolean {
+  return sentence.startOffset <= offset && offset < sentence.endOffset
+}
+
 function sentenceFilter(text: string, previousText: string | undefined): SentenceFilter {
   if (previousText === undefined) {
     return () => true
   }
-  const changed = changedLineNumbers(previousText, text)
-  return (sentence) => {
-    for (let line = sentence.line; line <= sentence.endLine; line++) {
-      if (changed.has(line)) {
-        return true
-      }
+
+  const changes = changedText(previousText, text)
+  const previousLines = blankInlineCode(blankMarkdownCode(previousText.split("\n")))
+  const previousSentences = segmentSentences(previousLines, previousText)
+  const mergedBoundaries = changes.deletions.flatMap((deletion) => {
+    const oldBefore = nearestNonWhitespaceBefore(previousText, deletion.previousStart)
+    const oldAfter = nearestNonWhitespaceAfter(previousText, deletion.previousEnd)
+    const newBefore = nearestNonWhitespaceBefore(text, deletion.currentOffset)
+    const newAfter = nearestNonWhitespaceAfter(text, deletion.currentOffset)
+    if (
+      oldBefore === undefined ||
+      oldAfter === undefined ||
+      newBefore === undefined ||
+      newAfter === undefined
+    ) {
+      return []
     }
-    return false
-  }
+    const wasOneSentence = previousSentences.some(
+      (sentence) => contains(sentence, oldBefore) && contains(sentence, oldAfter),
+    )
+    return wasOneSentence ? [] : [{ before: newBefore, after: newAfter }]
+  })
+
+  return (sentence) =>
+    changes.ranges.some(
+      (range) => range.start < sentence.endOffset && range.end > sentence.startOffset,
+    ) ||
+    mergedBoundaries.some(
+      (boundary) => contains(sentence, boundary.before) && contains(sentence, boundary.after),
+    )
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -190,6 +190,49 @@ interface CorrespondingOffset {
   readonly previous: number
 }
 
+function nearestRetainedProseBefore(
+  text: string,
+  retained: readonly RetainedRange[],
+  offsets: readonly number[],
+): Array<CorrespondingOffset | undefined> {
+  const ordered = offsets
+    .map((offset, index) => ({ offset, index }))
+    .sort((left, right) => left.offset - right.offset)
+  const result: Array<CorrespondingOffset | undefined> = new Array(offsets.length)
+  let cursor = 0
+  let retainedIndex = 0
+  let nearest: CorrespondingOffset | undefined
+
+  for (const query of ordered) {
+    while (cursor < query.offset && cursor < text.length) {
+      while (
+        retainedIndex < retained.length &&
+        (retained[retainedIndex]?.currentStart ?? 0) +
+          (retained[retainedIndex]?.length ?? 0) <=
+          cursor
+      ) {
+        retainedIndex++
+      }
+      const range = retained[retainedIndex]
+      if (
+        range &&
+        range.currentStart <= cursor &&
+        cursor < range.currentStart + range.length &&
+        !/\s/u.test(text[cursor] ?? "")
+      ) {
+        nearest = {
+          current: cursor,
+          previous: range.previousStart + cursor - range.currentStart,
+        }
+      }
+      cursor++
+    }
+    result[query.index] = nearest
+  }
+
+  return result
+}
+
 function nearestRetainedProseAfter(
   text: string,
   retained: readonly RetainedRange[],
@@ -359,10 +402,22 @@ function changedSentenceIdentityIndexes(
   currentProse: string,
   changes: TextChanges,
 ): ReadonlySet<number> {
-  const retainedOffsets = nearestRetainedProseAfter(
-    currentProse,
-    changes.retained,
-    currentSentences.map((sentence) => sentence.startOffset),
+  const insertedRanges = normalizeRanges(changes.ranges)
+  const retainedOffsets = [
+    ...nearestRetainedProseBefore(
+      currentProse,
+      changes.retained,
+      insertedRanges.map((range) => range.start),
+    ),
+    ...nearestRetainedProseAfter(
+      currentProse,
+      changes.retained,
+      insertedRanges.map((range) => range.end),
+    ),
+  ]
+  const currentIndexes = containingSentenceIndexes(
+    currentSentences,
+    retainedOffsets.map((offset) => offset?.current),
   )
   const previousIndexes = containingSentenceIndexes(
     previousSentences,
@@ -370,20 +425,20 @@ function changedSentenceIdentityIndexes(
   )
   const changed = new Set<number>()
 
-  for (let index = 0; index < currentSentences.length; index++) {
-    const sentence = currentSentences[index]
-    const retainedOffset = retainedOffsets[index]
+  for (let index = 0; index < retainedOffsets.length; index++) {
+    const currentIndex = currentIndexes[index]
     const previousIndex = previousIndexes[index]
     if (
-      !sentence ||
-      !retainedOffset ||
-      !contains(sentence, retainedOffset.current) ||
+      currentIndex === undefined ||
+      currentIndex === -1 ||
       previousIndex === undefined ||
       previousIndex === -1
     ) {
       continue
     }
-    if (sentence.text !== previousSentences[previousIndex]?.text) changed.add(index)
+    if (currentSentences[currentIndex]?.text !== previousSentences[previousIndex]?.text) {
+      changed.add(currentIndex)
+    }
   }
 
   return changed

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,5 +1,6 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
+import { changedLineNumbers } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
 import { blankMarkdownCodeWithStructure } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
@@ -12,16 +13,19 @@ import { phrasalVerb } from "./rules/phrasal-verb.ts"
 import { semicolon } from "./rules/semicolon.ts"
 import { sentenceLength } from "./rules/sentence-length.ts"
 import { verbForm } from "./rules/verb-form.ts"
-import { segmentSentences } from "./sentences.ts"
+import { type Sentence, segmentSentences } from "./sentences.ts"
 import type { Tagger } from "./tagger.ts"
 import type { LintKind, LintOptions, LintReport, Violation } from "./types.ts"
 
 export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
+type SentenceFilter = (sentence: Sentence) => boolean
+
 interface ResolvedOptions {
   readonly maxSentenceWords: number
   readonly dictionary?: Dictionary
   readonly tagger?: Tagger
+  readonly includeSentence: SentenceFilter
 }
 
 interface ExtractedProse {
@@ -86,9 +90,12 @@ const lintProse = (
   mechanicalLines: readonly string[],
   contentStarts: readonly number[],
   structuralBlanks: readonly boolean[],
-  { maxSentenceWords, dictionary, tagger }: ResolvedOptions,
+  { maxSentenceWords, dictionary, tagger, includeSentence }: ResolvedOptions,
 ) => [
-  ...sentenceLength(segmentSentences(lines, structuralBlanks), maxSentenceWords),
+  ...sentenceLength(
+    segmentSentences(lines, structuralBlanks).filter(includeSentence),
+    maxSentenceWords,
+  ),
   ...paragraphLength(
     segmentParagraphs(
       structuralLines.map((line, index) => line.slice(contentStarts[index] ?? 0)),
@@ -125,12 +132,30 @@ const lintExtracted = (extracted: ExtractedProse, options: ResolvedOptions): Vio
   )
 }
 
+// With a previousText, only sentences that touch a changed line are linted,
+// so pre-existing prose the author did not edit never blocks the edit.
+function sentenceFilter(text: string, previousText: string | undefined): SentenceFilter {
+  if (previousText === undefined) {
+    return () => true
+  }
+  const changed = changedLineNumbers(previousText, text)
+  return (sentence) => {
+    for (let line = sentence.line; line <= sentence.endLine; line++) {
+      if (changed.has(line)) {
+        return true
+      }
+    }
+    return false
+  }
+}
+
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
   const extracted = extract(kind, text, options)
   const resolved = {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,
     tagger: options.tagger,
+    includeSentence: sentenceFilter(text, options.previousText),
   }
   const raw = splitProseRuns(extracted).flatMap((run) =>
     lintExtracted(run, resolved).map((violation) => ({

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -39,9 +39,10 @@ interface ResolvedOptions {
 }
 
 function selectedProseLines(text: string, sentences: readonly Sentence[]): string[] {
-  const selected: string[] = Array.from(text, (character) =>
-    character === "\n" || character === "\r" ? character : " ",
-  )
+  const selected: string[] = Array.from({ length: text.length }, (_, offset) => {
+    const character = text[offset]
+    return character === "\n" || character === "\r" ? character : " "
+  })
   for (const sentence of sentences) {
     for (const range of sentence.contentRanges) {
       for (let offset = range.start; offset < range.end; offset++) {

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -359,8 +359,16 @@ function containingSentenceIndexes(
 }
 
 interface DeletionBoundary {
-  readonly before: number
-  readonly after: number
+  readonly before?: number
+  readonly after?: number
+}
+
+function deletionBoundaryStart(boundary: DeletionBoundary): number {
+  return boundary.before ?? boundary.after ?? Number.POSITIVE_INFINITY
+}
+
+function deletionBoundaryEnd(boundary: DeletionBoundary): number {
+  return boundary.after ?? boundary.before ?? Number.NEGATIVE_INFINITY
 }
 
 function deletionBoundaries(
@@ -368,7 +376,7 @@ function deletionBoundaries(
   currentProse: string,
   previousSentences: readonly Sentence[],
   changes: TextChanges,
-): MergedBoundary[] {
+): DeletionBoundary[] {
   const previousStarts = changes.deletions.map((deletion) => deletion.previousStart)
   const previousEnds = changes.deletions.map((deletion) => deletion.previousEnd)
   const currentOffsets = changes.deletions.map((deletion) => deletion.currentOffset)
@@ -376,31 +384,66 @@ function deletionBoundaries(
   const oldAfter = nearestNonWhitespaceAfter(previousProse, previousEnds)
   const newBefore = nearestNonWhitespaceBefore(currentProse, currentOffsets)
   const newAfter = nearestNonWhitespaceAfter(currentProse, currentOffsets)
+  const deletedFirst = nearestNonWhitespaceAfter(previousProse, previousStarts).map(
+    (offset, index) =>
+      offset !== undefined && offset < (changes.deletions[index]?.previousEnd ?? 0)
+        ? offset
+        : undefined,
+  )
+  const deletedLast = nearestNonWhitespaceBefore(previousProse, previousEnds).map(
+    (offset, index) =>
+      offset !== undefined && offset >= (changes.deletions[index]?.previousStart ?? 0)
+        ? offset
+        : undefined,
+  )
   const oldBeforeSentences = containingSentenceIndexes(previousSentences, oldBefore)
   const oldAfterSentences = containingSentenceIndexes(previousSentences, oldAfter)
+  const deletedFirstSentences = containingSentenceIndexes(previousSentences, deletedFirst)
+  const deletedLastSentences = containingSentenceIndexes(previousSentences, deletedLast)
   const boundaries: DeletionBoundary[] = []
 
   for (let index = 0; index < changes.deletions.length; index++) {
     const deletion = changes.deletions[index]
     const before = newBefore[index]
     const after = newAfter[index]
-    if (
-      deletion === undefined ||
-      oldBefore[index] === undefined ||
-      oldAfter[index] === undefined ||
-      before === undefined ||
-      after === undefined
-    ) {
+    if (deletion === undefined || (before === undefined && after === undefined)) continue
+
+    const beforeSentence = oldBeforeSentences[index] ?? -1
+    const afterSentence = oldAfterSentences[index] ?? -1
+    const deletedProse = previousProse.slice(deletion.previousStart, deletion.previousEnd)
+
+    if (before !== undefined && after !== undefined) {
+      if (beforeSentence === -1 || afterSentence === -1) continue
+      const previousTogether = beforeSentence === afterSentence
+      if (previousTogether && !/\S/u.test(deletedProse) && before + 1 < after) continue
+      boundaries.push({ before, after })
       continue
     }
-    const beforeSentence = oldBeforeSentences[index]
-    const previousTogether = beforeSentence !== -1 && beforeSentence === oldAfterSentences[index]
-    const deletedProse = previousProse.slice(deletion.previousStart, deletion.previousEnd)
-    if (previousTogether && !/\S/u.test(deletedProse) && before + 1 < after) continue
-    boundaries.push({ before, after })
+
+    if (!/\S/u.test(deletedProse)) continue
+    if (
+      before === undefined &&
+      after !== undefined &&
+      afterSentence !== -1 &&
+      deletedLastSentences[index] === afterSentence
+    ) {
+      boundaries.push({ after })
+    }
+    if (
+      after === undefined &&
+      before !== undefined &&
+      beforeSentence !== -1 &&
+      deletedFirstSentences[index] === beforeSentence
+    ) {
+      boundaries.push({ before })
+    }
   }
 
-  return boundaries.sort((left, right) => left.before - right.before || left.after - right.after)
+  return boundaries.sort(
+    (left, right) =>
+      deletionBoundaryStart(left) - deletionBoundaryStart(right) ||
+      deletionBoundaryEnd(left) - deletionBoundaryEnd(right),
+  )
 }
 
 function normalizeRanges(ranges: readonly ChangedRange[]): ChangedRange[] {
@@ -579,7 +622,7 @@ function selectChangedSentences(
 
     while (
       boundaryIndex < deletionBoundaries.length &&
-      (deletionBoundaries[boundaryIndex]?.before ?? 0) < sentence.startOffset
+      deletionBoundaryEnd(deletionBoundaries[boundaryIndex] ?? {}) < sentence.startOffset
     ) {
       boundaryIndex++
     }
@@ -587,10 +630,14 @@ function selectChangedSentences(
     let containsBoundary = false
     while (
       nextBoundary < deletionBoundaries.length &&
-      (deletionBoundaries[nextBoundary]?.before ?? Number.POSITIVE_INFINITY) < sentence.endOffset
+      deletionBoundaryStart(deletionBoundaries[nextBoundary] ?? {}) < sentence.endOffset
     ) {
       const boundary = deletionBoundaries[nextBoundary]
-      if (boundary && contains(sentence, boundary.before) && contains(sentence, boundary.after)) {
+      if (
+        boundary &&
+        (boundary.before === undefined || contains(sentence, boundary.before)) &&
+        (boundary.after === undefined || contains(sentence, boundary.after))
+      ) {
         containsBoundary = true
       }
       nextBoundary++

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -190,49 +190,6 @@ interface CorrespondingOffset {
   readonly previous: number
 }
 
-function nearestRetainedProseBefore(
-  text: string,
-  retained: readonly RetainedRange[],
-  offsets: readonly number[],
-): Array<CorrespondingOffset | undefined> {
-  const ordered = offsets
-    .map((offset, index) => ({ offset, index }))
-    .sort((left, right) => left.offset - right.offset)
-  const result: Array<CorrespondingOffset | undefined> = new Array(offsets.length)
-  let cursor = 0
-  let retainedIndex = 0
-  let nearest: CorrespondingOffset | undefined
-
-  for (const query of ordered) {
-    while (cursor < query.offset && cursor < text.length) {
-      while (
-        retainedIndex < retained.length &&
-        (retained[retainedIndex]?.currentStart ?? 0) +
-          (retained[retainedIndex]?.length ?? 0) <=
-          cursor
-      ) {
-        retainedIndex++
-      }
-      const range = retained[retainedIndex]
-      if (
-        range &&
-        range.currentStart <= cursor &&
-        cursor < range.currentStart + range.length &&
-        !/\s/u.test(text[cursor] ?? "")
-      ) {
-        nearest = {
-          current: cursor,
-          previous: range.previousStart + cursor - range.currentStart,
-        }
-      }
-      cursor++
-    }
-    result[query.index] = nearest
-  }
-
-  return result
-}
-
 function nearestRetainedProseAfter(
   text: string,
   retained: readonly RetainedRange[],
@@ -396,69 +353,47 @@ function normalizeRanges(ranges: readonly ChangedRange[]): ChangedRange[] {
   return normalized
 }
 
-function insertionSplitSentenceIndexes(
+function changedSentenceIdentityIndexes(
   previousSentences: readonly Sentence[],
   currentSentences: readonly Sentence[],
   currentProse: string,
   changes: TextChanges,
 ): ReadonlySet<number> {
-  const insertions = normalizeRanges(changes.ranges)
-  const before = nearestRetainedProseBefore(
+  const retainedOffsets = nearestRetainedProseAfter(
     currentProse,
     changes.retained,
-    insertions.map((range) => range.start),
+    currentSentences.map((sentence) => sentence.startOffset),
   )
-  const after = nearestRetainedProseAfter(
-    currentProse,
-    changes.retained,
-    insertions.map((range) => range.end),
-  )
-  const previousBefore = containingSentenceIndexes(
+  const previousIndexes = containingSentenceIndexes(
     previousSentences,
-    before.map((offset) => offset?.previous),
+    retainedOffsets.map((offset) => offset?.previous),
   )
-  const previousAfter = containingSentenceIndexes(
-    previousSentences,
-    after.map((offset) => offset?.previous),
-  )
-  const currentBefore = containingSentenceIndexes(
-    currentSentences,
-    before.map((offset) => offset?.current),
-  )
-  const currentAfter = containingSentenceIndexes(
-    currentSentences,
-    after.map((offset) => offset?.current),
-  )
-  const affected = new Set<number>()
+  const changed = new Set<number>()
 
-  for (let index = 0; index < insertions.length; index++) {
-    const oldBefore = previousBefore[index]
-    const oldAfter = previousAfter[index]
-    const newBefore = currentBefore[index]
-    const newAfter = currentAfter[index]
+  for (let index = 0; index < currentSentences.length; index++) {
+    const sentence = currentSentences[index]
+    const retainedOffset = retainedOffsets[index]
+    const previousIndex = previousIndexes[index]
     if (
-      oldBefore !== undefined &&
-      oldBefore !== -1 &&
-      oldBefore === oldAfter &&
-      newBefore !== undefined &&
-      newBefore !== -1 &&
-      newAfter !== undefined &&
-      newAfter !== -1 &&
-      newBefore !== newAfter
+      !sentence ||
+      !retainedOffset ||
+      !contains(sentence, retainedOffset.current) ||
+      previousIndex === undefined ||
+      previousIndex === -1
     ) {
-      affected.add(newBefore)
-      affected.add(newAfter)
+      continue
     }
+    if (sentence.text !== previousSentences[previousIndex]?.text) changed.add(index)
   }
 
-  return affected
+  return changed
 }
 
 function selectChangedSentences(
   sentences: readonly Sentence[],
   changedRanges: readonly ChangedRange[],
   mergedBoundaries: readonly MergedBoundary[],
-  splitSentenceIndexes: ReadonlySet<number>,
+  changedSentenceIndexes: ReadonlySet<number>,
 ): Sentence[] {
   const selected: Sentence[] = []
   let rangeIndex = 0
@@ -508,7 +443,7 @@ function selectChangedSentences(
     }
     boundaryIndex = nextBoundary
 
-    if (intersectsRange || containsBoundary || splitSentenceIndexes.has(sentenceIndex)) {
+    if (intersectsRange || containsBoundary || changedSentenceIndexes.has(sentenceIndex)) {
       selected.push(sentence)
     }
   }
@@ -539,7 +474,7 @@ function sentenceSelector(text: string, previousText: string | undefined): Sente
       sentences,
       changedRanges,
       mergedBoundaries,
-      insertionSplitSentenceIndexes(previousSentences, sentences, currentProse, changes),
+      changedSentenceIdentityIndexes(previousSentences, sentences, currentProse, changes),
     )
 }
 

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -399,22 +399,22 @@ function normalizeRanges(ranges: readonly ChangedRange[]): ChangedRange[] {
 function changedSentenceIdentityIndexes(
   previousSentences: readonly Sentence[],
   currentSentences: readonly Sentence[],
+  previousProse: string,
   currentProse: string,
   changes: TextChanges,
 ): ReadonlySet<number> {
   const insertedRanges = normalizeRanges(changes.ranges)
-  const retainedOffsets = [
-    ...nearestRetainedProseBefore(
-      currentProse,
-      changes.retained,
-      insertedRanges.map((range) => range.start),
-    ),
-    ...nearestRetainedProseAfter(
-      currentProse,
-      changes.retained,
-      insertedRanges.map((range) => range.end),
-    ),
-  ]
+  const before = nearestRetainedProseBefore(
+    currentProse,
+    changes.retained,
+    insertedRanges.map((range) => range.start),
+  )
+  const after = nearestRetainedProseAfter(
+    currentProse,
+    changes.retained,
+    insertedRanges.map((range) => range.end),
+  )
+  const retainedOffsets = [...before, ...after]
   const currentIndexes = containingSentenceIndexes(
     currentSentences,
     retainedOffsets.map((offset) => offset?.current),
@@ -423,21 +423,92 @@ function changedSentenceIdentityIndexes(
     previousSentences,
     retainedOffsets.map((offset) => offset?.previous),
   )
+  const deletionBeforeOffsets = nearestNonWhitespaceBefore(
+    previousProse,
+    changes.deletions.map((deletion) => deletion.previousEnd),
+  ).map((offset, index) =>
+    offset !== undefined && offset >= (changes.deletions[index]?.previousStart ?? 0)
+      ? offset
+      : undefined,
+  )
+  const deletionAfterOffsets = nearestNonWhitespaceAfter(
+    previousProse,
+    changes.deletions.map((deletion) => deletion.previousStart),
+  ).map((offset, index) =>
+    offset !== undefined && offset < (changes.deletions[index]?.previousEnd ?? 0)
+      ? offset
+      : undefined,
+  )
+  const deletionBeforeIndexes = containingSentenceIndexes(
+    previousSentences,
+    deletionBeforeOffsets,
+  )
+  const deletionAfterIndexes = containingSentenceIndexes(previousSentences, deletionAfterOffsets)
+  const deletionEdges = changes.deletions
+    .map((deletion, index) => ({
+      currentOffset: deletion.currentOffset,
+      beforeSentence: deletionBeforeIndexes[index] ?? -1,
+      afterSentence: deletionAfterIndexes[index] ?? -1,
+    }))
+    .sort((left, right) => left.currentOffset - right.currentOffset)
   const changed = new Set<number>()
+  let deletionIndex = 0
 
-  for (let index = 0; index < retainedOffsets.length; index++) {
-    const currentIndex = currentIndexes[index]
-    const previousIndex = previousIndexes[index]
-    if (
-      currentIndex === undefined ||
-      currentIndex === -1 ||
-      previousIndex === undefined ||
-      previousIndex === -1
-    ) {
-      continue
+  for (let rangeIndex = 0; rangeIndex < insertedRanges.length; rangeIndex++) {
+    const range = insertedRanges[rangeIndex]
+    if (!range) continue
+    const beforeOffset = before[rangeIndex]
+    const afterOffset = after[rangeIndex]
+    const beforeCurrent = currentIndexes[rangeIndex] ?? -1
+    const afterCurrent = currentIndexes[insertedRanges.length + rangeIndex] ?? -1
+    const beforePrevious = previousIndexes[rangeIndex] ?? -1
+    const afterPrevious = previousIndexes[insertedRanges.length + rangeIndex] ?? -1
+    const hasBefore = beforeOffset !== undefined && beforeCurrent !== -1 && beforePrevious !== -1
+    const hasAfter = afterOffset !== undefined && afterCurrent !== -1 && afterPrevious !== -1
+
+    if (hasBefore && hasAfter) {
+      const previousTogether = beforePrevious === afterPrevious
+      const currentTogether = beforeCurrent === afterCurrent
+      if (previousTogether !== currentTogether) {
+        changed.add(beforeCurrent)
+        changed.add(afterCurrent)
+      } else if (
+        previousTogether &&
+        currentTogether &&
+        beforeOffset.previous + 1 === afterOffset.previous &&
+        beforeOffset.current + 1 < afterOffset.current
+      ) {
+        let separatorOnly = true
+        for (let offset = range.start; offset < range.end; offset++) {
+          if (!/\s/u.test(currentProse[offset] ?? "")) {
+            separatorOnly = false
+            break
+          }
+        }
+        if (separatorOnly) changed.add(beforeCurrent)
+      }
     }
-    if (currentSentences[currentIndex]?.text !== previousSentences[previousIndex]?.text) {
-      changed.add(currentIndex)
+
+    while (
+      deletionIndex < deletionEdges.length &&
+      (deletionEdges[deletionIndex]?.currentOffset ?? 0) < range.start
+    ) {
+      deletionIndex++
+    }
+    for (
+      let localDeletion = deletionIndex;
+      localDeletion < deletionEdges.length &&
+      (deletionEdges[localDeletion]?.currentOffset ?? Number.POSITIVE_INFINITY) <= range.end;
+      localDeletion++
+    ) {
+      const deletion = deletionEdges[localDeletion]
+      if (!deletion) continue
+      if (!hasBefore && hasAfter && deletion.beforeSentence === afterPrevious) {
+        changed.add(afterCurrent)
+      }
+      if (hasBefore && !hasAfter && deletion.afterSentence === beforePrevious) {
+        changed.add(beforeCurrent)
+      }
     }
   }
 
@@ -529,7 +600,13 @@ function sentenceSelector(text: string, previousText: string | undefined): Sente
       sentences,
       changedRanges,
       mergedBoundaries,
-      changedSentenceIdentityIndexes(previousSentences, sentences, currentProse, changes),
+      changedSentenceIdentityIndexes(
+        previousSentences,
+        sentences,
+        previousProse,
+        currentProse,
+        changes,
+      ),
     )
 }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -315,3 +315,24 @@ function blankInlineCodeLine(line: string): string {
 export function blankInlineCode(lines: readonly string[]): string[] {
   return lines.map(blankInlineCodeLine)
 }
+
+export function proseVisibility(text: string): Uint8Array {
+  const visibility = new Uint8Array(text.length)
+  const sourceLines = text.split("\n")
+  const proseLines = blankMarkdownCode(sourceLines)
+  let offset = 0
+
+  for (let index = 0; index < sourceLines.length; index++) {
+    const line = sourceLines[index] ?? ""
+    if (line === proseLines[index]) {
+      visibility.fill(1, offset, offset + line.length)
+    }
+    offset += line.length
+    if (offset < text.length) {
+      visibility[offset] = 1
+      offset++
+    }
+  }
+
+  return visibility
+}

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -270,6 +270,10 @@ export function blankMarkdownCode(
   return blankMarkdownCodeWithStructure(inputLines, contentStarts).lines
 }
 
+export function maskMarkdownCode(text: string): string {
+  return blankMarkdownCode(text.split("\n")).join("\n")
+}
+
 interface InlineBacktickRun {
   readonly start: number
   readonly length: number

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -5,6 +5,10 @@ export interface Sentence {
   readonly endLine: number
   readonly startOffset: number
   readonly endOffset: number
+  readonly contentRanges: readonly {
+    readonly start: number
+    readonly end: number
+  }[]
 }
 
 const CLOSING_DELIMITERS = new Set([
@@ -197,7 +201,20 @@ export function segmentSentences(
     startOffset: number
     endOffset: number
     parts: string[]
+    contentRanges: Array<{ start: number; end: number }>
   } | null = null
+
+  const appendPart = (part: string, startOffset: number) => {
+    if (!open) return
+    const leadingWhitespace = part.length - part.trimStart().length
+    const text = part.trim()
+    open.parts.push(text)
+    if (text === "") return
+    const start = startOffset + leadingWhitespace
+    const end = start + text.length
+    open.contentRanges.push({ start, end })
+    open.endOffset = end
+  }
 
   const close = () => {
     if (!open) return
@@ -210,6 +227,7 @@ export function segmentSentences(
         endLine: open.endLine,
         startOffset: open.startOffset,
         endOffset: open.endOffset,
+        contentRanges: open.contentRanges,
       })
     }
     open = null
@@ -233,11 +251,11 @@ export function segmentSentences(
           startOffset,
           endOffset: startOffset,
           parts: [],
+          contentRanges: [],
         }
       }
       open.endLine = index + 1
-      open.parts.push(part.trim())
-      open.endOffset = (lineOffsets[index] ?? 0) + end
+      appendPart(part, (lineOffsets[index] ?? 0) + offset)
       close()
       offset = end
     }
@@ -254,11 +272,11 @@ export function segmentSentences(
           startOffset,
           endOffset: startOffset,
           parts: [],
+          contentRanges: [],
         }
       }
       open.endLine = index + 1
-      open.parts.push(rest.trim())
-      open.endOffset = (lineOffsets[index] ?? 0) + raw.trimEnd().length
+      appendPart(rest, (lineOffsets[index] ?? 0) + offset)
     }
   })
   close()

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -3,6 +3,8 @@ export interface Sentence {
   readonly line: number
   readonly column: number
   readonly endLine: number
+  readonly startOffset: number
+  readonly endOffset: number
 }
 
 const CLOSING_DELIMITERS = new Set([
@@ -180,16 +182,35 @@ function sentenceTerminatorEnds(text: string): number[] {
 // Sentences may span lines; position is where the sentence starts (1-based).
 export function segmentSentences(
   lines: readonly string[],
+  sourceText: string = lines.join("\n"),
   structuralBlanks: readonly boolean[] = lines.map((line) => line.trim() === ""),
 ): Sentence[] {
   const sentences: Sentence[] = []
-  let open: { line: number; column: number; endLine: number; parts: string[] } | null = null
+  const lineOffsets = [0]
+  for (let index = 0; index < sourceText.length; index++) {
+    if (sourceText[index] === "\n") lineOffsets.push(index + 1)
+  }
+  let open: {
+    line: number
+    column: number
+    endLine: number
+    startOffset: number
+    endOffset: number
+    parts: string[]
+  } | null = null
 
   const close = () => {
     if (!open) return
     const text = open.parts.join(" ").trim()
     if (text !== "") {
-      sentences.push({ text, line: open.line, column: open.column, endLine: open.endLine })
+      sentences.push({
+        text,
+        line: open.line,
+        column: open.column,
+        endLine: open.endLine,
+        startOffset: open.startOffset,
+        endOffset: open.endOffset,
+      })
     }
     open = null
   }
@@ -204,15 +225,19 @@ export function segmentSentences(
       const part = raw.slice(offset, end)
       if (!open) {
         const indent = part.length - part.trimStart().length
+        const startOffset = (lineOffsets[index] ?? 0) + offset + indent
         open = {
           line: index + 1,
           column: offset + indent + 1,
           endLine: index + 1,
+          startOffset,
+          endOffset: startOffset,
           parts: [],
         }
       }
       open.endLine = index + 1
       open.parts.push(part.trim())
+      open.endOffset = (lineOffsets[index] ?? 0) + end
       close()
       offset = end
     }
@@ -221,15 +246,19 @@ export function segmentSentences(
     if (rest.trim() !== "") {
       if (!open) {
         const indent = rest.length - rest.trimStart().length
+        const startOffset = (lineOffsets[index] ?? 0) + offset + indent
         open = {
           line: index + 1,
           column: offset + indent + 1,
           endLine: index + 1,
+          startOffset,
+          endOffset: startOffset,
           parts: [],
         }
       }
       open.endLine = index + 1
       open.parts.push(rest.trim())
+      open.endOffset = (lineOffsets[index] ?? 0) + raw.trimEnd().length
     }
   })
   close()

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -2,6 +2,7 @@ export interface Sentence {
   readonly text: string
   readonly line: number
   readonly column: number
+  readonly endLine: number
 }
 
 const CLOSING_DELIMITERS = new Set([
@@ -182,13 +183,13 @@ export function segmentSentences(
   structuralBlanks: readonly boolean[] = lines.map((line) => line.trim() === ""),
 ): Sentence[] {
   const sentences: Sentence[] = []
-  let open: { line: number; column: number; parts: string[] } | null = null
+  let open: { line: number; column: number; endLine: number; parts: string[] } | null = null
 
   const close = () => {
     if (!open) return
     const text = open.parts.join(" ").trim()
     if (text !== "") {
-      sentences.push({ text, line: open.line, column: open.column })
+      sentences.push({ text, line: open.line, column: open.column, endLine: open.endLine })
     }
     open = null
   }
@@ -203,8 +204,14 @@ export function segmentSentences(
       const part = raw.slice(offset, end)
       if (!open) {
         const indent = part.length - part.trimStart().length
-        open = { line: index + 1, column: offset + indent + 1, parts: [] }
+        open = {
+          line: index + 1,
+          column: offset + indent + 1,
+          endLine: index + 1,
+          parts: [],
+        }
       }
+      open.endLine = index + 1
       open.parts.push(part.trim())
       close()
       offset = end
@@ -214,8 +221,14 @@ export function segmentSentences(
     if (rest.trim() !== "") {
       if (!open) {
         const indent = rest.length - rest.trimStart().length
-        open = { line: index + 1, column: offset + indent + 1, parts: [] }
+        open = {
+          line: index + 1,
+          column: offset + indent + 1,
+          endLine: index + 1,
+          parts: [],
+        }
       }
+      open.endLine = index + 1
       open.parts.push(rest.trim())
     }
   })

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -27,6 +27,7 @@ export interface LintOptions {
   // POS tagger for the verb-form rules and POS-aware dictionary entries.
   readonly tagger?: Tagger
   readonly sourceDialect?: SourceDialect
+  readonly previousText?: string
 }
 
 export interface LintReport {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -27,6 +27,12 @@ export interface LintOptions {
   // POS tagger for the verb-form rules and POS-aware dictionary entries.
   readonly tagger?: Tagger
   readonly sourceDialect?: SourceDialect
+  /**
+   * The prior document text used to lint only sentences affected by changes.
+   * Affected sentences can contain both changed text and retained context.
+   * Omit this value to lint the current document in full.
+   * Deletions do not report removed content, and violation positions refer to the current text.
+   */
   readonly previousText?: string
 }
 

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -31,7 +31,8 @@ export interface LintOptions {
    * The prior document text used to lint only sentences affected by changes.
    * Affected sentences can contain both changed text and retained context.
    * Omit this value to lint the current document in full.
-   * Deletions do not report removed content, and violation positions refer to the current text.
+   * A deletion can affect adjacent current sentences but never reports removed content.
+   * Violation positions refer to the current text.
    */
   readonly previousText?: string
 }

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -56,6 +56,22 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
+  test("changing a line ending within a multi-line sentence does not report it", () => {
+    const previous = `${words(15)}\n${words(15)}.`
+    const current = `${words(15)}\r\n${words(15)}.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("editing content within a multi-line sentence reports it", () => {
+    const previous = `${words(15)}\n${words(15)}.`
+    const current = `${words(15)}\n${words(14)} changed.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
   test("appending whitespace does not report an unchanged unterminated sentence", () => {
     const previous = words(30)
     const current = `${previous} `

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -188,12 +188,15 @@ describe("lint prose-file: diff-only linting via previousText", () => {
   test.each([
     ["xapproximately.", "approximately."],
     ["approximatelyx", "approximately"],
-  ])("deleting prose at a sentence edge can create a dictionary violation: %s", (previous, current) => {
-    const report = lint("prose-file", current, { previousText: previous, dictionary })
+  ])(
+    "deleting prose at a sentence edge can create a dictionary violation: %s",
+    (previous, current) => {
+      const report = lint("prose-file", current, { previousText: previous, dictionary })
 
-    expect(report.violations).toHaveLength(1)
-    expect(report.violations[0]?.message).toContain('not "approximately"')
-  })
+      expect(report.violations).toHaveLength(1)
+      expect(report.violations[0]?.message).toContain('not "approximately"')
+    },
+  )
 
   test("an astral character before a changed line does not shift its dictionary position", () => {
     const previous = "😀 Intro.\napproximatelyx."
@@ -216,20 +219,26 @@ describe("lint prose-file: diff-only linting via previousText", () => {
   test.each([
     [" approximately.", "approximately."],
     ["approximately. ", "approximately."],
-  ])("deleting whitespace at a sentence edge does not report an existing violation: %s", (previous, current) => {
-    expect(
-      lint("prose-file", current, { previousText: previous, dictionary }).violations,
-    ).toHaveLength(0)
-  })
+  ])(
+    "deleting whitespace at a sentence edge does not report an existing violation: %s",
+    (previous, current) => {
+      expect(
+        lint("prose-file", current, { previousText: previous, dictionary }).violations,
+      ).toHaveLength(0)
+    },
+  )
 
   test.each([
     ["Remove this sentence. Approximately.", "Approximately."],
     ["Approximately. Remove this sentence.", "Approximately."],
-  ])("deleting a complete sentence at an edge does not report its neighbor: %s", (previous, current) => {
-    expect(
-      lint("prose-file", current, { previousText: previous, dictionary }).violations,
-    ).toHaveLength(0)
-  })
+  ])(
+    "deleting a complete sentence at an edge does not report its neighbor: %s",
+    (previous, current) => {
+      expect(
+        lint("prose-file", current, { previousText: previous, dictionary }).violations,
+      ).toHaveLength(0)
+    },
+  )
 
   test("deleting duplicate internal whitespace does not report an existing violation", () => {
     const previous = "Do this prior  to assembly."

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -167,6 +167,22 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
+  test("an excluded-code insertion does not select unrelated deletion-only prose", () => {
+    const previous = `${words(15)}  ${words(15)}.\n\n\`\`\`\nconst oldValue = 1;\n\`\`\``
+    const current = `${words(15)} ${words(15)}.\n\n\`\`\`\nconst newValue = 1;\n\`\`\``
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("a prose insertion stays selected beside unrelated deletion-only prose", () => {
+    const previous = `${words(15)}  ${words(15)}.\n\n${words(25)}.`
+    const current = `${words(15)} ${words(15)}.\n\nextra ${words(25)}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
+  })
+
   test("deleting one paragraph does not surface untouched pre-existing violations", () => {
     const previous = `${words(30)}.\n\n${words(28)}.`
     const current = `${words(28)}.`

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -42,6 +42,13 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.summary).toEqual({ total: 1, hard: 1 })
   })
 
+  test("editing a short sentence does not report an unchanged sentence on the same line", () => {
+    const previous = `${words(30)}. Keep this short.`
+    const current = `${words(30)}. Keep that short.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
   test("an insertion that pushes an existing sentence over the word cap is reported", () => {
     const previous = `${words(20)}.`
     const current = `extra extra extra extra extra extra ${words(20)}.`
@@ -70,6 +77,22 @@ describe("lint prose-file: diff-only linting via previousText", () => {
   test("deleting one paragraph does not surface untouched pre-existing violations", () => {
     const previous = `${words(30)}.\n\n${words(28)}.`
     const current = `${words(28)}.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("replacing a short line does not report an unchanged neighboring sentence", () => {
+    const longSentence = `${words(30)}.`
+    const previous = `${longSentence}\nOld short middle.\nA short closing sentence.`
+    const current = `${longSentence}\nNew short middle.\nA short closing sentence.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("deleting a complete sentence does not report unchanged neighboring sentences", () => {
+    const longSentence = `${words(30)}.`
+    const previous = `${longSentence}\nA short complete sentence.\nA short closing sentence.`
+    const current = `${longSentence}\nA short closing sentence.`
 
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const fixture = (name: string) =>
+  readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)), "utf8")
+
+describe("lint prose-file: diff-only linting via previousText", () => {
+  const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
+
+  test("a new document (no previousText) is linted in full", () => {
+    const text = `${words(26)}.\n\n${words(27)}.`
+
+    expect(lint("prose-file", text).violations).toHaveLength(2)
+  })
+
+  test("an unchanged document reports no violations even when it contains some", () => {
+    const text = `${words(30)}.`
+
+    expect(lint("prose-file", text, { previousText: text }).violations).toHaveLength(0)
+  })
+
+  test("an empty previousText means every line is new, so the full text is linted", () => {
+    const report = lint("prose-file", `${words(30)}.`, { previousText: "" })
+
+    expect(report.violations).toHaveLength(1)
+  })
+
+  test("editing one paragraph of a file full of violations reports only the touched region", () => {
+    const report = lint("prose-file", fixture("edit-current.md"), {
+      previousText: fixture("edit-previous.md"),
+    })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "sentence-length",
+      severity: "hard",
+      line: 5,
+      column: 1,
+    })
+    expect(report.summary).toEqual({ total: 1, hard: 1 })
+  })
+
+  test("an insertion that pushes an existing sentence over the word cap is reported", () => {
+    const previous = `${words(20)}.`
+    const current = `extra extra extra extra extra extra ${words(20)}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("editing a later line of a multi-line sentence flags the sentence at its start", () => {
+    const previous = `${words(13)}\n${words(11)}.`
+    const current = `${words(13)}\n${words(11)} plus two.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("deleting text never produces violations for the removed content", () => {
+    const previous = `${words(30)}.\n\nA short closing sentence.`
+    const current = "A short closing sentence."
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("deleting one paragraph does not surface untouched pre-existing violations", () => {
+    const previous = `${words(30)}.\n\n${words(28)}.`
+    const current = `${words(28)}.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("positions refer to the new text when an insertion shifts pre-existing prose", () => {
+    const previous = `Intro.\n\n${words(30)}.`
+    const current = `Intro.\n\n${words(28)} inserted.\n\n${words(30)}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
+  })
+})

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -111,6 +111,32 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
   })
 
+  test("inserting a line break inside a word reports the overlong changed sentence", () => {
+    const previous = `firsttoken ${words(24)}.`
+    const current = `first\ntoken ${words(24)}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      message: "Sentence has 26 words; the maximum is 25.",
+      line: 1,
+      column: 1,
+    })
+  })
+
+  test("replacing a sentence prefix reports an overlong retained trailing sentence", () => {
+    const previous = `${words(40)}.`
+    const current = `ZZZ.${previous.slice(words(10).length)}`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      message: "Sentence has 30 words; the maximum is 25.",
+      line: 1,
+      column: 6,
+    })
+  })
+
   test("inserting a standalone sentence does not report an unchanged long sentence", () => {
     const previous = `Intro. ${words(30)}.`
     const current = `Intro. Added sentence. ${words(30)}.`

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -170,6 +170,31 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.violations.at(-1)).toMatchObject({ line: 1000, column: 1 })
   })
 
+  test("bounds deletion analysis across many edits in a large fenced block", () => {
+    const padding = "x".repeat(20_000)
+    const previousCode = "ab".repeat(400)
+    const currentCode = "a".repeat(400)
+    const previous = ["Before.", "```", padding, previousCode, padding, "```", "After."].join("\n")
+    const current = ["Before.", "```", padding, currentCode, padding, "```", "After."].join("\n")
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
+  test("sweeps many changed visibility ranges against many sentences", () => {
+    const longSentence = `${words(26)}.`
+    const blocks = 2_000
+    const previous = [
+      "```",
+      ...Array.from({ length: blocks }, () => [longSentence, "```"]).flat(),
+    ].join("\n")
+    const current = previous.slice(4)
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(blocks / 2)
+    expect(report.violations.at(0)).toMatchObject({ line: 1, column: 1 })
+    expect(report.violations.at(-1)).toMatchObject({ line: blocks * 2 - 3, column: 1 })
+  })
+
   test("positions refer to the new text when an insertion shifts pre-existing prose", () => {
     const previous = `Intro.\n\n${words(30)}.`
     const current = `Intro.\n\n${words(28)} inserted.\n\n${words(30)}.`

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -160,6 +160,13 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
+  test("deleting duplicate internal whitespace does not report an existing violation", () => {
+    const previous = `${words(15)}  ${words(15)}.`
+    const current = `${words(15)} ${words(15)}.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
   test("deleting one paragraph does not surface untouched pre-existing violations", () => {
     const previous = `${words(30)}.\n\n${words(28)}.`
     const current = `${words(28)}.`

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -195,6 +195,24 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.violations[0]?.message).toContain('not "approximately"')
   })
 
+  test("an astral character before a changed line does not shift its dictionary position", () => {
+    const previous = "😀 Intro.\napproximatelyx."
+    const current = "😀 Intro.\napproximately."
+    const report = lint("prose-file", current, { previousText: previous, dictionary })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 1 })
+  })
+
+  test("an astral character in a changed multiline sentence preserves its line break", () => {
+    const previous = "😀 Intro\napproximatelyx."
+    const current = "😀 Intro\napproximately."
+    const report = lint("prose-file", current, { previousText: previous, dictionary })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 2, column: 1 })
+  })
+
   test.each([
     [" approximately.", "approximately."],
     ["approximately. ", "approximately."],

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -1,10 +1,25 @@
 import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
+import type { Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 
 const fixture = (name: string) =>
   readFileSync(fileURLToPath(new URL(`../fixtures/${name}`, import.meta.url)), "utf8")
+
+const dictionary = {
+  formatVersion: 1,
+  source: {
+    name: "test fixture",
+    repository: "https://example.test/dictionary",
+    commit: "fixture",
+    path: "dictionary.json",
+  },
+  entries: [
+    { unapproved: ["approximately"], suggestions: ["about"] },
+    { unapproved: ["prior to"], suggestions: ["before"] },
+  ],
+} as const satisfies Dictionary
 
 describe("lint prose-file: diff-only linting via previousText", () => {
   const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
@@ -160,11 +175,23 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
-  test("deleting duplicate internal whitespace does not report an existing violation", () => {
-    const previous = `${words(15)}  ${words(15)}.`
-    const current = `${words(15)} ${words(15)}.`
+  test.each([
+    ["Do this prior extra to assembly.", "Do this prior to assembly.", "prior to"],
+    ["It is approx-imately correct.", "It is approximately correct.", "approximately"],
+  ])("deleting prose can create a dictionary violation: %s", (previous, current, found) => {
+    const report = lint("prose-file", current, { previousText: previous, dictionary })
 
-    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.message).toContain(`not \"${found}\"`)
+  })
+
+  test("deleting duplicate internal whitespace does not report an existing violation", () => {
+    const previous = "Do this prior  to assembly."
+    const current = "Do this prior to assembly."
+
+    expect(
+      lint("prose-file", current, { previousText: previous, dictionary }).violations,
+    ).toHaveLength(0)
   })
 
   test("an excluded-code insertion does not select unrelated deletion-only prose", () => {

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -49,6 +49,13 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
+  test("changing line endings does not report an unchanged sentence", () => {
+    const previous = `${words(30)}.\nA short sentence.`
+    const current = `${words(30)}.\r\nA short sentence.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
   test("an insertion that pushes an existing sentence over the word cap is reported", () => {
     const previous = `${words(20)}.`
     const current = `extra extra extra extra extra extra ${words(20)}.`
@@ -110,6 +117,15 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     })
   })
 
+  test("deleting code fences lints prose newly exposed by the change", () => {
+    const previous = `\`\`\`\n${words(30)}.\n\`\`\``
+    const current = `${words(30)}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
   test("edits past the DP size bound conservatively treat the whole middle as changed", () => {
     const previous = Array.from({ length: 1001 }, (_, i) => `Old line ${i}.`).join("\n")
     const current = Array.from({ length: 1001 }, (_, i) =>
@@ -118,6 +134,22 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     const report = lint("prose-file", current, { previousText: previous })
 
     expect(report.violations.map((violation) => violation.line)).toEqual([1, 501, 1001])
+  })
+
+  test("the aggregate diff budget bounds many large changed chunks", () => {
+    const oldLine = `${"old ".repeat(248)}old.`
+    const newLine = `${"new ".repeat(248)}new.`
+    const previous = Array.from({ length: 1000 }, (_, index) =>
+      index % 2 === 0 ? `Anchor ${index}.` : oldLine,
+    ).join("\n")
+    const current = Array.from({ length: 1000 }, (_, index) =>
+      index % 2 === 0 ? `Anchor ${index}.` : newLine,
+    ).join("\n")
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(500)
+    expect(report.violations.at(0)).toMatchObject({ line: 2, column: 1 })
+    expect(report.violations.at(-1)).toMatchObject({ line: 1000, column: 1 })
   })
 
   test("positions refer to the new text when an insertion shifts pre-existing prose", () => {

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -185,6 +185,34 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.violations[0]?.message).toContain(`not \"${found}\"`)
   })
 
+  test.each([
+    ["xapproximately.", "approximately."],
+    ["approximatelyx", "approximately"],
+  ])("deleting prose at a sentence edge can create a dictionary violation: %s", (previous, current) => {
+    const report = lint("prose-file", current, { previousText: previous, dictionary })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]?.message).toContain('not "approximately"')
+  })
+
+  test.each([
+    [" approximately.", "approximately."],
+    ["approximately. ", "approximately."],
+  ])("deleting whitespace at a sentence edge does not report an existing violation: %s", (previous, current) => {
+    expect(
+      lint("prose-file", current, { previousText: previous, dictionary }).violations,
+    ).toHaveLength(0)
+  })
+
+  test.each([
+    ["Remove this sentence. Approximately.", "Approximately."],
+    ["Approximately. Remove this sentence.", "Approximately."],
+  ])("deleting a complete sentence at an edge does not report its neighbor: %s", (previous, current) => {
+    expect(
+      lint("prose-file", current, { previousText: previous, dictionary }).violations,
+    ).toHaveLength(0)
+  })
+
   test("deleting duplicate internal whitespace does not report an existing violation", () => {
     const previous = "Do this prior  to assembly."
     const current = "Do this prior to assembly."

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -326,7 +326,10 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     const current = Array.from({ length: 1001 }, (_, i) =>
       i === 0 || i === 500 || i === 1000 ? `${words(26)} tail${i}.` : `New line ${i}.`,
     ).join("\n")
-    const report = lint("prose-file", current, { previousText: previous })
+    const report = lint("prose-file", current, {
+      previousText: previous,
+      rules: { "paragraph-length": "off" },
+    })
 
     expect(report.violations.map((violation) => violation.line)).toEqual([1, 501, 1001])
   })

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -56,6 +56,13 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
+  test("appending whitespace does not report an unchanged unterminated sentence", () => {
+    const previous = words(30)
+    const current = `${previous} `
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
   test("an insertion that pushes an existing sentence over the word cap is reported", () => {
     const previous = `${words(20)}.`
     const current = `extra extra extra extra extra extra ${words(20)}.`
@@ -124,6 +131,17 @@ describe("lint prose-file: diff-only linting via previousText", () => {
 
     expect(report.violations).toHaveLength(1)
     expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("deleting fences preserves the identity of duplicate prose lines", () => {
+    const longSentence = `${words(30)}.`
+    const previous = ["```", longSentence, "```", longSentence, "```", longSentence, "```"].join(
+      "\n",
+    )
+    const current = [longSentence, longSentence, longSentence].join("\n")
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations.map((violation) => violation.line)).toEqual([1, 3])
   })
 
   test("edits past the DP size bound conservatively treat the whole middle as changed", () => {

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -74,6 +74,29 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
   })
 
+  test("deleting a terminator line that merges retained fragments lints the merged sentence", () => {
+    const previous = `${words(13)}\nEnds here.\n${words(13)} done.`
+    const current = `${words(13)}\n${words(13)} done.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      ruleId: "sentence-length",
+      line: 1,
+      column: 1,
+    })
+  })
+
+  test("edits past the DP size bound conservatively treat the whole middle as changed", () => {
+    const previous = Array.from({ length: 1001 }, (_, i) => `Old line ${i}.`).join("\n")
+    const current = Array.from({ length: 1001 }, (_, i) =>
+      i === 0 || i === 500 || i === 1000 ? `${words(26)} tail${i}.` : `New line ${i}.`,
+    ).join("\n")
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations.map((violation) => violation.line)).toEqual([1, 501, 1001])
+  })
+
   test("positions refer to the new text when an insertion shifts pre-existing prose", () => {
     const previous = `Intro.\n\n${words(30)}.`
     const current = `Intro.\n\n${words(28)} inserted.\n\n${words(30)}.`

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -88,6 +88,36 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
   })
 
+  test("inserting a terminator reports an overlong retained trailing sentence", () => {
+    const previous = `${words(40)}.`
+    const insertionOffset = words(10).length
+    const current = `${previous.slice(0, insertionOffset)}.${previous.slice(insertionOffset)}`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({
+      message: "Sentence has 30 words; the maximum is 25.",
+      line: 1,
+      column: insertionOffset + 3,
+    })
+  })
+
+  test("inserting a paragraph boundary reports an overlong retained trailing sentence", () => {
+    const previous = `${words(10)}\n${words(30)}.`
+    const current = `${words(10)}\n\n${words(30)}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 3, column: 1 })
+  })
+
+  test("inserting a standalone sentence does not report an unchanged long sentence", () => {
+    const previous = `Intro. ${words(30)}.`
+    const current = `Intro. Added sentence. ${words(30)}.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
   test("editing a later line of a multi-line sentence flags the sentence at its start", () => {
     const previous = `${words(13)}\n${words(11)}.`
     const current = `${words(13)}\n${words(11)} plus two.`

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -186,6 +186,24 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     expect(report.violations.at(-1)).toMatchObject({ line: 1000, column: 1 })
   })
 
+  test("character fallback reports a sentence merged by a large replacement", () => {
+    const fragment = words(13)
+    const previous = `${fragment}. ${"x".repeat(1_000_001)}\n${fragment}.`
+    const current = `${fragment}\r\n${fragment}.`
+    const report = lint("prose-file", current, { previousText: previous })
+
+    expect(report.violations).toHaveLength(1)
+    expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
+  })
+
+  test("character fallback does not report an unchanged neighboring sentence", () => {
+    const longSentence = `${words(30)}.`
+    const previous = `${longSentence}\n${"x".repeat(1_000_001)}.\nClosing sentence.`
+    const current = `${longSentence}\nChanged sentence.\nClosing sentence.`
+
+    expect(lint("prose-file", current, { previousText: previous }).violations).toHaveLength(0)
+  })
+
   test("bounds deletion analysis across many edits in a large fenced block", () => {
     const padding = "x".repeat(20_000)
     const previousCode = "ab".repeat(400)

--- a/test/fixtures/edit-current.md
+++ b/test/fixtures/edit-current.md
@@ -1,0 +1,7 @@
+# Manual
+
+This first paragraph sentence is deliberately far too long because it keeps adding more and more filler words until the total word count clearly exceeds twenty five.
+
+The edited middle paragraph now grows into a deliberately overlong sentence because the author keeps typing more and more filler words until the count clearly exceeds twenty five in total.
+
+This closing paragraph sentence is also deliberately far too long because it keeps adding more and more filler words until the total word count clearly exceeds twenty five.

--- a/test/fixtures/edit-previous.md
+++ b/test/fixtures/edit-previous.md
@@ -1,0 +1,7 @@
+# Manual
+
+This first paragraph sentence is deliberately far too long because it keeps adding more and more filler words until the total word count clearly exceeds twenty five.
+
+Short middle paragraph.
+
+This closing paragraph sentence is also deliberately far too long because it keeps adding more and more filler words until the total word count clearly exceeds twenty five.


### PR DESCRIPTION
## Intent

Implement HUF-135 so the pure synchronous lint engine accepts optional previousText and reports violations only in changed new-text regions, while linting new documents fully and preserving positions relative to the new text. Cover edited paragraphs, insertions that create violations, deletions, multiline sentence context, and shifted line and column positions with engine-seam tests, without changing CLI or extension wiring. Treat sentences adjacent to pure-deletion points as changed so deletion-created merged-sentence violations are caught, and add a regression test. Also add direct coverage for the large-diff fallback path that activates above roughly one million comparison cells.

## What Changed

- Add optional `previousText` support to lint only affected current-text sentences while preserving full-document linting when omitted.
- Handle insertions, deletions, Markdown visibility changes, multiline sentences, UTF-16 offsets, and bounded large-diff fallbacks.
- Add engine regression tests and fixtures for changed-region selection, deletion-created violations, positions, and large inputs.

## Risk Assessment

🚨 High: A required large-diff fallback path can miss violations in retained sentences whose identity changes at a replacement boundary.

## Testing

After a clean-worktree baseline, targeted diff-lint and full-document engine regressions passed, while a saved engine API transcript demonstrated full new-document linting, unchanged-region suppression, edited paragraph selection, deletion-created merge detection, current-text positions, and the million-cell fallback.

<details>
<summary>Evidence: HUF-135 engine API scenario transcript</summary>

```text
{
  "verification": "all scenario assertions passed",
  "fullNewDocument": {
    "summary": {
      "total": 1,
      "hard": 1
    },
    "violations": [
      {
        "ruleId": "sentence-length",
        "line": 1,
        "column": 1,
        "message": "Sentence has 26 words; the maximum is 25."
      }
    ]
  },
  "unchangedExistingViolation": {
    "summary": {
      "total": 0,
      "hard": 0
    },
    "violations": []
  },
  "editedParagraphOnly": {
    "summary": {
      "total": 1,
      "hard": 1
    },
    "violations": [
      {
        "ruleId": "sentence-length",
        "line": 3,
        "column": 1,
        "message": "Sentence has 27 words; the maximum is 25."
      }
    ]
  },
  "deletionCreatedMerge": {
    "summary": {
      "total": 1,
      "hard": 1
    },
    "violations": [
      {
        "ruleId": "sentence-length",
        "line": 1,
        "column": 1,
        "message": "Sentence has 27 words; the maximum is 25."
      }
    ]
  },
  "shiftedPositionInCurrentText": {
    "summary": {
      "total": 1,
      "hard": 1
    },
    "violations": [
      {
        "ruleId": "sentence-length",
        "line": 3,
        "column": 1,
        "message": "Sentence has 29 words; the maximum is 25."
      }
    ]
  },
  "millionCellFallback": {
    "summary": {
      "total": 3,
      "hard": 3
    },
    "violations": [
      {
        "ruleId": "sentence-length",
        "line": 1,
        "column": 1,
        "message": "Sentence has 27 words; the maximum is 25."
      },
      {
        "ruleId": "sentence-length",
        "line": 501,
        "column": 1,
        "message": "Sentence has 27 words; the maximum is 25."
      },
      {
        "ruleId": "sentence-length",
        "line": 1001,
        "column": 1,
        "message": "Sentence has 27 words; the maximum is 25."
      }
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/engine/lint.ts:276` - Pure deletions within one existing sentence are ignored. For example, deleting &#34;extra &#34; from &#34;Do this prior extra to assembly.&#34; creates &#34;prior to&#34;, but the old neighbors map to the same sentence, so no current sentence is selected and the new dictionary violation is missed. Handle deletion-created token or phrase changes at the sentence-selection boundary, while preserving the no-op whitespace behavior.
- 🚨 `src/engine/lint.ts:24` - Masking unselected sentence content also removes Markdown container prefixes required by dictionary paragraph analysis. For example, changing `&gt; Intro. Do this prior\n&gt; after assembly.` to `&gt; Intro. Do this prior\n&gt; to assembly.` selects the second sentence but masks the first line&#39;s `&gt;` while retaining the continuation&#39;s `&gt;`, so `dictionaryRule` treats the lines as separate paragraphs and misses &#34;prior to&#34;. Preserve structural Markdown context, or run rules on the original masked lines and filter violations by selected sentence spans.

🔧 Fix: Handle deletion-created token and phrase violations
1 error still open:
- 🚨 `src/engine/lint.ts:268` - Pure deletions at a sentence edge still miss newly created tokens. For example, changing &#34;xapproximately.&#34; to &#34;approximately.&#34; creates a dictionary violation, but the deletion has no preceding neighbor, so this guard discards it and no sentence is selected. Represent one-sided deletion boundaries and select the surviving adjacent sentence when a non-whitespace deletion changes tokenization, while preserving whitespace-only and complete-sentence deletion behavior.

🔧 Fix: Handle one-sided deletion-created violations
2 errors still open:
- 🚨 `src/engine/lint.ts:24` - `Array.from(text)` creates one element per Unicode code point, but sentence ranges use UTF-16 code-unit offsets. An astral character before a selected sentence shifts preserved newlines and masked content, causing incorrect columns, merged lines, or missed rule results. Build the mask with exactly `text.length` code-unit slots and preserve newlines at their original offsets.
- 🚨 `src/engine/lint.ts:299` - The whitespace-deletion shortcut misses Markdown hard-break changes. Changing `Do this prior  \nto assembly.` to `Do this prior\nto assembly.` creates the dictionary phrase `prior to`, but the remaining newline makes `before + 1 &lt; after`, so no sentence is selected. Before treating whitespace deletion as a no-op, compare whether the deletion changes Markdown paragraph or soft-line-break semantics.

🔧 Fix: Preserve UTF-16 offsets in diff-only masks
1 error still open:
- 🚨 `src/engine/diff.ts:241` - The large line-diff fallback records new replacement text but not the replaced old text as a deletion. With more than one million line-comparison cells, replacing a document-wide unterminated prefix with terminated short lines can make an exact retained overlong suffix into a new sentence, but the suffix is not selected because changedSentenceIdentityIndexes receives no deletion edge. Record the old middle as a deletion whenever oldText is nonempty, including replacements, as the character fallback does.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bun run test -- test/engine/diff-lint.test.ts`
- `bun run test -- test/engine/lint.test.ts test/engine/dictionary.test.ts test/engine/verb-form.test.ts`
- `bun /tmp/no-mistakes-evidence/01KYVKDM3S3CM1HYERNAY5E6RD/engine-api-evidence.ts | tee /tmp/no-mistakes-evidence/01KYVKDM3S3CM1HYERNAY5E6RD/engine-api-transcript.json`
- <code>`git status --short --branch` before and after testing confirmed no worktree changes.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
