### PR TITLE
feat(engine): add mechanical and list STE rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,31 @@ cat notes.md | simple-english
 simple-english --json README.md
 ```
 
-The CLI prints STE violations with a line, column, and rule ID.
+The CLI prints STE violations with a line, column, severity, and rule ID.
 It exits 1 when hard violations exist, 0 when no hard violations exist, and 2 when an input file cannot be read or a config file is invalid.
 Soft violations are still printed when the command exits 0.
-`--json` emits a machine-readable report.
+`--json` emits a machine-readable report with the severity of each violation and an approved suggestion for phrasal verbs.
 `--config <path>` loads an explicit config file instead of the discovered ones.
+
+## Rules
+
+| Rule ID | Severity | Default |
+| --- | --- | --- |
+| `sentence-length` | Hard | More than 25 words in one sentence |
+| `paragraph-length` | Hard | More than 6 sentences in one paragraph |
+| `contraction` | Hard | Contractions |
+| `semicolon` | Hard | Semicolons |
+| `phrasal-verb` | Hard | Curated phrasal verbs, with an approved single-verb suggestion |
+| `hedging` | Soft | Curated hedging phrases |
+| `marketing` | Soft | Curated marketing language |
+| `dictionary-not-approved-word` | Hard | Unapproved dictionary words and phrases |
+| `verb-progressive` | Hard | Progressive verb forms |
+| `verb-passive` | Soft | Passive voice |
+| `verb-perfect` | Hard | Perfect verb forms |
+
+Fenced code blocks are excluded from all rules.
+Inline code is excluded from the mechanical and list rules except `semicolon`.
+Hedging, marketing, and phrasal-verb multiword matches stay within one line.
 
 ## Configuration
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -42,6 +42,7 @@ interface FileViolation {
   readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
+  readonly suggestion?: string
 }
 
 interface CliReport {
@@ -83,7 +84,7 @@ const render = (report: CliReport, json: boolean): string => {
     return JSON.stringify(report, null, 2)
   }
   return report.violations
-    .map((v) => `${v.file}:${v.line}:${v.column} ${v.ruleId} ${v.message}`)
+    .map((v) => `${v.file}:${v.line}:${v.column} [${v.severity}] ${v.ruleId} ${v.message}`)
     .join("\n")
 }
 

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,5 +1,5 @@
 import type { Dictionary } from "../dictionary/schema.ts"
-import { blankMarkdownCode } from "./markdown.ts"
+import { blankInlineCode, blankMarkdownCode } from "./markdown.ts"
 import { segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
@@ -25,14 +25,15 @@ interface ResolvedOptions {
 const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Violation[]> = {
   "prose-file": (text, { maxSentenceWords, dictionary, tagger }) => {
     const lines = blankMarkdownCode(text)
+    const proseLines = blankInlineCode(lines)
     return [
-      ...sentenceLength(segmentSentences(lines), maxSentenceWords),
-      ...paragraphLength(segmentParagraphs(lines)),
-      ...contraction(lines),
+      ...sentenceLength(segmentSentences(proseLines), maxSentenceWords),
+      ...paragraphLength(segmentParagraphs(proseLines)),
+      ...contraction(proseLines),
       ...semicolon(lines),
-      ...phrasalVerb(lines),
-      ...hedging(lines),
-      ...marketing(lines),
+      ...phrasalVerb(proseLines),
+      ...hedging(proseLines),
+      ...marketing(proseLines),
       ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
       ...(tagger === undefined ? [] : verbForm(lines, tagger)),
     ]

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,6 +1,13 @@
 import type { Dictionary } from "../dictionary/schema.ts"
 import { blankMarkdownCode } from "./markdown.ts"
+import { segmentParagraphs } from "./paragraphs.ts"
+import { contraction } from "./rules/contraction.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
+import { hedging } from "./rules/hedging.ts"
+import { marketing } from "./rules/marketing.ts"
+import { paragraphLength } from "./rules/paragraph-length.ts"
+import { phrasalVerb } from "./rules/phrasal-verb.ts"
+import { semicolon } from "./rules/semicolon.ts"
 import { sentenceLength } from "./rules/sentence-length.ts"
 import { verbForm } from "./rules/verb-form.ts"
 import { segmentSentences } from "./sentences.ts"
@@ -20,6 +27,12 @@ const linters: Record<LintKind, (text: string, options: ResolvedOptions) => Viol
     const lines = blankMarkdownCode(text)
     return [
       ...sentenceLength(segmentSentences(lines), maxSentenceWords),
+      ...paragraphLength(segmentParagraphs(lines)),
+      ...contraction(lines),
+      ...semicolon(lines),
+      ...phrasalVerb(lines),
+      ...hedging(lines),
+      ...marketing(lines),
       ...(dictionary === undefined ? [] : dictionaryRule(lines, dictionary, tagger)),
       ...(tagger === undefined ? [] : verbForm(lines, tagger)),
     ]

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -180,22 +180,18 @@ export function blankMarkdownCode(text: string): string[] {
 }
 
 interface BacktickRun {
-  readonly line: number
   readonly start: number
   readonly length: number
 }
 
-export function blankInlineCode(lines: readonly string[]): string[] {
+function blankInlineCodeLine(line: string): string {
   const runs: BacktickRun[] = []
-
-  lines.forEach((line, lineIndex) => {
-    for (let index = 0; index < line.length; index += 1) {
-      if (line[index] !== "`") continue
-      const start = index
-      while (line[index + 1] === "`") index += 1
-      runs.push({ line: lineIndex, start, length: index - start + 1 })
-    }
-  })
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] !== "`") continue
+    const start = index
+    while (line[index + 1] === "`") index += 1
+    runs.push({ start, length: index - start + 1 })
+  }
 
   const nextMatchingRun = new Int32Array(runs.length).fill(-1)
   const latestRunByLength = new Map<number, number>()
@@ -206,7 +202,7 @@ export function blankInlineCode(lines: readonly string[]): string[] {
     latestRunByLength.set(run.length, index)
   }
 
-  const masked = lines.map((line) => line.split(""))
+  const masked = line.split("")
   for (let index = 0; index < runs.length; index += 1) {
     const closingIndex = nextMatchingRun[index] ?? -1
     if (closingIndex < 0) continue
@@ -214,13 +210,13 @@ export function blankInlineCode(lines: readonly string[]): string[] {
     const closing = runs[closingIndex]
     if (!opening || !closing) continue
 
-    for (let line = opening.line; line <= closing.line; line += 1) {
-      const start = line === opening.line ? opening.start : 0
-      const end = line === closing.line ? closing.start + closing.length : masked[line]?.length
-      masked[line]?.fill(" ", start, end)
-    }
+    masked.fill(" ", opening.start, closing.start + closing.length)
     index = closingIndex
   }
 
-  return masked.map((line) => line.join(""))
+  return masked.join("")
+}
+
+export function blankInlineCode(lines: readonly string[]): string[] {
+  return lines.map(blankInlineCodeLine)
 }

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -178,3 +178,49 @@ export function blankMarkdownCode(text: string): string[] {
     return line
   })
 }
+
+interface BacktickRun {
+  readonly line: number
+  readonly start: number
+  readonly length: number
+}
+
+export function blankInlineCode(lines: readonly string[]): string[] {
+  const runs: BacktickRun[] = []
+
+  lines.forEach((line, lineIndex) => {
+    for (let index = 0; index < line.length; index += 1) {
+      if (line[index] !== "`") continue
+      const start = index
+      while (line[index + 1] === "`") index += 1
+      runs.push({ line: lineIndex, start, length: index - start + 1 })
+    }
+  })
+
+  const nextMatchingRun = new Int32Array(runs.length).fill(-1)
+  const latestRunByLength = new Map<number, number>()
+  for (let index = runs.length - 1; index >= 0; index -= 1) {
+    const run = runs[index]
+    if (!run) continue
+    nextMatchingRun[index] = latestRunByLength.get(run.length) ?? -1
+    latestRunByLength.set(run.length, index)
+  }
+
+  const masked = lines.map((line) => line.split(""))
+  for (let index = 0; index < runs.length; index += 1) {
+    const closingIndex = nextMatchingRun[index] ?? -1
+    if (closingIndex < 0) continue
+    const opening = runs[index]
+    const closing = runs[closingIndex]
+    if (!opening || !closing) continue
+
+    for (let line = opening.line; line <= closing.line; line += 1) {
+      const start = line === opening.line ? opening.start : 0
+      const end = line === closing.line ? closing.start + closing.length : masked[line]?.length
+      masked[line]?.fill(" ", start, end)
+    }
+    index = closingIndex
+  }
+
+  return masked.map((line) => line.join(""))
+}

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -3,26 +3,29 @@ export interface Paragraph {
   readonly line: number
 }
 
-const LIST_MARKER = /^(?:[-*+]\s|\d+[.)]\s)/
+const LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/
 
 type LineKind = "blank" | "heading" | "table-row" | "list-item" | "prose"
+type ParagraphKind = "list-item" | "prose"
+
+function listItemContent(line: string): string | undefined {
+  const trimmed = line.trimStart()
+  const marker = LIST_MARKER.exec(trimmed)
+  return marker ? trimmed.slice(marker[0].length) : undefined
+}
 
 function classify(line: string): LineKind {
   const trimmed = line.trim()
   if (trimmed === "") return "blank"
   if (trimmed.startsWith("|")) return "table-row"
   if (trimmed.startsWith("#")) return "heading"
-  if (LIST_MARKER.test(trimmed)) return "list-item"
+  if (listItemContent(line) !== undefined) return "list-item"
   return "prose"
 }
 
-// A paragraph is a run of prose lines; a blank line, a heading, and a table
-// row all end it. A list item is its own paragraph: STE asks the writer to
-// replace a long paragraph with a vertical list, so a rule that counts the
-// list as one paragraph would punish the recommended fix.
 export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
   const paragraphs: Paragraph[] = []
-  let open: { line: number; lines: string[] } | null = null
+  let open: { line: number; lines: string[]; kind: ParagraphKind } | null = null
 
   const close = () => {
     if (open) {
@@ -40,13 +43,23 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
         break
       case "list-item":
         close()
-        paragraphs.push({ lines: [raw], line: index + 1 })
-        break
-      case "prose":
-        if (!open) {
-          open = { line: index + 1, lines: [] }
+        open = {
+          line: index + 1,
+          lines: [listItemContent(raw) ?? ""],
+          kind: "list-item",
         }
-        open.lines.push(raw)
+        break
+      case "prose": {
+        const indented = raw.length > raw.trimStart().length
+        if (open?.kind === "list-item" && !indented) {
+          close()
+        }
+        if (!open) {
+          open = { line: index + 1, lines: [], kind: "prose" }
+        }
+        open.lines.push(open.kind === "list-item" ? raw.trimStart() : raw)
+        break
+      }
     }
   })
   close()

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -50,10 +50,6 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
         }
         break
       case "prose": {
-        const indented = raw.length > raw.trimStart().length
-        if (open?.kind === "list-item" && !indented) {
-          close()
-        }
         if (!open) {
           open = { line: index + 1, lines: [], kind: "prose" }
         }

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -1,0 +1,55 @@
+export interface Paragraph {
+  readonly lines: readonly string[]
+  readonly line: number
+}
+
+const LIST_MARKER = /^(?:[-*+]\s|\d+[.)]\s)/
+
+type LineKind = "blank" | "heading" | "table-row" | "list-item" | "prose"
+
+function classify(line: string): LineKind {
+  const trimmed = line.trim()
+  if (trimmed === "") return "blank"
+  if (trimmed.startsWith("|")) return "table-row"
+  if (trimmed.startsWith("#")) return "heading"
+  if (LIST_MARKER.test(trimmed)) return "list-item"
+  return "prose"
+}
+
+// A paragraph is a run of prose lines; a blank line, a heading, and a table
+// row all end it. A list item is its own paragraph: STE asks the writer to
+// replace a long paragraph with a vertical list, so a rule that counts the
+// list as one paragraph would punish the recommended fix.
+export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
+  const paragraphs: Paragraph[] = []
+  let open: { line: number; lines: string[] } | null = null
+
+  const close = () => {
+    if (open) {
+      paragraphs.push({ lines: open.lines, line: open.line })
+      open = null
+    }
+  }
+
+  lines.forEach((raw, index) => {
+    switch (classify(raw)) {
+      case "blank":
+      case "heading":
+      case "table-row":
+        close()
+        break
+      case "list-item":
+        close()
+        paragraphs.push({ lines: [raw], line: index + 1 })
+        break
+      case "prose":
+        if (!open) {
+          open = { line: index + 1, lines: [] }
+        }
+        open.lines.push(raw)
+    }
+  })
+  close()
+
+  return paragraphs
+}

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -5,11 +5,11 @@ export interface Paragraph {
 
 const LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/
 
-type LineKind = "blank" | "block-boundary" | "list-item" | "prose"
-type ParagraphKind = "list-item" | "prose"
+type LineKind = "blank" | "block-boundary" | "blockquote" | "list-item" | "prose"
+type ParagraphKind = "blockquote" | "list-item" | "prose"
 
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
-const BLOCKQUOTE = /^ {0,3}>/
+const BLOCKQUOTE = /^ {0,3}>[ \t]?/
 
 function listItemContent(line: string): string | undefined {
   const trimmed = line.trimStart()
@@ -17,12 +17,16 @@ function listItemContent(line: string): string | undefined {
   return marker ? trimmed.slice(marker[0].length) : undefined
 }
 
+function blockquoteContent(line: string): string | undefined {
+  const marker = BLOCKQUOTE.exec(line)
+  return marker ? line.slice(marker[0].length) : undefined
+}
+
 function classify(line: string): LineKind {
   const trimmed = line.trim()
   if (trimmed === "") return "blank"
-  if (trimmed.startsWith("|") || ATX_HEADING.test(line) || BLOCKQUOTE.test(line)) {
-    return "block-boundary"
-  }
+  if (trimmed.startsWith("|") || ATX_HEADING.test(line)) return "block-boundary"
+  if (blockquoteContent(line) !== undefined) return "blockquote"
   if (listItemContent(line) !== undefined) return "list-item"
   return "prose"
 }
@@ -44,6 +48,19 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
       case "block-boundary":
         close()
         break
+      case "blockquote": {
+        const content = blockquoteContent(raw) ?? ""
+        if (content.trim() === "") {
+          close()
+          break
+        }
+        if (open?.kind !== "blockquote") close()
+        if (!open) {
+          open = { line: index + 1, lines: [], kind: "blockquote" }
+        }
+        open.lines.push(content)
+        break
+      }
       case "list-item":
         close()
         open = {

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -5,8 +5,11 @@ export interface Paragraph {
 
 const LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/
 
-type LineKind = "blank" | "heading" | "table-row" | "list-item" | "prose"
+type LineKind = "blank" | "block-boundary" | "list-item" | "prose"
 type ParagraphKind = "list-item" | "prose"
+
+const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
+const BLOCKQUOTE = /^ {0,3}>/
 
 function listItemContent(line: string): string | undefined {
   const trimmed = line.trimStart()
@@ -17,8 +20,9 @@ function listItemContent(line: string): string | undefined {
 function classify(line: string): LineKind {
   const trimmed = line.trim()
   if (trimmed === "") return "blank"
-  if (trimmed.startsWith("|")) return "table-row"
-  if (trimmed.startsWith("#")) return "heading"
+  if (trimmed.startsWith("|") || ATX_HEADING.test(line) || BLOCKQUOTE.test(line)) {
+    return "block-boundary"
+  }
   if (listItemContent(line) !== undefined) return "list-item"
   return "prose"
 }
@@ -37,8 +41,7 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
   lines.forEach((raw, index) => {
     switch (classify(raw)) {
       case "blank":
-      case "heading":
-      case "table-row":
+      case "block-boundary":
         close()
         break
       case "list-item":

--- a/src/engine/paragraphs.ts
+++ b/src/engine/paragraphs.ts
@@ -6,7 +6,7 @@ export interface Paragraph {
 const LIST_MARKER = /^(?:[-*+]|\d+[.)])\s+/
 
 type LineKind = "blank" | "block-boundary" | "blockquote" | "list-item" | "prose"
-type ParagraphKind = "blockquote" | "list-item" | "prose"
+type ParagraphKind = "blockquote" | "blockquote-list-item" | "list-item" | "prose"
 
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
 const BLOCKQUOTE = /^ {0,3}>[ \t]?/
@@ -50,15 +50,25 @@ export function segmentParagraphs(lines: readonly string[]): Paragraph[] {
         break
       case "blockquote": {
         const content = blockquoteContent(raw) ?? ""
-        if (content.trim() === "") {
+        const contentKind = classify(content)
+        if (contentKind === "blank" || contentKind === "block-boundary") {
           close()
           break
         }
-        if (open?.kind !== "blockquote") close()
+        if (contentKind === "list-item") {
+          close()
+          open = {
+            line: index + 1,
+            lines: [listItemContent(content) ?? ""],
+            kind: "blockquote-list-item",
+          }
+          break
+        }
+        if (open?.kind !== "blockquote" && open?.kind !== "blockquote-list-item") close()
         if (!open) {
           open = { line: index + 1, lines: [], kind: "blockquote" }
         }
-        open.lines.push(content)
+        open.lines.push(open.kind === "blockquote-list-item" ? content.trimStart() : content)
         break
       }
       case "list-item":

--- a/src/engine/rules/contraction.ts
+++ b/src/engine/rules/contraction.ts
@@ -1,0 +1,19 @@
+import { scanLines } from "../scan.ts"
+import type { Violation } from "../types.ts"
+
+const CONTRACTION = /\w+['’](?:t|re|ve|ll|d|m)\b/gi
+
+// `'s` is the only ambiguous case: "repo's" is a possessive, not a
+// contraction, so only this fixed set of stems forms a real `'s` contraction.
+const CONTRACTION_S =
+  /\b(?:it|he|she|that|what|who|there|here|let|one|where|how|everyone|everybody|something|nothing|somebody|nobody)['’]s\b/gi
+
+export function contraction(lines: readonly string[]): Violation[] {
+  return [...scanLines(lines, CONTRACTION), ...scanLines(lines, CONTRACTION_S)].map((match) => ({
+    ruleId: "contraction",
+    severity: "hard" as const,
+    message: `Do not use a contraction. Write the words in full. Found "${match.found}".`,
+    line: match.line,
+    column: match.column,
+  }))
+}

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -1,0 +1,26 @@
+import { scanLines } from "../scan.ts"
+import type { Violation } from "../types.ts"
+
+const HEDGES = [
+  "it is important to note",
+  "it should be noted",
+  "it is worth noting",
+  "please note that",
+  "as mentioned",
+  "as noted above",
+]
+
+const HEDGE_PATTERN = new RegExp(
+  `\\b(?:${HEDGES.map((phrase) => phrase.replace(/ /g, "\\s+")).join("|")})\\b`,
+  "gi",
+)
+
+export function hedging(lines: readonly string[]): Violation[] {
+  return scanLines(lines, HEDGE_PATTERN).map((match) => ({
+    ruleId: "hedging",
+    severity: "soft" as const,
+    message: `Do not hedge. Delete "${match.found.toLowerCase()}".`,
+    line: match.line,
+    column: match.column,
+  }))
+}

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -1,4 +1,5 @@
 import { scanLines } from "../scan.ts"
+import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
 const HEDGES = [
@@ -11,7 +12,7 @@ const HEDGES = [
 ]
 
 const HEDGE_PATTERN = new RegExp(
-  `\\b(?:${HEDGES.map((phrase) => phrase.replace(/ /g, "\\s+")).join("|")})\\b`,
+  `(?<!${TOKEN_CHARACTER_PATTERN})(?:${HEDGES.map((phrase) => phrase.replace(/ /g, "\\s+")).join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
   "gi",
 )
 

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -28,10 +28,7 @@ const MARKETING_WORDS = [
   "empowers",
 ]
 
-// A hyphen satisfies \b, so \brobust\b would also match inside "ultra-robust".
-// Excluding adjacent hyphens makes hyphenated compounds match only as whole
-// tokens.
-const MARKETING_PATTERN = new RegExp(`(?<![\\w-])(?:${MARKETING_WORDS.join("|")})(?![\\w-])`, "gi")
+const MARKETING_PATTERN = new RegExp(`\\b(?:${MARKETING_WORDS.join("|")})\\b`, "gi")
 
 export function marketing(lines: readonly string[]): Violation[] {
   return scanLines(lines, MARKETING_PATTERN).map((match) => ({

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,4 +1,3 @@
-import { scanLines } from "../scan.ts"
 import type { Violation } from "../types.ts"
 
 const MARKETING_WORDS = [
@@ -28,14 +27,45 @@ const MARKETING_WORDS = [
   "empowers",
 ]
 
-const MARKETING_PATTERN = new RegExp(`\\b(?:${MARKETING_WORDS.join("|")})\\b`, "gi")
+const MARKETING_SET = new Set(MARKETING_WORDS)
+const HYPHENATED_TOKEN = /[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*/g
+
+interface MarketingMatch {
+  readonly found: string
+  readonly offset: number
+}
+
+function findMarketingLanguage(token: string): MarketingMatch | undefined {
+  const normalized = token.toLowerCase()
+  if (MARKETING_SET.has(normalized)) {
+    return { found: normalized, offset: 0 }
+  }
+
+  let offset = 0
+  for (const part of normalized.split("-")) {
+    if (MARKETING_SET.has(part)) {
+      return { found: part, offset }
+    }
+    offset += part.length + 1
+  }
+}
 
 export function marketing(lines: readonly string[]): Violation[] {
-  return scanLines(lines, MARKETING_PATTERN).map((match) => ({
-    ruleId: "marketing",
-    severity: "soft" as const,
-    message: `Do not use marketing language. Delete "${match.found.toLowerCase()}".`,
-    line: match.line,
-    column: match.column,
-  }))
+  return lines.flatMap((line, lineIndex) =>
+    Array.from(line.matchAll(HYPHENATED_TOKEN)).flatMap((tokenMatch) => {
+      const match = findMarketingLanguage(tokenMatch[0])
+      if (!match) {
+        return []
+      }
+      return [
+        {
+          ruleId: "marketing",
+          severity: "soft" as const,
+          message: `Do not use marketing language. Delete "${match.found}".`,
+          line: lineIndex + 1,
+          column: tokenMatch.index + match.offset + 1,
+        },
+      ]
+    }),
+  )
 }

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,0 +1,44 @@
+import { scanLines } from "../scan.ts"
+import type { Violation } from "../types.ts"
+
+const MARKETING_WORDS = [
+  "seamless",
+  "seamlessly",
+  "robust",
+  "powerful",
+  "cutting-edge",
+  "effortless",
+  "effortlessly",
+  "world-class",
+  "next-generation",
+  "revolutionary",
+  "blazing",
+  "lightning-fast",
+  "elegant",
+  "delightful",
+  "turnkey",
+  "best-in-class",
+  "state-of-the-art",
+  "game-changing",
+  "battle-tested",
+  "enterprise-grade",
+  "supercharge",
+  "unleash",
+  "empower",
+  "empowers",
+]
+
+// A hyphen satisfies \b, so \brobust\b would also match inside "ultra-robust".
+// Excluding adjacent hyphens makes hyphenated compounds match only as whole
+// tokens.
+const MARKETING_PATTERN = new RegExp(`(?<![\\w-])(?:${MARKETING_WORDS.join("|")})(?![\\w-])`, "gi")
+
+export function marketing(lines: readonly string[]): Violation[] {
+  return scanLines(lines, MARKETING_PATTERN).map((match) => ({
+    ruleId: "marketing",
+    severity: "soft" as const,
+    message: `Do not use marketing language. Delete "${match.found.toLowerCase()}".`,
+    line: match.line,
+    column: match.column,
+  }))
+}

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -28,7 +28,7 @@ const MARKETING_WORDS = [
 ]
 
 const MARKETING_SET = new Set(MARKETING_WORDS)
-const HYPHENATED_TOKEN = /[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)*/g
+const HYPHENATED_TOKEN = /[A-Za-z0-9_]+(?:-+[A-Za-z0-9_]+)*/g
 
 interface MarketingMatch {
   readonly found: string

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -28,7 +28,7 @@ const MARKETING_WORDS = [
 ]
 
 const MARKETING_SET = new Set(MARKETING_WORDS)
-const HYPHENATED_TOKEN = /[A-Za-z0-9_]+(?:-+[A-Za-z0-9_]+)*/g
+const HYPHENATED_TOKEN = /-*[A-Za-z0-9_]+(?:-+[A-Za-z0-9_]+)*-*/g
 
 interface MarketingMatch {
   readonly found: string

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,3 +1,4 @@
+import { TOKEN_RUN_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
 const MARKETING_WORDS = [
@@ -28,7 +29,6 @@ const MARKETING_WORDS = [
 ]
 
 const MARKETING_SET = new Set(MARKETING_WORDS)
-const HYPHENATED_TOKEN = /-*[A-Za-z0-9_]+(?:-+[A-Za-z0-9_]+)*-*/g
 
 interface MarketingMatch {
   readonly found: string
@@ -52,7 +52,7 @@ function findMarketingLanguage(token: string): MarketingMatch | undefined {
 
 export function marketing(lines: readonly string[]): Violation[] {
   return lines.flatMap((line, lineIndex) =>
-    Array.from(line.matchAll(HYPHENATED_TOKEN)).flatMap((tokenMatch) => {
+    Array.from(line.matchAll(TOKEN_RUN_PATTERN)).flatMap((tokenMatch) => {
       const match = findMarketingLanguage(tokenMatch[0])
       if (!match) {
         return []

--- a/src/engine/rules/paragraph-length.ts
+++ b/src/engine/rules/paragraph-length.ts
@@ -1,0 +1,23 @@
+import type { Paragraph } from "../paragraphs.ts"
+import { segmentSentences } from "../sentences.ts"
+import type { Violation } from "../types.ts"
+
+const MAX_SENTENCES = 6
+
+export function paragraphLength(paragraphs: readonly Paragraph[]): Violation[] {
+  return paragraphs.flatMap((paragraph) => {
+    const count = segmentSentences(paragraph.lines).length
+    if (count <= MAX_SENTENCES) {
+      return []
+    }
+    return [
+      {
+        ruleId: "paragraph-length",
+        severity: "hard" as const,
+        message: `Paragraph has ${count} sentences; the maximum is ${MAX_SENTENCES}.`,
+        line: paragraph.line,
+        column: 1,
+      },
+    ]
+  })
+}

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -1,4 +1,5 @@
 import { scanLines } from "../scan.ts"
+import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
 interface PhrasalVerbEntry {
@@ -37,7 +38,7 @@ const PHRASAL_VERBS: readonly PhrasalVerbEntry[] = [
 const patterns = PHRASAL_VERBS.map((entry) => ({
   suggestion: entry.suggestion,
   pattern: new RegExp(
-    `\\b(?:${entry.forms.map((form) => form.replace(/ /g, "\\s+")).join("|")})\\b`,
+    `(?<!${TOKEN_CHARACTER_PATTERN})(?:${entry.forms.map((form) => form.replace(/ /g, "\\s+")).join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
     "gi",
   ),
 }))

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -1,0 +1,53 @@
+import { scanLines } from "../scan.ts"
+import type { Violation } from "../types.ts"
+
+interface PhrasalVerbEntry {
+  readonly forms: readonly string[]
+  readonly suggestion: string
+}
+
+// List and suggestions follow the pi-ste reference implementation, extended
+// with conjugated forms and "carry out" from the HUF-132 spec.
+const PHRASAL_VERBS: readonly PhrasalVerbEntry[] = [
+  { forms: ["carry out", "carries out", "carried out", "carrying out"], suggestion: "do" },
+  { forms: ["spin up", "spins up", "spun up", "spinning up"], suggestion: "start" },
+  { forms: ["spin down", "spins down", "spinning down"], suggestion: "stop" },
+  {
+    forms: ["tear down", "tears down", "tore down", "torn down", "tearing down"],
+    suggestion: "remove",
+  },
+  { forms: ["reach out", "reaches out", "reached out", "reaching out"], suggestion: "ask" },
+  { forms: ["dive into", "dives into", "dived into", "diving into"], suggestion: "examine" },
+  { forms: ["kick off", "kicks off", "kicked off", "kicking off"], suggestion: "start" },
+  { forms: ["roll out", "rolls out", "rolled out", "rolling out"], suggestion: "release" },
+  { forms: ["ramp up", "ramps up", "ramped up", "ramping up"], suggestion: "increase" },
+  {
+    forms: ["circle back", "circles back", "circled back", "circling back"],
+    suggestion: "return to",
+  },
+  {
+    forms: ["drill down", "drills down", "drilled down", "drilling down"],
+    suggestion: "examine",
+  },
+]
+
+const patterns = PHRASAL_VERBS.map((entry) => ({
+  suggestion: entry.suggestion,
+  pattern: new RegExp(
+    `\\b(?:${entry.forms.map((form) => form.replace(" ", "\\s+")).join("|")})\\b`,
+    "gi",
+  ),
+}))
+
+export function phrasalVerb(lines: readonly string[]): Violation[] {
+  return patterns.flatMap(({ pattern, suggestion }) =>
+    scanLines(lines, pattern).map((match) => ({
+      ruleId: "phrasal-verb",
+      severity: "hard" as const,
+      message: `Do not use a phrasal verb. Use "${suggestion}", not "${match.found.toLowerCase()}".`,
+      line: match.line,
+      column: match.column,
+      suggestion,
+    })),
+  )
+}

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -26,7 +26,7 @@ const PHRASAL_VERBS: readonly PhrasalVerbEntry[] = [
   { forms: ["ramp up", "ramps up", "ramped up", "ramping up"], suggestion: "increase" },
   {
     forms: ["circle back", "circles back", "circled back", "circling back"],
-    suggestion: "return to",
+    suggestion: "return",
   },
   {
     forms: ["drill down", "drills down", "drilled down", "drilling down"],

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -11,13 +11,16 @@ interface PhrasalVerbEntry {
 const PHRASAL_VERBS: readonly PhrasalVerbEntry[] = [
   { forms: ["carry out", "carries out", "carried out", "carrying out"], suggestion: "do" },
   { forms: ["spin up", "spins up", "spun up", "spinning up"], suggestion: "start" },
-  { forms: ["spin down", "spins down", "spinning down"], suggestion: "stop" },
+  { forms: ["spin down", "spins down", "spun down", "spinning down"], suggestion: "stop" },
   {
     forms: ["tear down", "tears down", "tore down", "torn down", "tearing down"],
     suggestion: "remove",
   },
   { forms: ["reach out", "reaches out", "reached out", "reaching out"], suggestion: "ask" },
-  { forms: ["dive into", "dives into", "dived into", "diving into"], suggestion: "examine" },
+  {
+    forms: ["dive into", "dives into", "dived into", "dove into", "diving into"],
+    suggestion: "examine",
+  },
   { forms: ["kick off", "kicks off", "kicked off", "kicking off"], suggestion: "start" },
   { forms: ["roll out", "rolls out", "rolled out", "rolling out"], suggestion: "release" },
   { forms: ["ramp up", "ramps up", "ramped up", "ramping up"], suggestion: "increase" },
@@ -34,7 +37,7 @@ const PHRASAL_VERBS: readonly PhrasalVerbEntry[] = [
 const patterns = PHRASAL_VERBS.map((entry) => ({
   suggestion: entry.suggestion,
   pattern: new RegExp(
-    `\\b(?:${entry.forms.map((form) => form.replace(" ", "\\s+")).join("|")})\\b`,
+    `\\b(?:${entry.forms.map((form) => form.replace(/ /g, "\\s+")).join("|")})\\b`,
     "gi",
   ),
 }))

--- a/src/engine/rules/registry.ts
+++ b/src/engine/rules/registry.ts
@@ -1,5 +1,11 @@
 export const ruleIds = [
+  "contraction",
   "dictionary-not-approved-word",
+  "hedging",
+  "marketing",
+  "paragraph-length",
+  "phrasal-verb",
+  "semicolon",
   "sentence-length",
   "verb-progressive",
   "verb-passive",

--- a/src/engine/rules/semicolon.ts
+++ b/src/engine/rules/semicolon.ts
@@ -1,0 +1,14 @@
+import { scanLines } from "../scan.ts"
+import type { Violation } from "../types.ts"
+
+const SEMICOLON = /;/g
+
+export function semicolon(lines: readonly string[]): Violation[] {
+  return scanLines(lines, SEMICOLON).map((match) => ({
+    ruleId: "semicolon",
+    severity: "hard" as const,
+    message: "Do not use a semicolon. Write two sentences.",
+    line: match.line,
+    column: match.column,
+  }))
+}

--- a/src/engine/scan.ts
+++ b/src/engine/scan.ts
@@ -1,0 +1,15 @@
+export interface LineMatch {
+  readonly found: string
+  readonly line: number
+  readonly column: number
+}
+
+export function scanLines(lines: readonly string[], pattern: RegExp): LineMatch[] {
+  return lines.flatMap((line, index) =>
+    Array.from(line.matchAll(pattern), (match) => ({
+      found: match[0],
+      line: index + 1,
+      column: match.index + 1,
+    })),
+  )
+}

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -4,55 +4,101 @@ export interface Sentence {
   readonly column: number
 }
 
-const SENTENCE_PUNCTUATION = /[.!?]+/g
 const CLOSING_DELIMITERS = new Set(["\"", "'", "’", "”", "»", "›", ")", "]", "}", "*", "_", "~", "`"])
 
-function markdownSuffixEnd(text: string, start: number): number | undefined {
-  const opening = text[start]
-  const closing = opening === "(" ? ")" : "]"
-  let depth = 1
+function markdownDelimiterEnds(text: string): {
+  readonly parentheses: Int32Array
+  readonly brackets: Int32Array
+} {
+  const parentheses = new Int32Array(text.length).fill(-1)
+  const brackets = new Int32Array(text.length).fill(-1)
+  const parenthesisStack: number[] = []
+  const bracketStack: number[] = []
 
-  for (let index = start + 1; index < text.length; index += 1) {
-    const character = text[index]
-    if (character === "\\") {
-      index += 1
-    } else if (character === opening) {
-      depth += 1
-    } else if (character === closing) {
-      depth -= 1
-      if (depth === 0) return index + 1
-    } else if (character === "\r" || character === "\n") {
-      return undefined
+  for (let index = 0; index < text.length; index += 1) {
+    switch (text[index]) {
+      case "\\":
+        index += 1
+        break
+      case "(":
+        parenthesisStack.push(index)
+        break
+      case ")": {
+        const opening = parenthesisStack.pop()
+        if (opening !== undefined) parentheses[opening] = index + 1
+        break
+      }
+      case "[":
+        bracketStack.push(index)
+        break
+      case "]": {
+        const opening = bracketStack.pop()
+        if (opening !== undefined) brackets[opening] = index + 1
+        break
+      }
     }
   }
+
+  return { parentheses, brackets }
 }
 
-function terminatorEnd(text: string): number | undefined {
-  for (const punctuation of text.matchAll(SENTENCE_PUNCTUATION)) {
-    let end = punctuation.index + punctuation[0].length
-    let closedLinkLabel = false
+function sentenceTerminatorEnds(text: string): number[] {
+  const { parentheses, brackets } = markdownDelimiterEnds(text)
+  const closingRuns = new Uint32Array(text.length + 1)
+  const closingBracketCounts = new Uint32Array(text.length + 1)
+  const referenceRuns = new Int32Array(text.length).fill(-1)
+  const ends: number[] = []
+  closingRuns[text.length] = text.length
 
-    while (CLOSING_DELIMITERS.has(text[end] ?? "")) {
-      closedLinkLabel ||= text[end] === "]"
-      end += 1
+  for (let index = text.length - 1; index >= 0; index -= 1) {
+    closingRuns[index] = CLOSING_DELIMITERS.has(text[index] ?? "")
+      ? closingRuns[index + 1]
+      : index
+    closingBracketCounts[index] =
+      closingBracketCounts[index + 1] + (text[index] === "]" ? 1 : 0)
+  }
+
+  for (let index = text.length - 1; index >= 0; index -= 1) {
+    if (text[index] !== "[" || brackets[index] < 0) continue
+    let end = closingRuns[brackets[index]]
+    if (text[end] === "[" && referenceRuns[end] >= 0) end = referenceRuns[end]
+    referenceRuns[index] = end
+  }
+
+  for (let index = 0; index < text.length; index += 1) {
+    if (text[index] !== "." && text[index] !== "!" && text[index] !== "?") continue
+
+    let punctuationEnd = index + 1
+    while (
+      text[punctuationEnd] === "." ||
+      text[punctuationEnd] === "!" ||
+      text[punctuationEnd] === "?"
+    ) {
+      punctuationEnd += 1
     }
+
+    let end = closingRuns[punctuationEnd]
+    const closedLinkLabel =
+      closingBracketCounts[punctuationEnd] > closingBracketCounts[end]
 
     if (closedLinkLabel && text[end] === "(") {
-      const suffixEnd = markdownSuffixEnd(text, end)
-      if (suffixEnd === undefined) continue
-      end = suffixEnd
-      while (CLOSING_DELIMITERS.has(text[end] ?? "")) end += 1
+      if (parentheses[end] < 0) {
+        index = punctuationEnd - 1
+        continue
+      }
+      end = closingRuns[parentheses[end]]
     }
 
-    while (text[end] === "[") {
-      const suffixEnd = markdownSuffixEnd(text, end)
-      if (suffixEnd === undefined) break
-      end = suffixEnd
-      while (CLOSING_DELIMITERS.has(text[end] ?? "")) end += 1
+    if (text[end] === "[" && referenceRuns[end] >= 0) end = referenceRuns[end]
+    if (end === text.length || /\s/.test(text[end] ?? "")) {
+      ends.push(end)
+      index = end - 1
+    } else {
+      index = punctuationEnd - 1
     }
-
-    if (end === text.length || /\s/.test(text[end] ?? "")) return end
   }
+
+  return ends
 }
 
 // A sentence starts at the first non-whitespace character and ends at
@@ -76,22 +122,25 @@ export function segmentSentences(lines: readonly string[]): Sentence[] {
       close()
       return
     }
-    let rest = raw
     let offset = 0
-    while (rest.trim() !== "") {
+    for (const end of sentenceTerminatorEnds(raw)) {
+      const part = raw.slice(offset, end)
+      if (!open) {
+        const indent = part.length - part.trimStart().length
+        open = { line: index + 1, column: offset + indent + 1, parts: [] }
+      }
+      open.parts.push(part.trim())
+      close()
+      offset = end
+    }
+
+    const rest = raw.slice(offset)
+    if (rest.trim() !== "") {
       if (!open) {
         const indent = rest.length - rest.trimStart().length
         open = { line: index + 1, column: offset + indent + 1, parts: [] }
       }
-      const end = terminatorEnd(rest)
-      if (end === undefined) {
-        open.parts.push(rest.trim())
-        break
-      }
-      open.parts.push(rest.slice(0, end).trim())
-      close()
-      offset += end
-      rest = rest.slice(end)
+      open.parts.push(rest.trim())
     }
   })
   close()

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -4,7 +4,31 @@ export interface Sentence {
   readonly column: number
 }
 
-const CLOSING_DELIMITERS = new Set(["\"", "'", "’", "”", "»", "›", ")", "]", "}", "*", "_", "~", "`"])
+const CLOSING_DELIMITERS = new Set([
+  '"',
+  "'",
+  "’",
+  "”",
+  "»",
+  "›",
+  ")",
+  "]",
+  "}",
+  "*",
+  "_",
+  "~",
+  "`",
+])
+
+function valueAt(values: Int32Array | Uint32Array, index: number): number {
+  const value = values[index]
+  if (value === undefined) throw new RangeError(`Array index ${index} is out of bounds`)
+  return value
+}
+
+function sentinelAt(values: Int32Array, index: number): number {
+  return values[index] ?? -1
+}
 
 function markdownDelimiterEnds(text: string): {
   readonly parentheses: Int32Array
@@ -33,7 +57,7 @@ function markdownDelimiterEnds(text: string): {
       case "\\":
         index += 1
         break
-      case "\"":
+      case '"':
       case "'": {
         const opening = parenthesisStack[parenthesisStack.length - 1]
         const isLinkTitle =
@@ -70,10 +94,12 @@ function markdownDelimiterEnds(text: string): {
   for (let index = 0; index < text.length - 1; index += 1) {
     if (text[index] !== "]") continue
     const suffixStart = index + 1
-    if (text[suffixStart] === "(" && parentheses[suffixStart] >= 0) {
-      linkSuffixes[suffixStart] = parentheses[suffixStart]
-    } else if (text[suffixStart] === "[" && brackets[suffixStart] >= 0) {
-      linkSuffixes[suffixStart] = brackets[suffixStart]
+    const parenthesisEnd = valueAt(parentheses, suffixStart)
+    const bracketEnd = valueAt(brackets, suffixStart)
+    if (text[suffixStart] === "(" && parenthesisEnd >= 0) {
+      linkSuffixes[suffixStart] = parenthesisEnd
+    } else if (text[suffixStart] === "[" && bracketEnd >= 0) {
+      linkSuffixes[suffixStart] = bracketEnd
     }
   }
 
@@ -90,22 +116,25 @@ function sentenceTerminatorEnds(text: string): number[] {
 
   for (let index = text.length - 1; index >= 0; index -= 1) {
     closingRuns[index] = CLOSING_DELIMITERS.has(text[index] ?? "")
-      ? closingRuns[index + 1]
+      ? valueAt(closingRuns, index + 1)
       : index
     closingBracketCounts[index] =
-      closingBracketCounts[index + 1] + (text[index] === "]" ? 1 : 0)
+      valueAt(closingBracketCounts, index + 1) + (text[index] === "]" ? 1 : 0)
   }
 
   for (let index = text.length - 1; index >= 0; index -= 1) {
-    if (text[index] !== "[" || brackets[index] < 0) continue
-    let end = closingRuns[brackets[index]]
-    if (text[end] === "[" && referenceRuns[end] >= 0) end = referenceRuns[end]
+    const bracketEnd = valueAt(brackets, index)
+    if (text[index] !== "[" || bracketEnd < 0) continue
+    let end = valueAt(closingRuns, bracketEnd)
+    const referenceEnd = sentinelAt(referenceRuns, end)
+    if (text[end] === "[" && referenceEnd >= 0) end = referenceEnd
     referenceRuns[index] = end
   }
 
   for (let index = 0; index < text.length; index += 1) {
-    if (linkSuffixes[index] >= 0) {
-      index = linkSuffixes[index] - 1
+    const linkSuffixEnd = valueAt(linkSuffixes, index)
+    if (linkSuffixEnd >= 0) {
+      index = linkSuffixEnd - 1
       continue
     }
     if (text[index] !== "." && text[index] !== "!" && text[index] !== "?") continue
@@ -119,19 +148,21 @@ function sentenceTerminatorEnds(text: string): number[] {
       punctuationEnd += 1
     }
 
-    let end = closingRuns[punctuationEnd]
+    let end = valueAt(closingRuns, punctuationEnd)
     const closedLinkLabel =
-      closingBracketCounts[punctuationEnd] > closingBracketCounts[end]
+      valueAt(closingBracketCounts, punctuationEnd) > valueAt(closingBracketCounts, end)
 
     if (closedLinkLabel && text[end] === "(") {
-      if (parentheses[end] < 0) {
+      const parenthesisEnd = valueAt(parentheses, end)
+      if (parenthesisEnd < 0) {
         index = punctuationEnd - 1
         continue
       }
-      end = closingRuns[parentheses[end]]
+      end = valueAt(closingRuns, parenthesisEnd)
     }
 
-    if (text[end] === "[" && referenceRuns[end] >= 0) end = referenceRuns[end]
+    const referenceEnd = sentinelAt(referenceRuns, end)
+    if (text[end] === "[" && referenceEnd >= 0) end = referenceEnd
     if (end === text.length || /\s/.test(text[end] ?? "")) {
       ends.push(end)
       index = end - 1

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -4,7 +4,49 @@ export interface Sentence {
   readonly column: number
 }
 
-const TERMINATOR = /[.!?]+["'’”»›)\]}*_~`]*(\s|$)/
+const SENTENCE_PUNCTUATION = /[.!?]+/g
+const CLOSING_DELIMITERS = new Set(["\"", "'", "’", "”", "»", "›", ")", "]", "}", "*", "_", "~", "`"])
+
+function markdownSuffixEnd(text: string, start: number): number | undefined {
+  const opening = text[start]
+  const closing = opening === "(" ? ")" : "]"
+  let depth = 1
+
+  for (let index = start + 1; index < text.length; index += 1) {
+    const character = text[index]
+    if (character === "\\") {
+      index += 1
+    } else if (character === opening) {
+      depth += 1
+    } else if (character === closing) {
+      depth -= 1
+      if (depth === 0) return index + 1
+    } else if (character === "\r" || character === "\n") {
+      return undefined
+    }
+  }
+}
+
+function terminatorEnd(text: string): number | undefined {
+  for (const punctuation of text.matchAll(SENTENCE_PUNCTUATION)) {
+    let end = punctuation.index + punctuation[0].length
+    let closedLinkLabel = false
+
+    while (CLOSING_DELIMITERS.has(text[end] ?? "")) {
+      closedLinkLabel ||= text[end] === "]"
+      end += 1
+    }
+
+    if (closedLinkLabel && (text[end] === "(" || text[end] === "[")) {
+      const suffixEnd = markdownSuffixEnd(text, end)
+      if (suffixEnd === undefined) continue
+      end = suffixEnd
+      while (CLOSING_DELIMITERS.has(text[end] ?? "")) end += 1
+    }
+
+    if (end === text.length || /\s/.test(text[end] ?? "")) return end
+  }
+}
 
 // A sentence starts at the first non-whitespace character and ends at
 // terminal punctuation and closing delimiters, at a blank line, or at EOF.
@@ -34,12 +76,11 @@ export function segmentSentences(lines: readonly string[]): Sentence[] {
         const indent = rest.length - rest.trimStart().length
         open = { line: index + 1, column: offset + indent + 1, parts: [] }
       }
-      const terminator = rest.match(TERMINATOR)
-      if (terminator?.index === undefined) {
+      const end = terminatorEnd(rest)
+      if (end === undefined) {
         open.parts.push(rest.trim())
         break
       }
-      const end = terminator.index + terminator[0].length
       open.parts.push(rest.slice(0, end).trim())
       close()
       offset += end

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -6,21 +6,6 @@ export interface Sentence {
 
 const CLOSING_DELIMITERS = new Set(["\"", "'", "’", "”", "»", "›", ")", "]", "}", "*", "_", "~", "`"])
 
-function closingDelimiterIndex(
-  text: string,
-  start: number,
-  delimiter: string,
-): number | undefined {
-  for (let index = start + 1; index < text.length; index += 1) {
-    if (text[index] === "\\") {
-      index += 1
-    } else if (text[index] === delimiter) {
-      return index
-    }
-  }
-  return undefined
-}
-
 function markdownDelimiterEnds(text: string): {
   readonly parentheses: Int32Array
   readonly brackets: Int32Array
@@ -31,9 +16,20 @@ function markdownDelimiterEnds(text: string): {
   const linkSuffixes = new Int32Array(text.length).fill(-1)
   const parenthesisStack: number[] = []
   const bracketStack: number[] = []
+  let opaqueDelimiter: string | undefined
 
   for (let index = 0; index < text.length; index += 1) {
-    switch (text[index]) {
+    const character = text[index]
+    if (opaqueDelimiter !== undefined) {
+      if (character === "\\") {
+        index += 1
+      } else if (character === opaqueDelimiter) {
+        opaqueDelimiter = undefined
+      }
+      continue
+    }
+
+    switch (character) {
       case "\\":
         index += 1
         break
@@ -42,20 +38,14 @@ function markdownDelimiterEnds(text: string): {
         const opening = parenthesisStack[parenthesisStack.length - 1]
         const isLinkTitle =
           opening !== undefined && text[opening - 1] === "]" && /\s/.test(text[index - 1] ?? "")
-        if (isLinkTitle) {
-          const end = closingDelimiterIndex(text, index, text[index] ?? "")
-          if (end !== undefined) index = end
-        }
+        if (isLinkTitle) opaqueDelimiter = character
         break
       }
       case "<": {
         const opening = parenthesisStack[parenthesisStack.length - 1]
         const isAngleDestination =
           opening !== undefined && text[opening - 1] === "]" && index === opening + 1
-        if (isAngleDestination) {
-          const end = closingDelimiterIndex(text, index, ">")
-          if (end !== undefined) index = end
-        }
+        if (isAngleDestination) opaqueDelimiter = ">"
         break
       }
       case "(":

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -4,10 +4,10 @@ export interface Sentence {
   readonly column: number
 }
 
-const TERMINATOR = /[.!?]+(\s|$)/
+const TERMINATOR = /[.!?]+["'’”»›)\]}*_~`]*(\s|$)/
 
 // A sentence starts at the first non-whitespace character and ends at
-// terminal punctuation followed by whitespace, at a blank line, or at EOF.
+// terminal punctuation and closing delimiters, at a blank line, or at EOF.
 // Sentences may span lines; position is where the sentence starts (1-based).
 export function segmentSentences(lines: readonly string[]): Sentence[] {
   const sentences: Sentence[] = []

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -6,6 +6,21 @@ export interface Sentence {
 
 const CLOSING_DELIMITERS = new Set(["\"", "'", "’", "”", "»", "›", ")", "]", "}", "*", "_", "~", "`"])
 
+function closingDelimiterIndex(
+  text: string,
+  start: number,
+  delimiter: string,
+): number | undefined {
+  for (let index = start + 1; index < text.length; index += 1) {
+    if (text[index] === "\\") {
+      index += 1
+    } else if (text[index] === delimiter) {
+      return index
+    }
+  }
+  return undefined
+}
+
 function markdownDelimiterEnds(text: string): {
   readonly parentheses: Int32Array
   readonly brackets: Int32Array
@@ -22,6 +37,27 @@ function markdownDelimiterEnds(text: string): {
       case "\\":
         index += 1
         break
+      case "\"":
+      case "'": {
+        const opening = parenthesisStack[parenthesisStack.length - 1]
+        const isLinkTitle =
+          opening !== undefined && text[opening - 1] === "]" && /\s/.test(text[index - 1] ?? "")
+        if (isLinkTitle) {
+          const end = closingDelimiterIndex(text, index, text[index] ?? "")
+          if (end !== undefined) index = end
+        }
+        break
+      }
+      case "<": {
+        const opening = parenthesisStack[parenthesisStack.length - 1]
+        const isAngleDestination =
+          opening !== undefined && text[opening - 1] === "]" && index === opening + 1
+        if (isAngleDestination) {
+          const end = closingDelimiterIndex(text, index, ">")
+          if (end !== undefined) index = end
+        }
+        break
+      }
       case "(":
         parenthesisStack.push(index)
         break

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -37,9 +37,16 @@ function terminatorEnd(text: string): number | undefined {
       end += 1
     }
 
-    if (closedLinkLabel && (text[end] === "(" || text[end] === "[")) {
+    if (closedLinkLabel && text[end] === "(") {
       const suffixEnd = markdownSuffixEnd(text, end)
       if (suffixEnd === undefined) continue
+      end = suffixEnd
+      while (CLOSING_DELIMITERS.has(text[end] ?? "")) end += 1
+    }
+
+    while (text[end] === "[") {
+      const suffixEnd = markdownSuffixEnd(text, end)
+      if (suffixEnd === undefined) break
       end = suffixEnd
       while (CLOSING_DELIMITERS.has(text[end] ?? "")) end += 1
     }

--- a/src/engine/sentences.ts
+++ b/src/engine/sentences.ts
@@ -9,9 +9,11 @@ const CLOSING_DELIMITERS = new Set(["\"", "'", "’", "”", "»", "›", ")", "
 function markdownDelimiterEnds(text: string): {
   readonly parentheses: Int32Array
   readonly brackets: Int32Array
+  readonly linkSuffixes: Int32Array
 } {
   const parentheses = new Int32Array(text.length).fill(-1)
   const brackets = new Int32Array(text.length).fill(-1)
+  const linkSuffixes = new Int32Array(text.length).fill(-1)
   const parenthesisStack: number[] = []
   const bracketStack: number[] = []
 
@@ -39,11 +41,21 @@ function markdownDelimiterEnds(text: string): {
     }
   }
 
-  return { parentheses, brackets }
+  for (let index = 0; index < text.length - 1; index += 1) {
+    if (text[index] !== "]") continue
+    const suffixStart = index + 1
+    if (text[suffixStart] === "(" && parentheses[suffixStart] >= 0) {
+      linkSuffixes[suffixStart] = parentheses[suffixStart]
+    } else if (text[suffixStart] === "[" && brackets[suffixStart] >= 0) {
+      linkSuffixes[suffixStart] = brackets[suffixStart]
+    }
+  }
+
+  return { parentheses, brackets, linkSuffixes }
 }
 
 function sentenceTerminatorEnds(text: string): number[] {
-  const { parentheses, brackets } = markdownDelimiterEnds(text)
+  const { parentheses, brackets, linkSuffixes } = markdownDelimiterEnds(text)
   const closingRuns = new Uint32Array(text.length + 1)
   const closingBracketCounts = new Uint32Array(text.length + 1)
   const referenceRuns = new Int32Array(text.length).fill(-1)
@@ -66,6 +78,10 @@ function sentenceTerminatorEnds(text: string): number[] {
   }
 
   for (let index = 0; index < text.length; index += 1) {
+    if (linkSuffixes[index] >= 0) {
+      index = linkSuffixes[index] - 1
+      continue
+    }
     if (text[index] !== "." && text[index] !== "!" && text[index] !== "?") continue
 
     let punctuationEnd = index + 1

--- a/src/engine/tokens.ts
+++ b/src/engine/tokens.ts
@@ -1,0 +1,2 @@
+export const TOKEN_CHARACTER_PATTERN = "[A-Za-z0-9_'’-]"
+export const TOKEN_RUN_PATTERN = new RegExp(`${TOKEN_CHARACTER_PATTERN}+`, "g")

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -15,6 +15,7 @@ export interface Violation {
   readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
+  readonly suggestion?: string
 }
 
 export interface LintOptions {

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -163,6 +163,39 @@ describe("simple-english CLI", () => {
     expect(result.stdout).toContain("verb-passive")
   })
 
+  test("human output shows the severity of each violation", async () => {
+    const result = await runCli(["test/fixtures/violations.md"])
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("[hard] sentence-length")
+  })
+
+  test("soft violations appear in the output but exit 0", async () => {
+    const result = await runCli([], { stdin: "This is a seamless flow." })
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain("[soft] marketing")
+    expect(result.stdout).toContain("seamless")
+  })
+
+  test("--json reports severity and the phrasal-verb suggestion", async () => {
+    const result = await runCli(["--json"], {
+      stdin: "Carry out the test. It is a seamless flow.",
+    })
+
+    expect(result.code).toBe(1)
+    const report = JSON.parse(result.stdout)
+    expect(report.summary).toEqual({ total: 2, hard: 1 })
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        ruleId: "phrasal-verb",
+        severity: "hard",
+        suggestion: "do",
+      }),
+      expect.objectContaining({ ruleId: "marketing", severity: "soft" }),
+    ])
+  })
+
   test("errors with exit code 2 on an unreadable file", async () => {
     const result = await runCli(["test/fixtures/does-not-exist.md"])
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -91,7 +91,7 @@ describe("simple-english CLI", () => {
     const result = await runCli([], { stdin: "The pump is running." })
 
     expect(result.code).toBe(1)
-    expect(result.stdout).toContain("<stdin>:1:10 verb-progressive")
+    expect(result.stdout).toContain("<stdin>:1:10 [hard] verb-progressive")
     expect(result.stdout).toContain("Do not use the progressive")
   })
 
@@ -99,7 +99,7 @@ describe("simple-english CLI", () => {
     const result = await runCli([], { stdin: "The bolt was removed." })
 
     expect(result.code).toBe(0)
-    expect(result.stdout).toContain("<stdin>:1:10 verb-passive")
+    expect(result.stdout).toContain("<stdin>:1:10 [soft] verb-passive")
     expect(result.stdout).toContain("active voice")
   })
 
@@ -107,7 +107,7 @@ describe("simple-english CLI", () => {
     const result = await runCli([], { stdin: "We attempt the repair." })
 
     expect(result.code).toBe(1)
-    expect(result.stdout).toContain("<stdin>:1:4 dictionary-not-approved-word")
+    expect(result.stdout).toContain("<stdin>:1:4 [hard] dictionary-not-approved-word")
     expect(result.stdout).toContain('Use "try", not "attempt".')
   })
 

--- a/test/engine/contraction.test.ts
+++ b/test/engine/contraction.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
+
+describe("lint prose-file: contraction rule", () => {
+  test("flags a contraction as a hard violation with its position", () => {
+    const report = lint("prose-file", "The lock isn't held.")
+
+    const violation = report.violations.find((v) => v.ruleId === "contraction")
+    expect(violation).toMatchObject({
+      ruleId: "contraction",
+      severity: "hard",
+      line: 1,
+      column: 10,
+    })
+    expect(violation?.message).toContain("isn't")
+  })
+
+  test("flags an apostrophe-s contraction", () => {
+    expect(idsFor("It's ready now.")).toContain("contraction")
+  })
+
+  test("does not flag a possessive", () => {
+    expect(idsFor("Check the repo's own docs and Cameron's notes.")).not.toContain("contraction")
+  })
+
+  test("flags every unambiguous contraction form", () => {
+    for (const form of ["don't", "we're", "we've", "we'll", "we'd", "I'm"]) {
+      expect(idsFor(`Now ${form} here.`), form).toContain("contraction")
+    }
+  })
+
+  test("flags a typographic apostrophe", () => {
+    expect(idsFor("The lock isn’t held.")).toContain("contraction")
+  })
+
+  test("does not flag plain prose", () => {
+    expect(idsFor("Do not remove the bolt.")).not.toContain("contraction")
+  })
+})

--- a/test/engine/contraction.test.ts
+++ b/test/engine/contraction.test.ts
@@ -38,4 +38,8 @@ describe("lint prose-file: contraction rule", () => {
   test("does not flag plain prose", () => {
     expect(idsFor("Do not remove the bolt.")).not.toContain("contraction")
   })
+
+  test("ignores contractions inside inline code", () => {
+    expect(idsFor("Use `don't` here.")).not.toContain("contraction")
+  })
 })

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -206,7 +206,10 @@ describe("lint prose-file: dictionary rule", () => {
   })
 
   test("matches hyphenated forms as one exact token", () => {
-    const report = lint("prose-file", "Use state-of-the-art parts.", { dictionary })
+    const report = lint("prose-file", "Use state-of-the-art parts.", {
+      dictionary,
+      rules: { marketing: "off" },
+    })
 
     expect(report.violations).toEqual([
       {

--- a/test/engine/hedging.test.ts
+++ b/test/engine/hedging.test.ts
@@ -34,6 +34,14 @@ describe("lint prose-file: hedging rule", () => {
     expect(report.summary.hard).toBe(0)
   })
 
+  test.each([
+    "The text says as mentioned-above.",
+    "Do not use as mentioned's wording.",
+    "Do not use as mentioned’s wording.",
+  ])("does not match within a token in %s", (text) => {
+    expect(idsFor(text)).not.toContain("hedging")
+  })
+
   test("does not flag plain prose that mentions notes", () => {
     expect(idsFor("Write a note in the log.")).not.toContain("hedging")
   })

--- a/test/engine/hedging.test.ts
+++ b/test/engine/hedging.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
+
+describe("lint prose-file: hedging rule", () => {
+  test("flags a hedge phrase as a soft violation", () => {
+    const report = lint("prose-file", "It is important to note that the lock is held.")
+
+    const violation = report.violations.find((v) => v.ruleId === "hedging")
+    expect(violation).toMatchObject({
+      ruleId: "hedging",
+      severity: "soft",
+      line: 1,
+      column: 1,
+    })
+    expect(violation?.message.toLowerCase()).toContain("it is important to note")
+  })
+
+  test("flags listed hedge phrases regardless of case", () => {
+    for (const text of [
+      "it should be noted that the pump runs.",
+      "Please note that the valve is open.",
+      "This is worth doing, as mentioned.",
+    ]) {
+      expect(idsFor(text), text).toContain("hedging")
+    }
+  })
+
+  test("soft hedging violations do not count as hard in the summary", () => {
+    const report = lint("prose-file", "It is worth noting that the pump runs.")
+
+    expect(report.summary.total).toBe(1)
+    expect(report.summary.hard).toBe(0)
+  })
+
+  test("does not flag plain prose that mentions notes", () => {
+    expect(idsFor("Write a note in the log.")).not.toContain("hedging")
+  })
+})

--- a/test/engine/lint.test.ts
+++ b/test/engine/lint.test.ts
@@ -53,6 +53,14 @@ describe("lint prose-file: sentence-length rule", () => {
     expect(report.violations[0]).toMatchObject({ line: 3, column: 20 })
   })
 
+  test("does not rescan punctuation inside a Markdown sentence suffix", () => {
+    const prefix = '[Short.](url "A. title") '
+    const report = lint("prose-file", `${prefix}${words(30)}.`)
+
+    const violation = report.violations.find((item) => item.ruleId === "sentence-length")
+    expect(violation).toMatchObject({ line: 1, column: prefix.length + 1 })
+  })
+
   test("counts a sentence that spans multiple lines once, at its start", () => {
     const text = `${words(13)}\n${words(13)}.`
     const report = lint("prose-file", text)

--- a/test/engine/lint.test.ts
+++ b/test/engine/lint.test.ts
@@ -68,6 +68,15 @@ describe("lint prose-file: sentence-length rule", () => {
     expect(report.violations.map((violation) => violation.ruleId)).toEqual(["semicolon"])
   })
 
+  test("does not pair inline code delimiters across paragraph boundaries", () => {
+    const text = "Use `literal\n\nCarry out the test.\nClose ` marker."
+    const report = lint("prose-file", text)
+
+    expect(report.violations).toContainEqual(
+      expect.objectContaining({ ruleId: "phrasal-verb", line: 3, column: 1 }),
+    )
+  })
+
   test("counts a sentence that spans multiple lines once, at its start", () => {
     const text = `${words(13)}\n${words(13)}.`
     const report = lint("prose-file", text)

--- a/test/engine/lint.test.ts
+++ b/test/engine/lint.test.ts
@@ -61,6 +61,13 @@ describe("lint prose-file: sentence-length rule", () => {
     expect(violation).toMatchObject({ line: 1, column: prefix.length + 1 })
   })
 
+  test("ignores inline code for all rules except semicolons", () => {
+    const text = `Use \`don't; carry out this seamless task as mentioned. One. Two. Three. Four. Five. Six. Seven. ${words(30)}.\` here.`
+    const report = lint("prose-file", text)
+
+    expect(report.violations.map((violation) => violation.ruleId)).toEqual(["semicolon"])
+  })
+
   test("counts a sentence that spans multiple lines once, at its start", () => {
     const text = `${words(13)}\n${words(13)}.`
     const report = lint("prose-file", text)

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -34,14 +34,17 @@ describe("lint prose-file: marketing rule", () => {
     expect(violation?.message).toContain("robust")
   })
 
-  test("flags only the first listed part of a hyphenated token", () => {
-    const report = lint("prose-file", "A robust-powerful platform.")
+  test.each(["robust-powerful", "robust--powerful"])(
+    "flags only the first listed part of the hyphenated token %s",
+    (token) => {
+      const report = lint("prose-file", `A ${token} platform.`)
 
-    const violations = report.violations.filter((v) => v.ruleId === "marketing")
-    expect(violations).toHaveLength(1)
-    expect(violations[0]).toMatchObject({ line: 1, column: 3 })
-    expect(violations[0]?.message).toContain("robust")
-  })
+      const violations = report.violations.filter((v) => v.ruleId === "marketing")
+      expect(violations).toHaveLength(1)
+      expect(violations[0]).toMatchObject({ line: 1, column: 3 })
+      expect(violations[0]?.message).toContain("robust")
+    },
+  )
 
   test("soft marketing violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "A robust and powerful tool.")

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -34,6 +34,15 @@ describe("lint prose-file: marketing rule", () => {
     expect(violation?.message).toContain("robust")
   })
 
+  test("flags only the first listed part of a hyphenated token", () => {
+    const report = lint("prose-file", "A robust-powerful platform.")
+
+    const violations = report.violations.filter((v) => v.ruleId === "marketing")
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ line: 1, column: 3 })
+    expect(violations[0]?.message).toContain("robust")
+  })
+
   test("soft marketing violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "A robust and powerful tool.")
 

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
+
+describe("lint prose-file: marketing rule", () => {
+  test("flags a marketing word as a soft violation with its position", () => {
+    const report = lint("prose-file", "This is a seamless flow.")
+
+    const violation = report.violations.find((v) => v.ruleId === "marketing")
+    expect(violation).toMatchObject({
+      ruleId: "marketing",
+      severity: "soft",
+      line: 1,
+      column: 11,
+    })
+    expect(violation?.message).toContain("seamless")
+  })
+
+  test("flags hyphenated marketing compounds", () => {
+    for (const text of [
+      "A state-of-the-art design.",
+      "The cutting-edge pipeline runs.",
+      "Our enterprise-grade stack.",
+    ]) {
+      expect(idsFor(text), text).toContain("marketing")
+    }
+  })
+
+  test("soft marketing violations do not count as hard in the summary", () => {
+    const report = lint("prose-file", "A robust and powerful tool.")
+
+    const violations = report.violations.filter((v) => v.ruleId === "marketing")
+    expect(violations).toHaveLength(2)
+    expect(report.summary.hard).toBe(0)
+  })
+
+  test("does not flag words that merely contain a listed word", () => {
+    expect(idsFor("The seam is straight. The power supply is on.")).not.toContain("marketing")
+  })
+})

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -53,6 +53,13 @@ describe("lint prose-file: marketing rule", () => {
     },
   )
 
+  test.each(["Turnkey's interface.", "Turnkey’s interface."])(
+    "preserves apostrophes in the token %s",
+    (text) => {
+      expect(idsFor(text)).not.toContain("marketing")
+    },
+  )
+
   test("soft marketing violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "A robust and powerful tool.")
 

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -17,14 +17,21 @@ describe("lint prose-file: marketing rule", () => {
     expect(violation?.message).toContain("seamless")
   })
 
-  test("flags hyphenated marketing compounds", () => {
-    for (const text of [
-      "A state-of-the-art design.",
-      "The cutting-edge pipeline runs.",
-      "Our enterprise-grade stack.",
-    ]) {
-      expect(idsFor(text), text).toContain("marketing")
-    }
+  test("flags complete hyphenated marketing compounds", () => {
+    const report = lint("prose-file", "A state-of-the-art design.")
+
+    const violations = report.violations.filter((v) => v.ruleId === "marketing")
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ line: 1, column: 3 })
+    expect(violations[0]?.message).toContain("state-of-the-art")
+  })
+
+  test("flags listed words within larger hyphenated tokens", () => {
+    const report = lint("prose-file", "An ultra-robust platform.")
+
+    const violation = report.violations.find((v) => v.ruleId === "marketing")
+    expect(violation).toMatchObject({ line: 1, column: 10 })
+    expect(violation?.message).toContain("robust")
   })
 
   test("soft marketing violations do not count as hard in the summary", () => {

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -46,6 +46,13 @@ describe("lint prose-file: marketing rule", () => {
     },
   )
 
+  test.each(["state-of-the-art--", "--state-of-the-art"])(
+    "preserves terminal hyphens in the token %s",
+    (token) => {
+      expect(idsFor(`A ${token} design.`)).not.toContain("marketing")
+    },
+  )
+
   test("soft marketing violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "A robust and powerful tool.")
 

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -65,6 +65,16 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor(text)).not.toContain("paragraph-length")
   })
 
+  test("does not count an ordered-list marker as a sentence", () => {
+    expect(idsFor("1. One. Two. Three. Four. Five. Six.")).not.toContain("paragraph-length")
+  })
+
+  test("flags a long list item across continuation lines", () => {
+    const text = "- One. Two. Three.\n Four. Five. Six. Seven."
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
   test("a table is not a paragraph", () => {
     const text = [
       "| Rule | Severity |",

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -77,15 +77,29 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor(text)).toContain("paragraph-length")
   })
 
+  test("flags a long blockquote paragraph", () => {
+    const text = "> One. Two. Three. Four. Five. Six. Seven."
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
+  test("a blockquote starts a paragraph after preceding content", () => {
+    const text = "One. Two. Three.\n> Four. Five. Six. Seven."
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
   test("a blockquote ends a list item paragraph", () => {
     const text = "- One. Two. Three.\n> Four. Five. Six. Seven."
 
     expect(idsFor(text)).not.toContain("paragraph-length")
   })
 
-  test("ignores punctuation in Markdown link destinations and titles", () => {
-    const text = 'One. Two. Three. Four. Five. Read [the docs](url "Version 1.") before setup.'
-
+  test.each([
+    'One. Two. Three. Four. Five. Read [the docs](url "Version 1.") before setup.',
+    'One. Two. Three. Four. Five. Read [docs](url "Version (beta.") before setup.',
+    'One. Two. Three. Four. Five. Read [docs](<url(with-parenthesis> "Version 1.") before setup.',
+  ])("ignores punctuation in Markdown link destinations and titles", (text) => {
     expect(idsFor(text)).not.toContain("paragraph-length")
   })
 

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -72,8 +72,21 @@ describe("lint prose-file: paragraph-length rule", () => {
   test.each([
     "- One. Two. Three.\n Four. Five. Six. Seven.",
     "- One. Two. Three.\nFour. Five. Six. Seven.",
+    "- One. Two. Three.\n#hashtag Four. Five. Six. Seven.",
   ])("flags a long list item across continuation lines", (text) => {
     expect(idsFor(text)).toContain("paragraph-length")
+  })
+
+  test("a blockquote ends a list item paragraph", () => {
+    const text = "- One. Two. Three.\n> Four. Five. Six. Seven."
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
+  test("ignores punctuation in Markdown link destinations and titles", () => {
+    const text = 'One. Two. Three. Four. Five. Read [the docs](url "Version 1.") before setup.'
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
   })
 
   test("scans malformed Markdown suffixes in linear time", () => {

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
+
+describe("lint prose-file: paragraph-length rule", () => {
+  test("flags a paragraph over 6 sentences as a hard violation", () => {
+    const report = lint("prose-file", "One. Two. Three. Four. Five. Six. Seven.")
+
+    const violation = report.violations.find((v) => v.ruleId === "paragraph-length")
+    expect(violation).toMatchObject({
+      ruleId: "paragraph-length",
+      severity: "hard",
+      line: 1,
+      column: 1,
+    })
+    expect(violation?.message).toContain("7")
+    expect(violation?.message).toContain("6")
+  })
+
+  test("does not flag a paragraph of exactly 6 sentences", () => {
+    expect(idsFor("One. Two. Three. Four. Five. Six.")).not.toContain("paragraph-length")
+  })
+
+  test("a blank line ends a paragraph", () => {
+    expect(idsFor("One. Two. Three. Four.\n\nFive. Six. Seven. Eight.")).not.toContain(
+      "paragraph-length",
+    )
+  })
+
+  test("a bullet list is not one long paragraph", () => {
+    const text = "- One. Two.\n- Three. Four.\n- Five. Six.\n- Seven. Eight.\n- Nine. Ten."
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
+  test("a numbered list is not one long paragraph", () => {
+    const text = "1. One. Two.\n2. Three. Four.\n3. Five. Six.\n4. Seven. Eight."
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
+  test("a table is not a paragraph", () => {
+    const text = [
+      "| Rule | Severity |",
+      "| --- | --- |",
+      "| one. | hard. |",
+      "| two. | soft. |",
+      "| three. | hard. |",
+      "| four. | soft. |",
+      "| five. | hard. |",
+    ].join("\n")
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
+  test("a heading ends a paragraph", () => {
+    const text = "One. Two. Three.\n## A heading\nFour. Five. Six. Seven."
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
+  test("still flags a long prose paragraph that spans hard-wrapped lines", () => {
+    const text = "One. Two. Three. Four.\nFive. Six. Seven. Eight. Nine."
+    const report = lint("prose-file", text)
+
+    const violation = report.violations.find((v) => v.ruleId === "paragraph-length")
+    expect(violation).toMatchObject({ severity: "hard", line: 1, column: 1 })
+    expect(violation?.message).toContain("9")
+  })
+
+  test("reports the line where the paragraph starts", () => {
+    const text = "A short opener.\n\nOne. Two. Three. Four. Five. Six. Seven."
+    const report = lint("prose-file", text)
+
+    const violation = report.violations.find((v) => v.ruleId === "paragraph-length")
+    expect(violation).toMatchObject({ line: 3, column: 1 })
+  })
+})

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -29,9 +29,15 @@ describe("lint prose-file: paragraph-length rule", () => {
   })
 
   test("flags sentences before closing Markdown delimiters", () => {
-    const text = "*One.* **Two.** _Three._ ~~Four.~~ `Five.` **Six!** _Seven?_"
+    const text = "*One.* **Two.** _Three._ ~~Four.~~ **Five.** _Six!_ *Seven?*"
 
     expect(idsFor(text)).toContain("paragraph-length")
+  })
+
+  test("ignores punctuation inside inline code spans", () => {
+    const text = "One. Two. Three. Four. Five. Six. `Seven. Eight.`"
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
   })
 
   test("flags sentences in Markdown links and references", () => {
@@ -115,8 +121,8 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor(text)).not.toContain("paragraph-length")
   })
 
-  test("scans malformed Markdown suffixes in linear time", () => {
-    const text = ".[".repeat(30_000)
+  test.each([".[", "](<"])("scans malformed Markdown suffixes in linear time", (part) => {
+    const text = part.repeat(30_000)
     const start = performance.now()
 
     lint("prose-file", text)

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -65,6 +65,18 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor(text)).not.toContain("paragraph-length")
   })
 
+  test("blockquoted list items are separate paragraphs", () => {
+    const text = "> - One. Two.\n> - Three. Four.\n> - Five. Six.\n> - Seven. Eight."
+
+    expect(idsFor(text)).not.toContain("paragraph-length")
+  })
+
+  test("flags a long blockquoted list item across continuation lines", () => {
+    const text = "> - One. Two. Three.\n> Four. Five. Six. Seven."
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
   test("does not count an ordered-list marker as a sentence", () => {
     expect(idsFor("1. One. Two. Three. Four. Five. Six.")).not.toContain("paragraph-length")
   })

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -34,6 +34,13 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor(text)).toContain("paragraph-length")
   })
 
+  test("flags sentences in Markdown links and references", () => {
+    const text =
+      '[One.](one) [Two.][two] [Three.][] [Four.](four "title") [Five.](<five>) [Six!](six_(nested)) [Seven?][seven]'
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
   test("a blank line ends a paragraph", () => {
     expect(idsFor("One. Two. Three. Four.\n\nFive. Six. Seven. Eight.")).not.toContain(
       "paragraph-length",

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -41,6 +41,12 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor(text)).toContain("paragraph-length")
   })
 
+  test("flags sentences with post-terminator Markdown references", () => {
+    const text = "One.[^1] Two.[two] Three.[^3] Four.[four] Five.[^5] Six.[six] Seven.[^7]"
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
   test("a blank line ends a paragraph", () => {
     expect(idsFor("One. Two. Three. Four.\n\nFive. Six. Seven. Eight.")).not.toContain(
       "paragraph-length",

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -22,6 +22,18 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor("One. Two. Three. Four. Five. Six.")).not.toContain("paragraph-length")
   })
 
+  test("flags a paragraph of quoted sentences", () => {
+    const text = '"One." "Two." “Three.” ‘Four.’ "Five?" “Six!” "Seven."'
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
+  test("flags sentences before closing Markdown delimiters", () => {
+    const text = "*One.* **Two.** _Three._ ~~Four.~~ `Five.` **Six!** _Seven?_"
+
+    expect(idsFor(text)).toContain("paragraph-length")
+  })
+
   test("a blank line ends a paragraph", () => {
     expect(idsFor("One. Two. Three. Four.\n\nFive. Six. Seven. Eight.")).not.toContain(
       "paragraph-length",

--- a/test/engine/paragraph-length.test.ts
+++ b/test/engine/paragraph-length.test.ts
@@ -69,10 +69,20 @@ describe("lint prose-file: paragraph-length rule", () => {
     expect(idsFor("1. One. Two. Three. Four. Five. Six.")).not.toContain("paragraph-length")
   })
 
-  test("flags a long list item across continuation lines", () => {
-    const text = "- One. Two. Three.\n Four. Five. Six. Seven."
-
+  test.each([
+    "- One. Two. Three.\n Four. Five. Six. Seven.",
+    "- One. Two. Three.\nFour. Five. Six. Seven.",
+  ])("flags a long list item across continuation lines", (text) => {
     expect(idsFor(text)).toContain("paragraph-length")
+  })
+
+  test("scans malformed Markdown suffixes in linear time", () => {
+    const text = ".[".repeat(30_000)
+    const start = performance.now()
+
+    lint("prose-file", text)
+
+    expect(performance.now() - start).toBeLessThan(500)
   })
 
   test("a table is not a paragraph", () => {

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -53,6 +53,14 @@ describe("lint prose-file: phrasal-verb rule", () => {
     expect(violation).toMatchObject({ line: 1, column: 8 })
   })
 
+  test.each([
+    "The channel carries out-of-band data.",
+    "Do not confuse carry out's spelling.",
+    "Do not confuse carry out’s spelling.",
+  ])("does not match within a token in %s", (text) => {
+    expect(idsFor(text)).not.toContain("phrasal-verb")
+  })
+
   test("does not flag the bare verb without its particle", () => {
     expect(idsFor("We spin the wheel. Carry the box.")).not.toContain("phrasal-verb")
   })

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -20,7 +20,12 @@ describe("lint prose-file: phrasal-verb rule", () => {
   })
 
   test("flags conjugated forms", () => {
-    for (const text of ["The runner carries out the job.", "We carried out the check."]) {
+    for (const text of [
+      "The runner carries out the job.",
+      "We carried out the check.",
+      "We spun down the cluster.",
+      "They dove into the logs.",
+    ]) {
       expect(idsFor(text), text).toContain("phrasal-verb")
     }
   })

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
+
+describe("lint prose-file: phrasal-verb rule", () => {
+  test("flags a phrasal verb as a hard violation with the approved alternative", () => {
+    const report = lint("prose-file", "Carry out the test.")
+
+    const violation = report.violations.find((v) => v.ruleId === "phrasal-verb")
+    expect(violation).toMatchObject({
+      ruleId: "phrasal-verb",
+      severity: "hard",
+      line: 1,
+      column: 1,
+      suggestion: "do",
+    })
+    expect(violation?.message).toContain('"do"')
+    expect(violation?.message.toLowerCase()).toContain("carry out")
+  })
+
+  test("flags conjugated forms", () => {
+    for (const text of ["The runner carries out the job.", "We carried out the check."]) {
+      expect(idsFor(text), text).toContain("phrasal-verb")
+    }
+  })
+
+  test("suggests the single-verb alternative for each listed phrasal verb", () => {
+    const cases: readonly [string, string][] = [
+      ["Spin up the worker.", "start"],
+      ["Tear down the stack.", "remove"],
+      ["Reach out to the team.", "ask"],
+      ["Roll out the change.", "release"],
+      ["Ramp up the load.", "increase"],
+    ]
+    for (const [text, suggestion] of cases) {
+      const report = lint("prose-file", text)
+      const violation = report.violations.find((v) => v.ruleId === "phrasal-verb")
+      expect(violation?.suggestion, text).toBe(suggestion)
+    }
+  })
+
+  test("reports the column where the phrasal verb starts", () => {
+    const report = lint("prose-file", "Please spin up the worker.")
+
+    const violation = report.violations.find((v) => v.ruleId === "phrasal-verb")
+    expect(violation).toMatchObject({ line: 1, column: 8 })
+  })
+
+  test("does not flag the bare verb without its particle", () => {
+    expect(idsFor("We spin the wheel. Carry the box.")).not.toContain("phrasal-verb")
+  })
+
+  test("does not flag unrelated words that contain a listed verb", () => {
+    expect(idsFor("The spinner works. The carrier is here.")).not.toContain("phrasal-verb")
+  })
+})

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -37,6 +37,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
       ["Reach out to the team.", "ask"],
       ["Roll out the change.", "release"],
       ["Ramp up the load.", "increase"],
+      ["Circle back tomorrow.", "return"],
     ]
     for (const [text, suggestion] of cases) {
       const report = lint("prose-file", text)

--- a/test/engine/semicolon.test.ts
+++ b/test/engine/semicolon.test.ts
@@ -28,6 +28,14 @@ describe("lint prose-file: semicolon rule", () => {
     expect(idsFor("Start the job. Then stop it.")).not.toContain("semicolon")
   })
 
+  test("flags semicolons inside inline code", () => {
+    const report = lint("prose-file", "Use `const value = 1;` here.")
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "semicolon", line: 1, column: 21 }),
+    ])
+  })
+
   test("ignores semicolons inside fenced code blocks", () => {
     const text = "A sentence.\n```ts\nconst x = 1;\n```\nAnother sentence."
 

--- a/test/engine/semicolon.test.ts
+++ b/test/engine/semicolon.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest"
+import { lint } from "../../src/engine/lint.ts"
+
+const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
+
+describe("lint prose-file: semicolon rule", () => {
+  test("flags a semicolon as a hard violation at its column", () => {
+    const report = lint("prose-file", "Start the job; then stop it.")
+
+    const violation = report.violations.find((v) => v.ruleId === "semicolon")
+    expect(violation).toMatchObject({
+      ruleId: "semicolon",
+      severity: "hard",
+      line: 1,
+      column: 14,
+    })
+  })
+
+  test("flags each semicolon separately", () => {
+    const report = lint("prose-file", "One; two; three.")
+
+    const violations = report.violations.filter((v) => v.ruleId === "semicolon")
+    expect(violations).toHaveLength(2)
+    expect(violations.map((v) => v.column)).toEqual([4, 9])
+  })
+
+  test("does not flag text without semicolons", () => {
+    expect(idsFor("Start the job. Then stop it.")).not.toContain("semicolon")
+  })
+
+  test("ignores semicolons inside fenced code blocks", () => {
+    const text = "A sentence.\n```ts\nconst x = 1;\n```\nAnother sentence."
+
+    expect(idsFor(text)).not.toContain("semicolon")
+  })
+})


### PR DESCRIPTION
## Intent

Implement Linear HUF-132 Mechanical and list rules for pi-simple-english. Add pure synchronous engine rules with stable IDs: hard paragraph length over 6 sentences, contractions, semicolons, and curated phrasal verbs with approved single-verb suggestions; soft curated hedging and marketing language warnings. Cover triggering and non-triggering fixtures at the engine seam, plus CLI E2E severity and exit behavior. Human and JSON output must include severity, and only hard violations cause exit code 1. Mirror the pi-ste reference defaults without wink-nlp, dictionary, or config. Keep semicolon scanning of inline code and per-line multiword matching as accepted reference-aligned behavior. Include missing phrasal-verb conjugation fixtures and robust global replacement in phrase regex construction.

## What Changed

- Add hard paragraph-length, contraction, semicolon, and phrasal-verb rules, plus soft hedging and marketing rules with approved phrasal-verb suggestions.
- Improve Markdown-aware paragraph, sentence, token, and inline-code handling across lists, blockquotes, links, and references.
- Include severity in human and JSON CLI output, preserve exit 0 for soft-only findings, and document the rule defaults.

## Risk Assessment

🚨 High: The new hard semicolon rule remains reachable inside code that the required reference behavior masks, so the change does not fully satisfy authoritative acceptance criteria.

## Testing

No prior baseline result was supplied; targeted engine and CLI tests passed, and manual CLI checks demonstrated human and JSON severity, hard-versus-soft exit behavior, stable rule IDs, suggestions, inline-code semicolon scanning, per-line matching, all conjugations, and global whitespace matching, with transcripts recorded as evidence.

<details>
<summary>Evidence: CLI human-output and exit-code transcript</summary>

```text
=== Hard and soft input ===
One. Two. Three. Four. Five. Six. Seven.

It's ready.
Use `x;` now.
Carry out the test.
It is worth noting that this is a seamless flow.
=== Human output ===
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md:1:1 [hard] paragraph-length Paragraph has 7 sentences; the maximum is 6.
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md:3:1 [hard] contraction Do not use a contraction. Write the words in full. Found "It's".
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md:4:7 [hard] semicolon Do not use a semicolon. Write two sentences.
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md:5:1 [hard] phrasal-verb Do not use a phrasal verb. Use "do", not "carry out".
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md:6:1 [soft] hedging Do not hedge. Delete "it is worth noting".
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md:6:35 [soft] marketing Do not use marketing language. Delete "seamless".
exit_code=1

=== Soft-only input ===
It is worth noting that this is a seamless flow.
=== Human output ===
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/soft-only.md:1:1 [soft] hedging Do not hedge. Delete "it is worth noting".
/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/soft-only.md:1:35 [soft] marketing Do not use marketing language. Delete "seamless".
exit_code=0

=== Per-line matching input ===
Carry
out the test.
=== Human output ===
<no violations>
exit_code=0

=== JSON hard-and-soft exit ===
exit_code=1
```
</details>
<details>
<summary>Evidence: CLI JSON report with severity and suggestion fields</summary>

```text
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md",
      "ruleId": "paragraph-length",
      "severity": "hard",
      "message": "Paragraph has 7 sentences; the maximum is 6.",
      "line": 1,
      "column": 1
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"It's\".",
      "line": 3,
      "column": 1
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md",
      "ruleId": "semicolon",
      "severity": "hard",
      "message": "Do not use a semicolon. Write two sentences.",
      "line": 4,
      "column": 7
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md",
      "ruleId": "phrasal-verb",
      "severity": "hard",
      "message": "Do not use a phrasal verb. Use \"do\", not \"carry out\".",
      "line": 5,
      "column": 1,
      "suggestion": "do"
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md",
      "ruleId": "hedging",
      "severity": "soft",
      "message": "Do not hedge. Delete \"it is worth noting\".",
      "line": 6,
      "column": 1
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 6,
      "column": 35
    }
  ],
  "summary": {
    "total": 6,
    "hard": 4
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/engine/rules/marketing.ts:34` - The required criterion says to &#34;Mirror the pi-ste reference defaults.&#34; This pattern intentionally suppresses listed words adjacent to hyphens, so `ultra-robust` produces no marketing warning. pi-ste checks hyphenated token parts and reports `robust`. Allow hyphen adjacency while preserving matches for complete listed compounds, or explicitly authorize this deviation.

🔧 Fix: Fix marketing matches within hyphenated tokens
2 errors still open:
- 🚨 `src/engine/rules/paragraph-length.ts:8` - The required &#34;hard paragraph length over 6 sentences&#34; behavior remains bypassable: `segmentSentences` recognizes punctuation only before whitespace or EOF, so seven valid quoted sentences such as `&#34;One.&#34; &#34;Two.&#34; ... &#34;Seven.&#34;` count as one and produce no hard violation. Fix sentence termination at the shared `segmentSentences` boundary to accept closing quotes and Markdown delimiters, then add a paragraph regression fixture.
- 🚨 `src/engine/rules/marketing.ts:31` - The required &#34;Mirror the pi-ste reference defaults&#34; behavior is still mismatched for hyphenated tokens. `robust-powerful` produces two marketing violations, while pi-ste checks hyphen parts in order and emits only the first matching part per token. Preserve exact compound matches, but emit only the first listed part when falling back to hyphen-part matching, with a focused regression fixture.

🔧 Fix: Fix quoted sentence and hyphenated marketing detection
3 errors still open:
- 🚨 `src/engine/sentences.ts:7` - The required hard limit over 6 sentences remains bypassable. Seven valid Markdown link sentences such as `[One.](x) ... [Seven.](x)` are counted as one because each period is followed by `](`, which TERMINATOR cannot consume. Handle complete closing link and reference syntax at the shared segmentSentences boundary and add a regression fixture.
- 🚨 `src/engine/rules/marketing.ts:31` - The required pi-ste behavior of reporting only the first matching hyphen part remains reachable through repeated hyphens. `robust--powerful` becomes two tokens here and emits two warnings, while pi-ste retains it as one token and emits only `robust`. Tokenize the complete word and hyphen run before applying findMarketingLanguage, with a focused fixture.
- 🚨 `src/engine/rules/phrasal-verb.ts:29` - The intent requires approved single-verb suggestions, but `circle back` suggests the two-word `return to`. This mirrors pi-ste but conflicts with the stated single-verb requirement. Confirm that this exception is authorized or select the approved single-word alternative.

🔧 Fix: Fix Markdown boundaries and list rule edge cases
2 errors still open:
- 🚨 `src/engine/sentences.ts:47` - The required &#34;hard paragraph length over 6 sentences&#34; remains bypassable for valid Markdown footnotes or shortcut references after punctuation. `One.[^1] Two.[^2] ... Seven.[^7]` counts as one sentence because each period is followed by `[` and rejected as a terminator. Recognize bounded post-terminator reference suffixes at the shared `segmentSentences` boundary and add a focused regression fixture.
- 🚨 `src/engine/rules/marketing.ts:31` - The required criterion says to &#34;Mirror the pi-ste reference defaults.&#34; This tokenizer drops terminal hyphens, so `state-of-the-art--` is treated as an exact compound and warned on. pi-ste retains the full hyphen run as one token and emits no match because no individual part is listed. Preserve leading and trailing hyphen runs during tokenization before exact and fallback matching, with a focused fixture.

🔧 Fix: Fix Markdown references and terminal hyphen tokenization
2 errors still open:
- 🚨 `src/engine/rules/marketing.ts:31` - The required criterion says to &#34;Mirror the pi-ste reference defaults.&#34; This tokenizer excludes straight and curly apostrophes, so `Turnkey&#39;s interface` reports `turnkey`, while pi-ste retains `turnkey&#39;s` as one token and does not match it. Preserve apostrophes in complete token runs and add focused non-triggering fixtures.
- 🚨 `src/engine/rules/phrasal-verb.ts:40` - The required criterion says to &#34;Mirror the pi-ste reference defaults.&#34; The `\b` boundary treats a hyphen as a phrase boundary, so `The channel carries out-of-band data` incorrectly emits a hard `carries out` violation. pi-ste retains `out-of-band` as one token and does not match the phrase. Use token-compatible hyphen and apostrophe boundaries and add a regression fixture.

🔧 Fix: Align marketing and phrasal token boundaries
2 errors still open:
- 🚨 `src/engine/paragraphs.ts:43` - The required &#34;hard paragraph length over 6 sentences&#34; invariant fails for list items. `1. One. Two. Three. Four. Five. Six.` is reported as seven sentences because the ordered-list marker is retained, while a valid wrapped item such as `- One. Two. Three.\n  Four. Five. Six. Seven.` is split into two paragraphs and bypasses the rule. At this segmentation boundary, exclude the marker and retain continuation lines as part of the list-item paragraph, with focused regressions.
- 🚨 `src/engine/rules/hedging.ts:14` - The required criterion says to &#34;Mirror the pi-ste reference defaults.&#34; The `\b` boundaries match listed phrases inside hyphenated or apostrophe-containing tokens, such as `as mentioned-above`, while pi-ste retains `mentioned-above` as one token and does not match the phrase. Use the shared token-compatible outer boundaries and add non-triggering fixtures.

🔧 Fix: Fix list paragraphs and hedging token boundaries
2 issues (1 error, 1 warning) still open:
- 🚨 `src/engine/paragraphs.ts:54` - The required &#34;hard paragraph length over 6 sentences&#34; remains bypassable for valid CommonMark lazy list continuations. `- One. Two. Three.\nFour. Five. Six. Seven.` is one list-item paragraph, but the unindented continuation closes the item here, producing two short paragraphs. Preserve lazy prose continuation at `segmentParagraphs` until a real block boundary or next list item, and add a focused regression fixture.
- ⚠️ `src/engine/sentences.ts:48` - Each punctuation candidate followed by `[` can rescan the complete remaining line through `markdownSuffixEnd`. An incomplete line such as repeated `.[` has no closing bracket and causes quadratic work in both sentence and paragraph linting. Use a single-pass scanner or precomputed delimiter closures so each character is inspected a bounded number of times.

🔧 Fix: Fix lazy lists and linearize Markdown scanning
2 errors still open:
- 🚨 `src/engine/paragraphs.ts:17` - The required &#34;hard paragraph length over 6 sentences&#34; remains bypassable after the claimed lazy-list fix. In `- One. Two. Three.\n#hashtag Four. Five. Six. Seven.`, `#hashtag` is a valid CommonMark lazy continuation, not an ATX heading, but `classify` closes and discards it. Conversely, a real blockquote boundary beginning with `&gt;` is appended to the list item and can cause a false hard violation. Recognize bounded Markdown block syntax at this shared classifier and add both regression cases.
- 🚨 `src/engine/sentences.ts:68` - Punctuation inside a Markdown link destination or title is still scanned unless punctuation in the label first causes the scanner to skip the suffix. `One. Two. Three. Four. Five. Read [the docs](url &#34;Version 1.&#34;) before setup.` therefore counts as seven sentences and produces a false hard paragraph violation. Precompute complete link suffix ranges and exclude their internal punctuation from sentence candidates, with a focused regression fixture.

🔧 Fix: Fix Markdown paragraph and link sentence boundaries
2 errors still open:
- 🚨 `src/engine/paragraphs.ts:23` - The required &#34;hard paragraph length over 6 sentences&#34; rule is bypassed for blockquotes. `&gt; One. Two. Three. Four. Five. Six. Seven.` is classified as a block boundary and discarded, so no paragraph reaches the rule. At `segmentParagraphs`, close the preceding paragraph but retain stripped blockquote content as its own paragraph.
- 🚨 `src/engine/sentences.ts:25` - The required hard limit produces a false violation for valid Markdown titles containing unmatched parentheses. In `One. Two. Three. Four. Five. Read [docs](url &#34;Version (beta.&#34;) before setup.`, the global parenthesis stack pairs the link&#39;s closing parenthesis with the title parenthesis, so title punctuation becomes a separate seventh sentence. Make the bounded link-suffix scan aware of quoted titles and angle-bracket destinations, then add a focused regression.

🔧 Fix: Fix blockquote and Markdown link sentence counting
1 error still open:
- 🚨 `src/engine/paragraphs.ts:61` - The required paragraph and list behavior fails inside blockquotes. `&gt; - One. Two.\n&gt; - Three. Four.\n&gt; - Five. Six.\n&gt; - Seven. Eight.` appends all stripped lines to one blockquote paragraph and emits a false hard eight-sentence violation, although each list item must be separate. Reclassify stripped blockquote content at this paragraph boundary so inner list markers retain list semantics.

🔧 Fix: Fix blockquoted list paragraph segmentation
2 issues (1 error, 1 warning) still open:
- 🚨 `src/engine/lint.ts:21` - The criteria require &#34;Mirror the pi-ste reference defaults&#34; while explicitly preserving semicolon scanning of inline code. These lines mask only fenced blocks and are also passed unchanged to every new rule. Therefore `Use `don&#39;t` here.` causes a hard contraction violation, and inline punctuation can inflate paragraph length, although pi-ste masks inline spans. Keep fence-only masking for semicolons, but pass inline-masked lines to the other rules.
- ⚠️ `src/engine/sentences.ts:56` - The forward scan for each possible angle-bracket link destination reintroduces quadratic processing. An input such as `](&lt;` repeated many times has no closing `&gt;`, so every `&lt;` scans the remaining line, and sentence scanning performs this work for both sentence and paragraph rules. Track angle destinations during the existing single pass instead of rescanning forward.

🔧 Fix: Mask inline code and linearize Markdown destination scanning
1 error still open:
- 🚨 `src/engine/markdown.ts:23` - The intent requires masking inline spans while mirroring pi-ste defaults, but this collects and pairs backtick runs across the entire file. For `Use `literal\n\nCarry out the test.\nClose ` marker.`, the runs on lines 1 and 4 pair and blank line 3, hiding the required hard phrasal-verb violation even though an inline span cannot cross the blank paragraph boundary and pi-ste resets masking per line. Reset pairing at block boundaries, or mirror per-line masking, and add this regression case.

🔧 Fix: Prevent inline code masking across paragraph boundaries
1 error still open:
- 🚨 `src/engine/lint.ts:23` - The required criterion says to &#34;Mirror the pi-ste reference defaults.&#34; The shared fence masker accepts at most three leading whitespace characters, while pi-ste trims all leading whitespace. Thus `    ```\n    const x = 1;\n    ```` emits a hard semicolon violation here instead of masking the fenced content. Align `blankCodeFences` with the reference boundary and add a focused fixture.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/engine/contraction.test.ts test/engine/hedging.test.ts test/engine/lint.test.ts test/engine/marketing.test.ts test/engine/paragraph-length.test.ts test/engine/phrasal-verb.test.ts test/engine/semicolon.test.ts test/cli/cli.test.ts`
- <code>`bun src/cli/main.ts /tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md` verified all six stable rule IDs, human severity labels, inline-code semicolon scanning, and exit code 1</code>
- <code>`bun src/cli/main.ts --json /tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/hard-and-soft.md` verified JSON severity, phrasal-verb suggestion, summary, and exit code 1</code>
- <code>`bun src/cli/main.ts /tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/soft-only.md` verified soft warnings with exit code 0</code>
- <code>`bun src/cli/main.ts /tmp/no-mistakes-evidence/01KYV95RQBY8Y8HNM5A52TB210/per-line.md` verified split multiword phrases do not match across lines</code>
- <code>`bun -e &#39;...&#39;` exercised all 46 curated phrasal-verb forms and tab-separated hedge matching to verify global whitespace replacement</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
