### PR TITLE
feat(extension): gate agent writes with STE linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ pi install npm:pi-simple-english
 ```
 
 For local development, run `pi -e .` from the repository instead.
-The extension adds a concise STE rule summary to the system prompt after it loads global and project configuration.
-It checks prose in `write` and `edit` tool calls before the tools change a file.
+At the start of each agent turn, the extension adds a concise STE rule summary that reflects the active configuration.
+It checks proposed `write` and `edit` content before the tools change a file, using the same file-extension content kinds described for the CLI below.
 Hard violations block the tool call with the line, column, rule ID, and a suggested fix so that the agent can correct the text and retry.
 Soft violations permit the tool call and appear as warnings.
 Edits use the existing file as a baseline, so unchanged violations do not block unrelated changes.
+A configuration or dictionary load error makes the extension fail closed and block `write` and `edit` for that session.
 
 ## CLI
 
@@ -74,7 +75,8 @@ Hedging, marketing, and phrasal-verb multiword matches stay within one line.
 
 Config is an optional JSON object.
 The global file lives at `simple-english.json` in the pi agent config directory, which defaults to `~/.pi/agent` and honors `PI_CODING_AGENT_DIR`.
-An optional per-project file at `.pi/simple-english.json` deep-merges over it, with the project value winning per key.
+For the CLI, an optional per-project file at `.pi/simple-english.json` deep-merges over it, with the project value winning per key.
+The extension uses the same merge for a trusted project and otherwise loads only the global file.
 
 ```json
 {
@@ -99,6 +101,7 @@ Entries without POS metadata use word-level matching.
 
 Set `SIMPLE_ENGLISH_DICTIONARY` to a replacement file that uses the documented [dictionary data format](src/dictionary/README.md).
 If that file cannot be read or validated, the CLI prints a dictionary error and continues with all other lint rules.
+The extension instead fails closed as described above.
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ A pi extension that makes the pi coding agent comply with ASD-STE100 Simplified 
 
 This project is a TypeScript and Effect reimplementation of [pi-ste](https://github.com/ctotheameron/pi-ste).
 
+## pi extension
+
+Install the package from npm:
+
+```sh
+pi install npm:pi-simple-english
+```
+
+For local development, run `pi -e .` from the repository instead.
+The extension adds a concise STE rule summary to the system prompt after it loads global and project configuration.
+It checks prose in `write` and `edit` tool calls before the tools change a file.
+Hard violations block the tool call with the line, column, rule ID, and a suggested fix so that the agent can correct the text and retry.
+Soft violations permit the tool call and appear as warnings.
+Edits use the existing file as a baseline, so unchanged violations do not block unrelated changes.
+
 ## CLI
 
 ```sh

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@earendil-works/pi-coding-agent": "0.83.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.8.0",
         "vitest": "^3.0.0",
@@ -18,6 +19,58 @@
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.4", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.67", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.10", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/credential-provider-env": "^3.972.65", "@aws-sdk/credential-provider-http": "^3.972.67", "@aws-sdk/credential-provider-login": "^3.972.72", "@aws-sdk/credential-provider-process": "^3.972.65", "@aws-sdk/credential-provider-sso": "^3.973.9", "@aws-sdk/credential-provider-web-identity": "^3.972.71", "@aws-sdk/nested-clients": "^3.997.39", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.72", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/nested-clients": "^3.997.39", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.76", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.65", "@aws-sdk/credential-provider-http": "^3.972.67", "@aws-sdk/credential-provider-ini": "^3.973.10", "@aws-sdk/credential-provider-process": "^3.972.65", "@aws-sdk/credential-provider-sso": "^3.973.9", "@aws-sdk/credential-provider-web-identity": "^3.972.71", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.65", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.9", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/nested-clients": "^3.997.39", "@aws-sdk/token-providers": "3.1100.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.71", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/nested-clients": "^3.997.39", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.31", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.26", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.47", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-UcPdY05u3TzvDah86NG6B9FgePYU6bXO7CRQIzQrieFL5xBBGajM7g1lCngmP4WA8EPed/kgT5CvM28cqSlBbA=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.39", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.43", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
 
     "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
@@ -35,6 +88,14 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
+
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.83.0", "", { "dependencies": { "@earendil-works/pi-ai": "^0.83.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.83.0", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.83.0", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.83.0", "@earendil-works/pi-ai": "^0.83.0", "@earendil-works/pi-tui": "^0.83.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.83.0", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -88,7 +149,55 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
+    "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
+
+    "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
+
+    "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
+
+    "@protobufjs/codegen": ["@protobufjs/codegen@2.0.5", "", {}, "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g=="],
+
+    "@protobufjs/eventemitter": ["@protobufjs/eventemitter@1.1.1", "", {}, "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg=="],
+
+    "@protobufjs/fetch": ["@protobufjs/fetch@1.1.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.1" } }, "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw=="],
+
+    "@protobufjs/float": ["@protobufjs/float@1.0.2", "", {}, "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="],
+
+    "@protobufjs/path": ["@protobufjs/path@1.1.2", "", {}, "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="],
+
+    "@protobufjs/pool": ["@protobufjs/pool@1.1.0", "", {}, "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="],
+
+    "@protobufjs/utf8": ["@protobufjs/utf8@1.1.2", "", {}, "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.3", "", { "os": "android", "cpu": "arm" }, "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw=="],
 
@@ -140,6 +249,26 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.3", "", { "os": "win32", "cpu": "x64" }, "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g=="],
 
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
+    "@smithy/core": ["@smithy/core@3.31.1", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.16", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.12", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -149,6 +278,8 @@
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w=="],
 
@@ -164,17 +295,41 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.7", "", { "dependencies": { "@vitest/pretty-format": "3.2.7", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
+    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
 
@@ -186,21 +341,87 @@
 
     "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gaxios": ["gaxios@7.3.0", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "google-auth-library": ["google-auth-library@10.9.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
+
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -212,11 +433,27 @@
 
     "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
+    "proper-lockfile": ["proper-lockfile@4.1.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
+
+    "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
+
     "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 
     "rollup": ["rollup@4.62.3", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.3", "@rollup/rollup-android-arm64": "4.62.3", "@rollup/rollup-darwin-arm64": "4.62.3", "@rollup/rollup-darwin-x64": "4.62.3", "@rollup/rollup-freebsd-arm64": "4.62.3", "@rollup/rollup-freebsd-x64": "4.62.3", "@rollup/rollup-linux-arm-gnueabihf": "4.62.3", "@rollup/rollup-linux-arm-musleabihf": "4.62.3", "@rollup/rollup-linux-arm64-gnu": "4.62.3", "@rollup/rollup-linux-arm64-musl": "4.62.3", "@rollup/rollup-linux-loong64-gnu": "4.62.3", "@rollup/rollup-linux-loong64-musl": "4.62.3", "@rollup/rollup-linux-ppc64-gnu": "4.62.3", "@rollup/rollup-linux-ppc64-musl": "4.62.3", "@rollup/rollup-linux-riscv64-gnu": "4.62.3", "@rollup/rollup-linux-riscv64-musl": "4.62.3", "@rollup/rollup-linux-s390x-gnu": "4.62.3", "@rollup/rollup-linux-x64-gnu": "4.62.3", "@rollup/rollup-linux-x64-musl": "4.62.3", "@rollup/rollup-openbsd-x64": "4.62.3", "@rollup/rollup-openharmony-arm64": "4.62.3", "@rollup/rollup-win32-arm64-msvc": "4.62.3", "@rollup/rollup-win32-ia32-msvc": "4.62.3", "@rollup/rollup-win32-x64-gnu": "4.62.3", "@rollup/rollup-win32-x64-msvc": "4.62.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -238,7 +475,15 @@
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typebox": ["typebox@1.3.7", "", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -248,10 +493,30 @@
 
     "vitest": ["vitest@3.2.7", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.7", "@vitest/mocker": "3.2.7", "@vitest/pretty-format": "^3.2.7", "@vitest/runner": "3.2.7", "@vitest/snapshot": "3.2.7", "@vitest/spy": "3.2.7", "@vitest/utils": "3.2.7", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.7", "@vitest/ui": "3.2.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wink-eng-lite-web-model": ["wink-eng-lite-web-model@1.8.1", "", {}, "sha512-M2tSOU/rVNkDj8AS8IoKJaM7apJJjS0cN+hE8CPazfnB4A/ojyc9+7RMPk18UOiIdSyWk7MR6w8z9lWix2l5tA=="],
 
     "wink-nlp": ["wink-nlp@2.4.0", "", {}, "sha512-d02inlNJL0LLNTLoYfkxZYGrqnYDSZV4HI4WpeuyIEfpu7UcUqUW1ZYWr+JTFm4ZR6dQdzOW/FtHEQRO+o/zzA=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1100.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.4", "@aws-sdk/nested-clients": "^3.997.39", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "ASD-STE100 Simplified Technical English lint engine and CLI for the pi coding agent",
   "license": "MIT",
   "type": "module",
+  "keywords": ["pi-package", "simplified-technical-english", "linter"],
+  "pi": {
+    "extensions": ["./src/extension/index.ts"]
+  },
+  "files": ["src", "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md"],
   "bin": {
     "simple-english": "./src/cli/main.ts"
   },
@@ -17,8 +22,12 @@
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
   },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@earendil-works/pi-coding-agent": "0.83.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.8.0",
     "vitest": "^3.0.0"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,51 +3,12 @@ import { readFile } from "node:fs/promises"
 import { Effect, Either } from "effect"
 import { loadConfig } from "../config/load.ts"
 import { loadDictionary } from "../dictionary/load.ts"
+import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
-import type { LintKind, LintReport, SourceDialect } from "../engine/types.ts"
+import type { LintKind, LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
 
 const KINDS: readonly LintKind[] = ["prose-file", "slash-source", "hash-source", "commit-message"]
-
-const SLASH_EXTENSIONS = new Set([
-  "ts",
-  "tsx",
-  "js",
-  "jsx",
-  "mjs",
-  "cjs",
-  "go",
-  "rs",
-  "java",
-  "c",
-  "h",
-  "cpp",
-  "hpp",
-  "cc",
-  "cs",
-  "swift",
-  "kt",
-  "scala",
-])
-
-const HASH_EXTENSIONS = new Set(["sh", "bash", "zsh", "py", "rb", "yaml", "yml", "toml", "pl"])
-
-interface PathClassification {
-  readonly kind: LintKind
-  readonly sourceDialect: SourceDialect
-}
-
-const classifyPath = (path: string): PathClassification => {
-  const dot = path.lastIndexOf(".")
-  if (dot <= path.lastIndexOf("/")) return { kind: "prose-file", sourceDialect: "general" }
-  const extension = path.slice(dot + 1).toLowerCase()
-  if (SLASH_EXTENSIONS.has(extension)) return { kind: "slash-source", sourceDialect: "general" }
-  if (HASH_EXTENSIONS.has(extension)) {
-    const sourceDialect = ["sh", "bash", "zsh"].includes(extension) ? "shell" : "general"
-    return { kind: "hash-source", sourceDialect }
-  }
-  return { kind: "prose-file", sourceDialect: "general" }
-}
 
 interface CliArgs {
   readonly json: boolean

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -47,10 +47,12 @@ const readConfigFile = (path: string, optional: boolean): Effect.Effect<SteConfi
 export const loadConfig = (
   explicitPath?: string,
   cwd = process.cwd(),
-): Effect.Effect<SteConfig, ConfigError> =>
-  explicitPath === undefined
-    ? Effect.all([
-        readConfigFile(globalConfigPath(), true),
-        readConfigFile(projectConfigPath(cwd), true),
-      ]).pipe(Effect.map(([global, project]) => mergeConfigs(global, project)))
-    : readConfigFile(explicitPath, false)
+  includeProjectConfig = true,
+): Effect.Effect<SteConfig, ConfigError> => {
+  if (explicitPath !== undefined) return readConfigFile(explicitPath, false)
+  const globalConfig = readConfigFile(globalConfigPath(), true)
+  if (!includeProjectConfig) return globalConfig
+  return Effect.all([globalConfig, readConfigFile(projectConfigPath(cwd), true)]).pipe(
+    Effect.map(([global, project]) => mergeConfigs(global, project)),
+  )
+}

--- a/src/engine/kinds.ts
+++ b/src/engine/kinds.ts
@@ -1,0 +1,43 @@
+import type { LintKind, SourceDialect } from "./types.ts"
+
+const SLASH_EXTENSIONS = new Set([
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "go",
+  "rs",
+  "java",
+  "c",
+  "h",
+  "cpp",
+  "hpp",
+  "cc",
+  "cs",
+  "swift",
+  "kt",
+  "scala",
+])
+
+const HASH_EXTENSIONS = new Set(["sh", "bash", "zsh", "py", "rb", "yaml", "yml", "toml", "pl"])
+
+export interface PathClassification {
+  readonly kind: LintKind
+  readonly sourceDialect: SourceDialect
+}
+
+export const classifyPath = (path: string): PathClassification => {
+  const dot = path.lastIndexOf(".")
+  if (dot <= Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"))) {
+    return { kind: "prose-file", sourceDialect: "general" }
+  }
+  const extension = path.slice(dot + 1).toLowerCase()
+  if (SLASH_EXTENSIONS.has(extension)) return { kind: "slash-source", sourceDialect: "general" }
+  if (HASH_EXTENSIONS.has(extension)) {
+    const sourceDialect = ["sh", "bash", "zsh"].includes(extension) ? "shell" : "general"
+    return { kind: "hash-source", sourceDialect }
+  }
+  return { kind: "prose-file", sourceDialect: "general" }
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -151,7 +151,7 @@ function lintProposedText(
 function createGatedWriteTool(cwd: string, state: SessionState) {
   const definition = createWriteToolDefinition(cwd)
   const execute: typeof definition.execute = async (...args) => {
-    const [toolCallId, input, _signal, _onUpdate, ctx] = args
+    const [toolCallId, input, signal, _onUpdate, ctx] = args
     const implementation = createWriteToolDefinition(cwd, {
       operations: {
         mkdir: async () => undefined,
@@ -171,6 +171,7 @@ function createGatedWriteTool(cwd: string, state: SessionState) {
           )
           if (result?.block) throw new Error(result.reason)
           await mkdir(dirname(path), { recursive: true })
+          if (signal?.aborted) throw new Error("Operation aborted")
           await writeFile(path, content, "utf8")
         },
       },

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -2,11 +2,11 @@ import { constants } from "node:fs"
 import { access, mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname } from "node:path"
 import {
-  createEditToolDefinition,
-  createWriteToolDefinition,
   type ExtensionAPI,
   type ExtensionContext,
   type ToolCallEventResult,
+  createEditToolDefinition,
+  createWriteToolDefinition,
 } from "@earendil-works/pi-coding-agent"
 import { Effect } from "effect"
 import { loadConfig } from "../config/load.ts"
@@ -161,14 +161,7 @@ function createGatedWriteTool(cwd: string, state: SessionState) {
               `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
             )
           }
-          const result = lintProposedText(
-            state,
-            ctx,
-            "write",
-            toolCallId,
-            input.path,
-            content,
-          )
+          const result = lintProposedText(state, ctx, "write", toolCallId, input.path, content)
           if (result?.block) throw new Error(result.reason)
           await mkdir(dirname(path), { recursive: true })
           if (signal?.aborted) throw new Error("Operation aborted")
@@ -229,9 +222,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     pi.registerTool(createGatedWriteTool(ctx.cwd, state))
     pi.registerTool(createGatedEditTool(ctx.cwd, state))
     try {
-      state.config = await Effect.runPromise(
-        loadConfig(undefined, ctx.cwd, ctx.isProjectTrusted()),
-      )
+      state.config = await Effect.runPromise(loadConfig(undefined, ctx.cwd, ctx.isProjectTrusted()))
       state.dictionary = await Effect.runPromise(
         loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
       )

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,11 +1,12 @@
 import { constants } from "node:fs"
-import { access, readFile, writeFile } from "node:fs/promises"
+import { access, mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname } from "node:path"
 import {
   createEditToolDefinition,
+  createWriteToolDefinition,
   type ExtensionAPI,
   type ExtensionContext,
   type ToolCallEventResult,
-  type WriteToolInput,
 } from "@earendil-works/pi-coding-agent"
 import { Effect } from "effect"
 import { loadConfig } from "../config/load.ts"
@@ -147,6 +148,38 @@ function lintProposedText(
   }
 }
 
+function createGatedWriteTool(cwd: string, state: SessionState) {
+  const definition = createWriteToolDefinition(cwd)
+  const execute: typeof definition.execute = async (...args) => {
+    const [toolCallId, input, _signal, _onUpdate, ctx] = args
+    const implementation = createWriteToolDefinition(cwd, {
+      operations: {
+        mkdir: async () => undefined,
+        writeFile: async (path, content) => {
+          if (!state.ready) {
+            throw new Error(
+              `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+            )
+          }
+          const result = lintProposedText(
+            state,
+            ctx,
+            "write",
+            toolCallId,
+            input.path,
+            content,
+          )
+          if (result?.block) throw new Error(result.reason)
+          await mkdir(dirname(path), { recursive: true })
+          await writeFile(path, content, "utf8")
+        },
+      },
+    })
+    return implementation.execute(...args)
+  }
+  return { ...definition, execute }
+}
+
 function createGatedEditTool(cwd: string, state: SessionState) {
   const definition = createEditToolDefinition(cwd)
   const execute: typeof definition.execute = async (...args) => {
@@ -192,6 +225,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     state.ready = false
     state.error = undefined
     state.pendingWarnings.clear()
+    pi.registerTool(createGatedWriteTool(ctx.cwd, state))
     pi.registerTool(createGatedEditTool(ctx.cwd, state))
     try {
       state.config = await Effect.runPromise(
@@ -213,22 +247,13 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     systemPrompt: `${event.systemPrompt}\n\n${ruleSummary(state.config)}`,
   }))
 
-  pi.on("tool_call", async (event, ctx) => {
+  pi.on("tool_call", async (event) => {
     if (event.toolName !== "write" && event.toolName !== "edit") return undefined
-    if (!state.ready) {
-      return {
-        block: true,
-        reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
-      }
+    if (state.ready) return undefined
+    return {
+      block: true,
+      reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
     }
-
-    if (event.toolName === "write") {
-      const input = event.input as WriteToolInput
-      if (typeof input.path !== "string" || typeof input.content !== "string") return undefined
-      return lintProposedText(state, ctx, "write", event.toolCallId, input.path, input.content)
-    }
-
-    return undefined
   })
 
   pi.on("tool_result", (event) => {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,0 +1,250 @@
+import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import type {
+  EditToolInput,
+  ExtensionAPI,
+  ExtensionContext,
+  ToolCallEventResult,
+  WriteToolInput,
+} from "@earendil-works/pi-coding-agent"
+import { Effect } from "effect"
+import { loadConfig } from "../config/load.ts"
+import type { SteConfig } from "../config/schema.ts"
+import { loadDictionary } from "../dictionary/load.ts"
+import type { Dictionary } from "../dictionary/schema.ts"
+import { classifyPath } from "../engine/kinds.ts"
+import { lint } from "../engine/lint.ts"
+import type { RuleId } from "../engine/rules/registry.ts"
+import type { Tagger } from "../engine/tagger.ts"
+import type { RuleSetting, Violation } from "../engine/types.ts"
+import { makeWinkTagger } from "../tagger/wink.ts"
+
+const DEFAULT_RULE_SETTINGS: Readonly<Record<RuleId, RuleSetting>> = {
+  contraction: "hard",
+  "dictionary-not-approved-word": "hard",
+  hedging: "soft",
+  marketing: "soft",
+  "paragraph-length": "hard",
+  "phrasal-verb": "hard",
+  semicolon: "hard",
+  "sentence-length": "hard",
+  "verb-progressive": "hard",
+  "verb-passive": "soft",
+  "verb-perfect": "hard",
+}
+
+const RULE_SUMMARIES: Readonly<Record<RuleId, string>> = {
+  contraction: "Do not use contractions. Write the words in full.",
+  "dictionary-not-approved-word": "Use approved words from the STE dictionary.",
+  hedging: "Remove hedging phrases.",
+  marketing: "Use factual language instead of marketing language.",
+  "paragraph-length": "Use no more than six sentences in one paragraph.",
+  "phrasal-verb": "Use an approved single-word verb instead of a phrasal verb.",
+  semicolon: "Do not use semicolons. Write two sentences.",
+  "sentence-length": "Keep each sentence within the configured word limit.",
+  "verb-progressive": "Do not use progressive verb forms.",
+  "verb-passive": "Prefer active voice.",
+  "verb-perfect": "Do not use perfect verb forms.",
+}
+
+interface SessionState {
+  config: SteConfig
+  dictionary?: Dictionary
+  tagger?: Tagger
+  error?: string
+  ready: boolean
+  readonly pendingWarnings: Map<string, string>
+}
+
+interface Replacement {
+  readonly start: number
+  readonly end: number
+  readonly text: string
+}
+
+const normalizedToolPath = (path: string): string => (path.startsWith("@") ? path.slice(1) : path)
+
+function applyEdits(previousText: string, edits: EditToolInput["edits"]): string | undefined {
+  const replacements: Replacement[] = []
+  for (const edit of edits) {
+    if (edit.oldText.length === 0) return undefined
+    const start = previousText.indexOf(edit.oldText)
+    if (start === -1 || previousText.indexOf(edit.oldText, start + edit.oldText.length) !== -1) {
+      return undefined
+    }
+    replacements.push({ start, end: start + edit.oldText.length, text: edit.newText })
+  }
+  replacements.sort((left, right) => left.start - right.start)
+  for (let index = 1; index < replacements.length; index++) {
+    if ((replacements[index]?.start ?? 0) < (replacements[index - 1]?.end ?? 0)) return undefined
+  }
+
+  let currentText = ""
+  let cursor = 0
+  for (const replacement of replacements) {
+    currentText += previousText.slice(cursor, replacement.start) + replacement.text
+    cursor = replacement.end
+  }
+  return currentText + previousText.slice(cursor)
+}
+
+function resolvedSetting(config: SteConfig, ruleId: RuleId): RuleSetting {
+  return config.rules?.[ruleId] ?? DEFAULT_RULE_SETTINGS[ruleId]
+}
+
+function ruleSummary(config: SteConfig): string {
+  const maxSentenceWords = config.maxSentenceWords ?? 25
+  const rules = (Object.keys(RULE_SUMMARIES) as RuleId[])
+    .filter((ruleId) => resolvedSetting(config, ruleId) !== "off")
+    .map((ruleId) => {
+      const summary =
+        ruleId === "sentence-length"
+          ? `Keep each sentence to ${maxSentenceWords} words or fewer.`
+          : RULE_SUMMARIES[ruleId]
+      return `- [${resolvedSetting(config, ruleId)}] ${summary}`
+    })
+    .join("\n")
+  return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nThe write and edit tools reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
+}
+
+function suggestedFix(violation: Violation): string {
+  if (violation.suggestion !== undefined) return `Use "${violation.suggestion}".`
+  if (violation.suggestions !== undefined && violation.suggestions.length > 0) {
+    return `Use one of these approved alternatives: ${violation.suggestions.map((item) => `"${item}"`).join(", ")}.`
+  }
+  const fixes: Readonly<Record<RuleId, string>> = {
+    contraction: "Write the contracted words in full.",
+    "dictionary-not-approved-word": "Replace the unapproved word with an approved alternative.",
+    hedging: "Delete the hedging phrase.",
+    marketing: "Replace the phrase with factual language.",
+    "paragraph-length": "Split the paragraph into shorter paragraphs.",
+    "phrasal-verb": "Replace the phrasal verb with one approved verb.",
+    semicolon: "Replace the semicolon with a full stop and write two sentences.",
+    "sentence-length": "Split the sentence into shorter sentences.",
+    "verb-progressive": "Use a permitted simple verb form.",
+    "verb-passive": "Name the actor and use active voice.",
+    "verb-perfect": "Use a permitted simple verb form.",
+  }
+  return fixes[violation.ruleId]
+}
+
+function formatViolations(path: string, heading: string, violations: readonly Violation[]): string {
+  const details = violations
+    .map(
+      (violation) =>
+        `- line ${violation.line}, column ${violation.column} [${violation.ruleId}]: ${violation.message} Suggested fix: ${suggestedFix(violation)}`,
+    )
+    .join("\n")
+  return `${heading} ${path}:\n${details}`
+}
+
+function notifyWarnings(
+  ctx: ExtensionContext,
+  path: string,
+  violations: readonly Violation[],
+): void {
+  if (violations.length === 0 || !ctx.hasUI) return
+  ctx.ui.notify(formatViolations(path, "STE warnings for", violations), "warning")
+}
+
+function lintProposedText(
+  state: SessionState,
+  ctx: ExtensionContext,
+  operation: "write" | "edit",
+  toolCallId: string,
+  path: string,
+  text: string,
+  previousText?: string,
+): ToolCallEventResult | undefined {
+  const classification = classifyPath(path)
+  const report = lint(classification.kind, text, {
+    ...state.config,
+    dictionary: state.dictionary,
+    tagger: state.tagger,
+    sourceDialect: classification.sourceDialect,
+    previousText,
+  })
+  const hard = report.violations.filter((violation) => violation.severity === "hard")
+  const soft = report.violations.filter((violation) => violation.severity === "soft")
+  notifyWarnings(ctx, path, soft)
+  if (hard.length === 0) {
+    if (soft.length > 0) {
+      state.pendingWarnings.set(toolCallId, formatViolations(path, "STE warnings for", soft))
+    }
+    return undefined
+  }
+  return {
+    block: true,
+    reason: formatViolations(path, `STE blocked ${operation} for`, hard),
+  }
+}
+
+export default function simpleEnglishExtension(pi: ExtensionAPI): void {
+  const state: SessionState = { config: {}, ready: false, pendingWarnings: new Map() }
+
+  pi.on("session_start", async (_event, ctx) => {
+    state.ready = false
+    state.error = undefined
+    state.pendingWarnings.clear()
+    try {
+      state.config = await Effect.runPromise(loadConfig(undefined, ctx.cwd))
+      state.dictionary = await Effect.runPromise(
+        loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+      )
+      state.tagger = makeWinkTagger()
+      state.ready = true
+    } catch (error) {
+      state.error = error instanceof Error ? error.message : String(error)
+      if (ctx.hasUI)
+        ctx.ui.notify(`Simple English extension failed to start: ${state.error}`, "error")
+    }
+  })
+
+  pi.on("before_agent_start", (event) => ({
+    systemPrompt: `${event.systemPrompt}\n\n${ruleSummary(state.config)}`,
+  }))
+
+  pi.on("tool_call", async (event, ctx) => {
+    if (event.toolName !== "write" && event.toolName !== "edit") return undefined
+    if (!state.ready) {
+      return {
+        block: true,
+        reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+      }
+    }
+
+    if (event.toolName === "write") {
+      const input = event.input as WriteToolInput
+      if (typeof input.path !== "string" || typeof input.content !== "string") return undefined
+      return lintProposedText(state, ctx, "write", event.toolCallId, input.path, input.content)
+    }
+
+    const input = event.input as EditToolInput
+    if (typeof input.path !== "string" || !Array.isArray(input.edits)) return undefined
+    const absolutePath = resolve(ctx.cwd, normalizedToolPath(input.path))
+    let previousText: string
+    try {
+      previousText = await readFile(absolutePath, "utf8")
+    } catch {
+      return undefined
+    }
+    const currentText = applyEdits(previousText, input.edits)
+    if (currentText === undefined) return undefined
+    return lintProposedText(
+      state,
+      ctx,
+      "edit",
+      event.toolCallId,
+      input.path,
+      currentText,
+      previousText,
+    )
+  })
+
+  pi.on("tool_result", (event) => {
+    const warning = state.pendingWarnings.get(event.toolCallId)
+    if (warning === undefined) return undefined
+    state.pendingWarnings.delete(event.toolCallId)
+    return { content: [...event.content, { type: "text" as const, text: warning }] }
+  })
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -1,11 +1,11 @@
-import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
-import type {
-  EditToolInput,
-  ExtensionAPI,
-  ExtensionContext,
-  ToolCallEventResult,
-  WriteToolInput,
+import { constants } from "node:fs"
+import { access, readFile, writeFile } from "node:fs/promises"
+import {
+  createEditToolDefinition,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type ToolCallEventResult,
+  type WriteToolInput,
 } from "@earendil-works/pi-coding-agent"
 import { Effect } from "effect"
 import { loadConfig } from "../config/load.ts"
@@ -54,38 +54,6 @@ interface SessionState {
   error?: string
   ready: boolean
   readonly pendingWarnings: Map<string, string>
-}
-
-interface Replacement {
-  readonly start: number
-  readonly end: number
-  readonly text: string
-}
-
-const normalizedToolPath = (path: string): string => (path.startsWith("@") ? path.slice(1) : path)
-
-function applyEdits(previousText: string, edits: EditToolInput["edits"]): string | undefined {
-  const replacements: Replacement[] = []
-  for (const edit of edits) {
-    if (edit.oldText.length === 0) return undefined
-    const start = previousText.indexOf(edit.oldText)
-    if (start === -1 || previousText.indexOf(edit.oldText, start + edit.oldText.length) !== -1) {
-      return undefined
-    }
-    replacements.push({ start, end: start + edit.oldText.length, text: edit.newText })
-  }
-  replacements.sort((left, right) => left.start - right.start)
-  for (let index = 1; index < replacements.length; index++) {
-    if ((replacements[index]?.start ?? 0) < (replacements[index - 1]?.end ?? 0)) return undefined
-  }
-
-  let currentText = ""
-  let cursor = 0
-  for (const replacement of replacements) {
-    currentText += previousText.slice(cursor, replacement.start) + replacement.text
-    cursor = replacement.end
-  }
-  return currentText + previousText.slice(cursor)
 }
 
 function resolvedSetting(config: SteConfig, ruleId: RuleId): RuleSetting {
@@ -179,6 +147,44 @@ function lintProposedText(
   }
 }
 
+function createGatedEditTool(cwd: string, state: SessionState) {
+  const definition = createEditToolDefinition(cwd)
+  const execute: typeof definition.execute = async (...args) => {
+    const [toolCallId, input, _signal, _onUpdate, ctx] = args
+    let previousText: string | undefined
+    const implementation = createEditToolDefinition(cwd, {
+      operations: {
+        access: (path) => access(path, constants.R_OK | constants.W_OK),
+        readFile: async (path) => {
+          const content = await readFile(path)
+          previousText = content.toString("utf8")
+          return content
+        },
+        writeFile: async (path, content) => {
+          if (!state.ready) {
+            throw new Error(
+              `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+            )
+          }
+          const result = lintProposedText(
+            state,
+            ctx,
+            "edit",
+            toolCallId,
+            input.path,
+            content,
+            previousText,
+          )
+          if (result?.block) throw new Error(result.reason)
+          await writeFile(path, content, "utf8")
+        },
+      },
+    })
+    return implementation.execute(...args)
+  }
+  return { ...definition, execute }
+}
+
 export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   const state: SessionState = { config: {}, ready: false, pendingWarnings: new Map() }
 
@@ -186,8 +192,11 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     state.ready = false
     state.error = undefined
     state.pendingWarnings.clear()
+    pi.registerTool(createGatedEditTool(ctx.cwd, state))
     try {
-      state.config = await Effect.runPromise(loadConfig(undefined, ctx.cwd))
+      state.config = await Effect.runPromise(
+        loadConfig(undefined, ctx.cwd, ctx.isProjectTrusted()),
+      )
       state.dictionary = await Effect.runPromise(
         loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
       )
@@ -219,26 +228,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
       return lintProposedText(state, ctx, "write", event.toolCallId, input.path, input.content)
     }
 
-    const input = event.input as EditToolInput
-    if (typeof input.path !== "string" || !Array.isArray(input.edits)) return undefined
-    const absolutePath = resolve(ctx.cwd, normalizedToolPath(input.path))
-    let previousText: string
-    try {
-      previousText = await readFile(absolutePath, "utf8")
-    } catch {
-      return undefined
-    }
-    const currentText = applyEdits(previousText, input.edits)
-    if (currentText === undefined) return undefined
-    return lintProposedText(
-      state,
-      ctx,
-      "edit",
-      event.toolCallId,
-      input.path,
-      currentText,
-      previousText,
-    )
+    return undefined
   })
 
   pi.on("tool_result", (event) => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1,0 +1,261 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+import simpleEnglishExtension from "../../src/extension/index.ts"
+
+type EventHandler = (event: Record<string, unknown>, context: ExtensionContextStub) => unknown
+
+interface ExtensionContextStub {
+  readonly cwd: string
+  readonly hasUI: boolean
+  readonly ui: {
+    notify(message: string, level: "info" | "warning" | "error"): void
+  }
+}
+
+class ExtensionApiStub {
+  readonly handlers = new Map<string, EventHandler>()
+
+  on(event: string, handler: EventHandler): void {
+    this.handlers.set(event, handler)
+  }
+
+  async emit(event: string, payload: Record<string, unknown>, context: ExtensionContextStub) {
+    const handler = this.handlers.get(event)
+    if (handler === undefined) throw new Error(`No handler registered for ${event}`)
+    return handler(payload, context)
+  }
+}
+
+const temporaryDirectories: string[] = []
+const originalAgentDirectory = process.env.PI_CODING_AGENT_DIR
+
+afterEach(async () => {
+  if (originalAgentDirectory === undefined) process.env.PI_CODING_AGENT_DIR = undefined
+  else process.env.PI_CODING_AGENT_DIR = originalAgentDirectory
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })))
+})
+
+async function startExtension(options?: {
+  readonly globalConfig?: object
+  readonly projectConfig?: object
+}) {
+  const cwd = await mkdtemp(join(process.cwd(), ".extension-test-"))
+  temporaryDirectories.push(cwd)
+  const globalDirectory = join(cwd, "global")
+  await mkdir(globalDirectory)
+  process.env.PI_CODING_AGENT_DIR = globalDirectory
+  if (options?.globalConfig !== undefined) {
+    await writeFile(
+      join(globalDirectory, "simple-english.json"),
+      JSON.stringify(options.globalConfig),
+    )
+  }
+  if (options?.projectConfig !== undefined) {
+    const projectDirectory = join(cwd, ".pi")
+    await mkdir(projectDirectory)
+    await writeFile(
+      join(projectDirectory, "simple-english.json"),
+      JSON.stringify(options.projectConfig),
+    )
+  }
+
+  const notifications: Array<{ message: string; level: string }> = []
+  const context: ExtensionContextStub = {
+    cwd,
+    hasUI: true,
+    ui: {
+      notify: (message, level) => notifications.push({ message, level }),
+    },
+  }
+  const pi = new ExtensionApiStub()
+  simpleEnglishExtension(pi as never)
+  await pi.emit("session_start", { reason: "startup" }, context)
+  return { cwd, pi, context, notifications }
+}
+
+describe.sequential("pi extension wiring", () => {
+  test("declares a production pi extension package", async () => {
+    const manifest = JSON.parse(await readFile(join(process.cwd(), "package.json"), "utf8"))
+
+    expect(manifest.pi.extensions).toEqual(["./src/extension/index.ts"])
+    expect(manifest.dependencies).toMatchObject({
+      effect: expect.any(String),
+      "wink-eng-lite-web-model": expect.any(String),
+      "wink-nlp": expect.any(String),
+    })
+    expect(manifest.peerDependencies).toMatchObject({
+      "@earendil-works/pi-coding-agent": "*",
+    })
+  })
+
+  test("injects an STE rule summary into the system prompt", async () => {
+    const { pi, context } = await startExtension()
+
+    const result = await pi.emit(
+      "before_agent_start",
+      { systemPrompt: "Base system prompt." },
+      context,
+    )
+
+    expect(result).toMatchObject({
+      systemPrompt: expect.stringContaining("Simplified Technical English"),
+    })
+    expect(result).toMatchObject({
+      systemPrompt: expect.stringContaining("Do not use contractions"),
+    })
+  })
+
+  test("blocks a hard write with location, rule, and fix feedback, then permits a clean write", async () => {
+    const { pi, context } = await startExtension()
+
+    const blocked = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-1",
+        input: { path: "notes.md", content: "This isn't permitted." },
+      },
+      context,
+    )
+
+    expect(blocked).toMatchObject({ block: true })
+    expect(blocked).toMatchObject({ reason: expect.stringContaining("line 1, column 6") })
+    expect(blocked).toMatchObject({ reason: expect.stringContaining("[contraction]") })
+    expect(blocked).toMatchObject({ reason: expect.stringContaining("Suggested fix:") })
+
+    const permitted = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-2",
+        input: { path: "notes.md", content: "This is permitted." },
+      },
+      context,
+    )
+
+    expect(permitted).toBeUndefined()
+  })
+
+  test("uses the file extension to lint only prose comments in source files", async () => {
+    const { pi, context } = await startExtension()
+
+    const stringLiteral = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-source-1",
+        input: { path: "source.ts", content: `const message = "This isn't prose."` },
+      },
+      context,
+    )
+    const comment = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-source-2",
+        input: { path: "source.ts", content: "// This isn't permitted." },
+      },
+      context,
+    )
+
+    expect(stringLiteral).toBeUndefined()
+    expect(comment).toMatchObject({ block: true })
+  })
+
+  test("lints edits against the previous file and ignores unchanged violations", async () => {
+    const { cwd, pi, context } = await startExtension()
+    await writeFile(join(cwd, "notes.md"), "This isn't compliant.\nReplace this sentence.")
+
+    const unchangedViolation = await pi.emit(
+      "tool_call",
+      {
+        toolName: "edit",
+        toolCallId: "edit-1",
+        input: {
+          path: "notes.md",
+          edits: [{ oldText: "Replace this sentence.", newText: "Keep this sentence." }],
+        },
+      },
+      context,
+    )
+    const changedViolation = await pi.emit(
+      "tool_call",
+      {
+        toolName: "edit",
+        toolCallId: "edit-2",
+        input: {
+          path: "notes.md",
+          edits: [{ oldText: "Replace this sentence.", newText: "This isn't acceptable." }],
+        },
+      },
+      context,
+    )
+
+    expect(unchangedViolation).toBeUndefined()
+    expect(changedViolation).toMatchObject({ block: true })
+    expect(changedViolation).toMatchObject({ reason: expect.stringContaining("line 2, column 6") })
+  })
+
+  test("passes soft violations and shows warning feedback", async () => {
+    const { pi, context, notifications } = await startExtension()
+
+    const result = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-soft",
+        input: { path: "notes.md", content: "It is important to note that the valve is open." },
+      },
+      context,
+    )
+
+    expect(result).toBeUndefined()
+    expect(notifications).toContainEqual({
+      level: "warning",
+      message: expect.stringContaining("[hedging]"),
+    })
+
+    const toolResult = await pi.emit(
+      "tool_result",
+      {
+        toolName: "write",
+        toolCallId: "write-soft",
+        input: { path: "notes.md", content: "It is important to note that the valve is open." },
+        content: [{ type: "text", text: "Wrote notes.md" }],
+        details: undefined,
+        isError: false,
+      },
+      context,
+    )
+    expect(toolResult).toMatchObject({
+      content: [
+        { type: "text", text: "Wrote notes.md" },
+        { type: "text", text: expect.stringContaining("STE warnings for notes.md") },
+      ],
+    })
+  })
+
+  test("uses project rule settings over global settings in the extension context", async () => {
+    const { pi, context, notifications } = await startExtension({
+      globalConfig: { rules: { contraction: "hard" } },
+      projectConfig: { rules: { contraction: "soft" } },
+    })
+
+    const result = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-config",
+        input: { path: "notes.md", content: "This isn't blocked." },
+      },
+      context,
+    )
+
+    expect(result).toBeUndefined()
+    expect(notifications).toContainEqual({
+      level: "warning",
+      message: expect.stringContaining("[contraction]"),
+    })
+  })
+})

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -5,19 +5,36 @@ import simpleEnglishExtension from "../../src/extension/index.ts"
 
 type EventHandler = (event: Record<string, unknown>, context: ExtensionContextStub) => unknown
 
+type ToolHandler = {
+  readonly name: string
+  execute(
+    toolCallId: string,
+    input: never,
+    signal: AbortSignal | undefined,
+    onUpdate: undefined,
+    context: ExtensionContextStub,
+  ): unknown
+}
+
 interface ExtensionContextStub {
   readonly cwd: string
   readonly hasUI: boolean
   readonly ui: {
     notify(message: string, level: "info" | "warning" | "error"): void
   }
+  isProjectTrusted(): boolean
 }
 
 class ExtensionApiStub {
   readonly handlers = new Map<string, EventHandler>()
+  readonly tools = new Map<string, ToolHandler>()
 
   on(event: string, handler: EventHandler): void {
     this.handlers.set(event, handler)
+  }
+
+  registerTool(tool: ToolHandler): void {
+    this.tools.set(tool.name, tool)
   }
 
   async emit(event: string, payload: Record<string, unknown>, context: ExtensionContextStub) {
@@ -25,20 +42,39 @@ class ExtensionApiStub {
     if (handler === undefined) throw new Error(`No handler registered for ${event}`)
     return handler(payload, context)
   }
+
+  async executeTool(
+    toolName: string,
+    toolCallId: string,
+    input: Record<string, unknown>,
+    context: ExtensionContextStub,
+  ) {
+    const gate = await this.emit("tool_call", { toolName, toolCallId, input }, context)
+    if (typeof gate === "object" && gate !== null && "block" in gate && gate.block === true) {
+      throw new Error("reason" in gate ? String(gate.reason) : "Tool call blocked")
+    }
+    const tool = this.tools.get(toolName)
+    if (tool === undefined) throw new Error(`No tool registered for ${toolName}`)
+    return tool.execute(toolCallId, input as never, undefined, undefined, context)
+  }
 }
 
 const temporaryDirectories: string[] = []
 const originalAgentDirectory = process.env.PI_CODING_AGENT_DIR
+const originalHome = process.env.HOME
 
 afterEach(async () => {
   if (originalAgentDirectory === undefined) process.env.PI_CODING_AGENT_DIR = undefined
   else process.env.PI_CODING_AGENT_DIR = originalAgentDirectory
+  if (originalHome === undefined) process.env.HOME = undefined
+  else process.env.HOME = originalHome
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })))
 })
 
 async function startExtension(options?: {
   readonly globalConfig?: object
   readonly projectConfig?: object
+  readonly trusted?: boolean
 }) {
   const cwd = await mkdtemp(join(process.cwd(), ".extension-test-"))
   temporaryDirectories.push(cwd)
@@ -67,6 +103,7 @@ async function startExtension(options?: {
     ui: {
       notify: (message, level) => notifications.push({ message, level }),
     },
+    isProjectTrusted: () => options?.trusted ?? true,
   }
   const pi = new ExtensionApiStub()
   simpleEnglishExtension(pi as never)
@@ -165,36 +202,108 @@ describe.sequential("pi extension wiring", () => {
 
   test("lints edits against the previous file and ignores unchanged violations", async () => {
     const { cwd, pi, context } = await startExtension()
-    await writeFile(join(cwd, "notes.md"), "This isn't compliant.\nReplace this sentence.")
+    const path = join(cwd, "notes.md")
+    await writeFile(path, "This isn't compliant.\nReplace this sentence.")
 
-    const unchangedViolation = await pi.emit(
-      "tool_call",
+    await pi.executeTool(
+      "edit",
+      "edit-1",
       {
-        toolName: "edit",
-        toolCallId: "edit-1",
-        input: {
-          path: "notes.md",
-          edits: [{ oldText: "Replace this sentence.", newText: "Keep this sentence." }],
-        },
-      },
-      context,
-    )
-    const changedViolation = await pi.emit(
-      "tool_call",
-      {
-        toolName: "edit",
-        toolCallId: "edit-2",
-        input: {
-          path: "notes.md",
-          edits: [{ oldText: "Replace this sentence.", newText: "This isn't acceptable." }],
-        },
+        path: "notes.md",
+        edits: [{ oldText: "Replace this sentence.", newText: "Keep this sentence." }],
       },
       context,
     )
 
-    expect(unchangedViolation).toBeUndefined()
-    expect(changedViolation).toMatchObject({ block: true })
-    expect(changedViolation).toMatchObject({ reason: expect.stringContaining("line 2, column 6") })
+    await expect(
+      pi.executeTool(
+        "edit",
+        "edit-2",
+        {
+          path: "notes.md",
+          edits: [{ oldText: "Keep this sentence.", newText: "This isn't acceptable." }],
+        },
+        context,
+      ),
+    ).rejects.toThrow("line 2, column 6")
+    expect(await readFile(path, "utf8")).toBe("This isn't compliant.\nKeep this sentence.")
+  })
+
+  test("uses pi edit path and text normalization and fails closed", async () => {
+    const { cwd, pi, context } = await startExtension()
+    process.env.HOME = cwd
+    const path = join(cwd, "home-notes.md")
+    const original = "\uFEFFKeep this line.\r\nReplace this line.\r\nKeep the final line.\r\n"
+    await writeFile(path, original)
+
+    await expect(
+      pi.executeTool(
+        "edit",
+        "edit-normalized",
+        {
+          path: "~/home-notes.md",
+          edits: [
+            {
+              oldText: "Replace this line.\nKeep the final line.",
+              newText: "This isn't permitted.\nKeep the final line.",
+            },
+          ],
+        },
+        context,
+      ),
+    ).rejects.toThrow("[contraction]")
+    expect(await readFile(path, "utf8")).toBe(original)
+
+    await expect(
+      pi.executeTool(
+        "edit",
+        "edit-invalid",
+        {
+          path: "@~/home-notes.md",
+          edits: [{ oldText: "Missing text.", newText: "This isn't permitted." }],
+        },
+        context,
+      ),
+    ).rejects.toThrow("Could not find")
+    expect(await readFile(path, "utf8")).toBe(original)
+  })
+
+  test("serializes parallel edits before linting the projected file", async () => {
+    const { cwd, pi, context } = await startExtension({
+      projectConfig: {
+        maxSentenceWords: 6,
+        rules: { "dictionary-not-approved-word": "off" },
+      },
+    })
+    const path = join(cwd, "notes.md")
+    await writeFile(path, "Open the access panel now.")
+
+    const results = await Promise.allSettled([
+      pi.executeTool(
+        "edit",
+        "edit-parallel-1",
+        {
+          path: "notes.md",
+          edits: [{ oldText: "Open the", newText: "Open the small" }],
+        },
+        context,
+      ),
+      pi.executeTool(
+        "edit",
+        "edit-parallel-2",
+        {
+          path: "notes.md",
+          edits: [{ oldText: "access panel", newText: "front access panel" }],
+        },
+        context,
+      ),
+    ])
+
+    expect(results.map((result) => result.status)).toEqual(["fulfilled", "rejected"])
+    expect(results[1]).toMatchObject({
+      reason: expect.objectContaining({ message: expect.stringContaining("[sentence-length]") }),
+    })
+    expect(await readFile(path, "utf8")).toBe("Open the small access panel now.")
   })
 
   test("passes soft violations and shows warning feedback", async () => {
@@ -234,6 +343,26 @@ describe.sequential("pi extension wiring", () => {
         { type: "text", text: expect.stringContaining("STE warnings for notes.md") },
       ],
     })
+  })
+
+  test("ignores project rule settings until the project is trusted", async () => {
+    const { pi, context } = await startExtension({
+      globalConfig: { rules: { contraction: "hard" } },
+      projectConfig: { rules: { contraction: "off" } },
+      trusted: false,
+    })
+
+    const result = await pi.emit(
+      "tool_call",
+      {
+        toolName: "write",
+        toolCallId: "write-untrusted-config",
+        input: { path: "notes.md", content: "This isn't permitted." },
+      },
+      context,
+    )
+
+    expect(result).toMatchObject({ block: true })
   })
 
   test("uses project rule settings over global settings in the extension context", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -160,8 +160,17 @@ describe.sequential("pi extension wiring", () => {
     })
   })
 
-  test("injects an STE rule summary into the system prompt", async () => {
-    const { pi, context } = await startExtension()
+  test("injects an STE rule summary that reflects merged active settings", async () => {
+    const { pi, context } = await startExtension({
+      globalConfig: {
+        maxSentenceWords: 30,
+        rules: { contraction: "hard", semicolon: "soft" },
+      },
+      projectConfig: {
+        maxSentenceWords: 8,
+        rules: { contraction: "off", semicolon: "hard" },
+      },
+    })
 
     const result = await pi.emit(
       "before_agent_start",
@@ -173,7 +182,13 @@ describe.sequential("pi extension wiring", () => {
       systemPrompt: expect.stringContaining("Simplified Technical English"),
     })
     expect(result).toMatchObject({
-      systemPrompt: expect.stringContaining("Do not use contractions"),
+      systemPrompt: expect.stringContaining("[hard] Do not use semicolons"),
+    })
+    expect(result).toMatchObject({
+      systemPrompt: expect.stringContaining("Keep each sentence to 8 words or fewer"),
+    })
+    expect(result).toMatchObject({
+      systemPrompt: expect.not.stringContaining("Do not use contractions"),
     })
   })
 

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1,7 +1,23 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { afterEach, describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 import simpleEnglishExtension from "../../src/extension/index.ts"
+
+const mkdirControl = vi.hoisted(() => ({
+  afterMkdir: undefined as (() => Promise<void>) | undefined,
+}))
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>()
+  return {
+    ...actual,
+    mkdir: async (...args: Parameters<typeof actual.mkdir>) => {
+      const result = await actual.mkdir(...args)
+      await mkdirControl.afterMkdir?.()
+      return result
+    },
+  }
+})
 
 type EventHandler = (event: Record<string, unknown>, context: ExtensionContextStub) => unknown
 
@@ -64,6 +80,7 @@ class ExtensionApiStub {
     toolCallId: string,
     input: Record<string, unknown>,
     context: ExtensionContextStub,
+    signal?: AbortSignal,
   ) {
     const gate = await this.emit("tool_call", { toolName, toolCallId, input }, context)
     if (typeof gate === "object" && gate !== null && "block" in gate && gate.block === true) {
@@ -71,7 +88,7 @@ class ExtensionApiStub {
     }
     const tool = this.tools.get(toolName)
     if (tool === undefined) throw new Error(`No tool registered for ${toolName}`)
-    return tool.execute(toolCallId, input as never, undefined, undefined, context)
+    return tool.execute(toolCallId, input as never, signal, undefined, context)
   }
 }
 
@@ -80,6 +97,7 @@ const originalAgentDirectory = process.env.PI_CODING_AGENT_DIR
 const originalHome = process.env.HOME
 
 afterEach(async () => {
+  mkdirControl.afterMkdir = undefined
   if (originalAgentDirectory === undefined) process.env.PI_CODING_AGENT_DIR = undefined
   else process.env.PI_CODING_AGENT_DIR = originalAgentDirectory
   if (originalHome === undefined) process.env.HOME = undefined
@@ -187,6 +205,39 @@ describe.sequential("pi extension wiring", () => {
     )
 
     expect(await readFile(join(cwd, "notes.md"), "utf8")).toBe("This is permitted.")
+  })
+
+  test("does not write when cancellation occurs during directory creation", async () => {
+    const { cwd, pi, context } = await startExtension()
+    const controller = new AbortController()
+    let notifyMkdirStarted: () => void = () => undefined
+    let releaseMkdir: () => void = () => undefined
+    const mkdirStarted = new Promise<void>((resolve) => {
+      notifyMkdirStarted = resolve
+    })
+    const mkdirReleased = new Promise<void>((resolve) => {
+      releaseMkdir = resolve
+    })
+    mkdirControl.afterMkdir = async () => {
+      notifyMkdirStarted()
+      await mkdirReleased
+    }
+
+    const execution = pi.executeTool(
+      "write",
+      "write-aborted",
+      { path: "nested/notes.md", content: "This is permitted." },
+      context,
+      controller.signal,
+    )
+    await mkdirStarted
+    controller.abort()
+    releaseMkdir()
+
+    await expect(execution).rejects.toThrow("Operation aborted")
+    await expect(readFile(join(cwd, "nested/notes.md"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    })
   })
 
   test("gates write input after later tool-call handlers mutate it", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -26,11 +26,13 @@ interface ExtensionContextStub {
 }
 
 class ExtensionApiStub {
-  readonly handlers = new Map<string, EventHandler>()
+  readonly handlers = new Map<string, EventHandler[]>()
   readonly tools = new Map<string, ToolHandler>()
 
   on(event: string, handler: EventHandler): void {
-    this.handlers.set(event, handler)
+    const handlers = this.handlers.get(event) ?? []
+    handlers.push(handler)
+    this.handlers.set(event, handlers)
   }
 
   registerTool(tool: ToolHandler): void {
@@ -38,9 +40,23 @@ class ExtensionApiStub {
   }
 
   async emit(event: string, payload: Record<string, unknown>, context: ExtensionContextStub) {
-    const handler = this.handlers.get(event)
-    if (handler === undefined) throw new Error(`No handler registered for ${event}`)
-    return handler(payload, context)
+    const handlers = this.handlers.get(event)
+    if (handlers === undefined) throw new Error(`No handler registered for ${event}`)
+    let result: unknown
+    for (const handler of handlers) {
+      const next = await handler(payload, context)
+      if (next !== undefined) result = next
+      if (
+        event === "tool_call" &&
+        typeof next === "object" &&
+        next !== null &&
+        "block" in next &&
+        next.block === true
+      ) {
+        return next
+      }
+    }
+    return result
   }
 
   async executeTool(
@@ -144,60 +160,75 @@ describe.sequential("pi extension wiring", () => {
   })
 
   test("blocks a hard write with location, rule, and fix feedback, then permits a clean write", async () => {
-    const { pi, context } = await startExtension()
+    const { cwd, pi, context } = await startExtension()
 
-    const blocked = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-1",
-        input: { path: "notes.md", content: "This isn't permitted." },
-      },
+    const blocked = await pi
+      .executeTool(
+        "write",
+        "write-1",
+        { path: "notes.md", content: "This isn't permitted." },
+        context,
+      )
+      .then(
+        () => undefined,
+        (error: Error) => error,
+      )
+
+    expect(blocked).toBeInstanceOf(Error)
+    expect(blocked?.message).toContain("line 1, column 6")
+    expect(blocked?.message).toContain("[contraction]")
+    expect(blocked?.message).toContain("Suggested fix:")
+
+    await pi.executeTool(
+      "write",
+      "write-2",
+      { path: "notes.md", content: "This is permitted." },
       context,
     )
 
-    expect(blocked).toMatchObject({ block: true })
-    expect(blocked).toMatchObject({ reason: expect.stringContaining("line 1, column 6") })
-    expect(blocked).toMatchObject({ reason: expect.stringContaining("[contraction]") })
-    expect(blocked).toMatchObject({ reason: expect.stringContaining("Suggested fix:") })
+    expect(await readFile(join(cwd, "notes.md"), "utf8")).toBe("This is permitted.")
+  })
 
-    const permitted = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-2",
-        input: { path: "notes.md", content: "This is permitted." },
-      },
-      context,
-    )
+  test("gates write input after later tool-call handlers mutate it", async () => {
+    const { cwd, pi, context } = await startExtension()
+    pi.on("tool_call", (event) => {
+      if (event.toolName !== "write") return undefined
+      const input = event.input as Record<string, unknown>
+      input.path = "notes.md"
+      input.content = "This isn't permitted."
+      return undefined
+    })
 
-    expect(permitted).toBeUndefined()
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-mutated",
+        { path: "source.ts", content: `const message = "This isn't prose."` },
+        context,
+      ),
+    ).rejects.toThrow("[contraction]")
+    await expect(readFile(join(cwd, "notes.md"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
   })
 
   test("uses the file extension to lint only prose comments in source files", async () => {
     const { pi, context } = await startExtension()
 
-    const stringLiteral = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-source-1",
-        input: { path: "source.ts", content: `const message = "This isn't prose."` },
-      },
-      context,
-    )
-    const comment = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-source-2",
-        input: { path: "source.ts", content: "// This isn't permitted." },
-      },
-      context,
-    )
-
-    expect(stringLiteral).toBeUndefined()
-    expect(comment).toMatchObject({ block: true })
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-source-1",
+        { path: "source.ts", content: `const message = "This isn't prose."` },
+        context,
+      ),
+    ).resolves.toBeDefined()
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-source-2",
+        { path: "source.ts", content: "// This isn't permitted." },
+        context,
+      ),
+    ).rejects.toThrow("[contraction]")
   })
 
   test("lints edits against the previous file and ignores unchanged violations", async () => {
@@ -309,17 +340,14 @@ describe.sequential("pi extension wiring", () => {
   test("passes soft violations and shows warning feedback", async () => {
     const { pi, context, notifications } = await startExtension()
 
-    const result = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-soft",
-        input: { path: "notes.md", content: "It is important to note that the valve is open." },
-      },
+    const result = await pi.executeTool(
+      "write",
+      "write-soft",
+      { path: "notes.md", content: "It is important to note that the valve is open." },
       context,
     )
 
-    expect(result).toBeUndefined()
+    expect(result).toBeDefined()
     expect(notifications).toContainEqual({
       level: "warning",
       message: expect.stringContaining("[hedging]"),
@@ -352,17 +380,14 @@ describe.sequential("pi extension wiring", () => {
       trusted: false,
     })
 
-    const result = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-untrusted-config",
-        input: { path: "notes.md", content: "This isn't permitted." },
-      },
-      context,
-    )
-
-    expect(result).toMatchObject({ block: true })
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-untrusted-config",
+        { path: "notes.md", content: "This isn't permitted." },
+        context,
+      ),
+    ).rejects.toThrow("[contraction]")
   })
 
   test("uses project rule settings over global settings in the extension context", async () => {
@@ -371,17 +396,14 @@ describe.sequential("pi extension wiring", () => {
       projectConfig: { rules: { contraction: "soft" } },
     })
 
-    const result = await pi.emit(
-      "tool_call",
-      {
-        toolName: "write",
-        toolCallId: "write-config",
-        input: { path: "notes.md", content: "This isn't blocked." },
-      },
+    const result = await pi.executeTool(
+      "write",
+      "write-config",
+      { path: "notes.md", content: "This isn't blocked." },
       context,
     )
 
-    expect(result).toBeUndefined()
+    expect(result).toBeDefined()
     expect(notifications).toContainEqual({
       level: "warning",
       message: expect.stringContaining("[contraction]"),


### PR DESCRIPTION
## Intent

Build HUF-138's core pi extension experience so installing pi-simple-english causes agent writes to comply with ASD-STE100. Declare a valid pi package entry point with all runtime dependencies available in production. At session start, load and merge global plus project configuration with project values winning, then prime each agent turn with a concise rule summary that reflects the active settings. Intercept built-in write and edit calls using the content kind derived from the target file extension: lint complete content for writes and lint edits diff-only against the previous file text. Block hard violations with actionable line, column, rule ID, and suggested-fix feedback so the agent can retry, while allowing soft violations and surfacing warnings. Verify the integration only through a stubbed ExtensionAPI double, without running pi in automated tests. Do not add full Markdown or language parsers or reopen established engine behavior. Also manually demonstrate in a throwaway worktree session that a blocked agent write is corrected on retry.

## What Changed

- Add a production-ready pi extension entry point that loads trusted configuration and injects the active STE rule summary into each agent turn.
- Override write and edit tools to lint extension-derived content, block hard violations with actionable feedback, surface soft warnings, and fail closed when setup fails.
- Share path classification with the CLI and add stubbed extension tests and documentation for configuration, trust, cancellation, and concurrent edits.

## Risk Assessment

✅ Low: The implementation is well-bounded and the previously identified gating, trust, concurrency, and cancellation risks are addressed.

## Testing

The existing extension baseline passed before and after strengthening its configuration-aware prompt assertion; targeted CLI classification and config checks passed, the production tarball installed without dev dependencies, and an isolated real pi session blocked a hard contraction with actionable feedback, accepted the corrected retry, surfaced its soft warning, and persisted the corrected file.

<details>
<summary>Evidence: Curated blocked-write and corrected-retry pi transcript</summary>

```text
$ pi --mode json -e <production-installed-package> -p <blocked-write-then-retry prompt>
ASSISTANT TOOL CALL: write {"path":"proof.md","content":"This isn't permitted."}
TOOL RESULT (error=true): STE blocked write for proof.md:
- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
ASSISTANT TOOL CALL: write {"path":"proof.md","content":"This is permitted."}
TOOL RESULT (error=false): Successfully wrote 18 bytes to proof.md
STE warnings for proof.md:
- line 1, column 6 [verb-passive]: Use the active voice, unless the actor is unknown. Found: "is permitted". Suggested fix: Name the actor and use active voice.
ASSISTANT: The retry succeeded.

$ cat proof.md
This is permitted.
```
</details>
<details>
<summary>Evidence: Production package and runtime dependency installation transcript</summary>

```text
$ npm pack --pack-destination .test-huf138/pack
npm notice
npm notice 📦  pi-simple-english@0.1.0
npm notice Tarball Contents
npm notice 1.1kB LICENSE
npm notice 5.4kB README.md
npm notice 926B THIRD_PARTY_NOTICES.md
npm notice 947B package.json
npm notice 5.3kB src/cli/main.ts
npm notice 2.2kB src/config/load.ts
npm notice 737B src/config/merge.ts
npm notice 2.2kB src/config/schema.ts
npm notice 5.2kB src/dictionary/data/pi-ste.json
npm notice 234B src/dictionary/form.ts
npm notice 1.8kB src/dictionary/load.ts
npm notice 1.4kB src/dictionary/README.md
npm notice 955B src/dictionary/schema.ts
npm notice 10.7kB src/engine/comments.ts
npm notice 9.7kB src/engine/diff.ts
npm notice 590B src/engine/identifiers.ts
npm notice 1.1kB src/engine/kinds.ts
npm notice 24.0kB src/engine/lint.ts
npm notice 10.0kB src/engine/markdown.ts
npm notice 3.1kB src/engine/paragraphs.ts
npm notice 809B src/engine/rules/contraction.ts
npm notice 8.4kB src/engine/rules/dictionary.ts
npm notice 781B src/engine/rules/hedging.ts
npm notice 1.6kB src/engine/rules/marketing.ts
npm notice 678B src/engine/rules/paragraph-length.ts
npm notice 2.2kB src/engine/rules/phrasal-verb.ts
npm notice 296B src/engine/rules/registry.ts
npm notice 404B src/engine/rules/semicolon.ts
npm notice 691B src/engine/rules/sentence-length.ts
npm notice 2.7kB src/engine/rules/verb-form.ts
npm notice 376B src/engine/scan.ts
npm notice 8.3kB src/engine/sentences.ts
npm notice 194B src/engine/tagger.ts
npm notice 139B src/engine/tokens.ts
npm notice 1.5kB src/engine/types.ts
npm notice 9.9kB src/extension/index.ts
npm notice 1.4kB src/tagger/wink.ts
npm notice Tarball Details
npm notice name: pi-simple-english
npm notice version: 0.1.0
npm notice filename: pi-simple-english-0.1.0.tgz
npm notice package size: 33.0 kB
npm notice unpacked size: 127.9 kB
npm notice shasum: 82cf2efb9ceb7301bad938ee2a9890088b5f9d40
npm notice integrity: sha512-YUxTUSLxCUmEK[...]IWd7DFVQRz5iw==
npm notice total files: 37
npm notice
pi-simple-english-0.1.0.tgz

$ npm install --omit=dev --ignore-scripts <package-tarball>
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead

added 147 packages in 4s

20 packages are looking for funding
  run `npm fund` for details

$ production dependency check
{
  "entry": [
    "./src/extension/index.ts"
  ],
  "runtimeDependencies": [
    "effect",
    "wink-eng-lite-web-model",
    "wink-nlp"
  ],
  "peerDependencies": {
    "@earendil-works/pi-coding-agent": "*"
  }
}

$ packaged extension entry check
Packaged extension entry exists.
```
</details>
<details>
<summary>Evidence: Raw pi JSON event stream</summary>

```text
{"type":"session","version":3,"id":"019fb886-d9dc-7f4b-ae01-1551cd6a92d1","timestamp":"2026-07-31T14:14:33.180Z","cwd":"/home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KYVRMBMQMHA7X5T21VP1CEE9/.test-huf138/project"}
{"type":"agent_start"}
{"type":"turn_start"}
{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Test the installed STE write gate. Make exactly two write tool attempts to proof.md. First, call write with the exact content `This isn't permitted.`. This intentionally tests the hard-violation feedback. After that tool call is blocked, retry by calling write with the exact content `This is permitted.`. Do not use another tool and do not create another file. Then state whether the retry succeeded."}],"timestamp":1785507273729}}
{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"Test the installed STE write gate. Make exactly two write tool attempts to proof.md. First, call write with the exact content `This isn't permitted.`. This intentionally tests the hard-violation feedback. After that tool call is blocked, retry by calling write with the exact content `This is permitted.`. Do not use another tool and do not create another file. Then state whether the retry succeeded."}],"timestamp":1785507273729}}
{"type":"message_start","message":{"role":"assistant","content":[],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736}}
{"type":"message_update","assistantMessageEvent":{"type":"thinking_start","contentIndex":0,"partial":{"role":"assistant","content":[{"type":"thinking","thinking":""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}},"message":{"role":"assistant","content":[{"type":"thinking","thinking":""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}}
{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"**Confirming required tools**","partial":{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}},"message":{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}}
{"type":"message_update","assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"\n\n","partial":{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**\n\n"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}},"message":{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**\n\n"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}}
{"type":"message_update","assistantMessageEvent":{"type":"thinking_end","contentIndex":0,"content":"**Confirming required tools**","partial":{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**","thinkingSignature":"{\"id\":\"rs_0b7595a3d438998a016a6cadcbfa9c81918f6124e14ff0c465\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqbK3PF6bOQ0gMARZtg8iWb_o3IXOxUjJoayzQNSRuJtpSxm2GfjbOZjW_pjrVOgtHY6Nx1OWPR1ZT1DisF8h738ibLIxg4kaTuY-1VxkSWaxK5VzJJ55uozlcCKuQ4sZwkTmYokHyTpVjC7vtvFh6y765h7wLvliNJtBHd8CpKeDaAlwZt_yKIXA3boUST4tirCDA_n9MX0NVIzhydPpylJepW6zEoukYRTIrXPj-nUTiG8NMDYGyKVFpes3YH4CETRY2Uyd5JsYY90P2IXJuWX0v7qGY6z6e6FOZrFSpC31mqaPITcGLXkeao-PIhJFEEuQhAyE7x1FXH1cizitwRaV8p3cOoAfQy0ZGL1VAHvHFMcrhVmXze8xRh-VDAq00gTGR1OHbu2p74P-FtABn-qqRxiKbf2em-mOOuVABNtBgjupnHeY4UM8FQH2oBsiOlypYUApLrdSeU7I3fuWwgmiSeyx9R4ugI3n4-tDFhWiO4RRY-0GPaFA_pvW6k2ZaK0NB1VpTKlncXk8I4lE8YW4SluWxY0CvsrKB8PXNFQ701ilv3ofu9cUATrjPB9KTEd6-eS4i3KgeYNxpQgo1LqU7HRzVNFJZoz66SGLn8LnkLbfd-Y6l7hRvEMfz_hAmSPaRrDTDe-cUFIulduQMEKEcMhg4zLH1v35-7O6acDfZF9gao6jtxTO9J_vxHXnhJcywoIOCPdZLlNOzS7vlJCzAVmX_Gawi1qWghYFpxZIvW_QSoNGDskEFNunkrGsUIrLwILfU_KG3Vqt3RUw4k7U70FEaGhh2dfSjaxx-O2eCxtEYRXx8e5DdO0SicAH54iQelkia6A7nFaKe_0irDnI-j_1YzHnkMvuUWywbHH2N-8S8j5r06v4_d0L4BChHMWzmaggb00iEPNow6yqh-Orb0MR9RybSi1x_SUTjXdHawAbe49Xcopwyn9-L6jyVWbA5fzfCMroXA0_0dilfQc8FAQ==\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Confirming required tools**\"}]}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}},"message":{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**","thinkingSignature":"{\"id\":\"rs_0b7595a3d438998a016a6cadcbfa9c81918f6124e14ff0c465\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqbK3PF6bOQ0gMARZtg8iWb_o3IXOxUjJoayzQNSRuJtpSxm2GfjbOZjW_pjrVOgtHY6Nx1OWPR1ZT1DisF8h738ibLIxg4kaTuY-1VxkSWaxK5VzJJ55uozlcCKuQ4sZwkTmYokHyTpVjC7vtvFh6y765h7wLvliNJtBHd8CpKeDaAlwZt_yKIXA3boUST4tirCDA_n9MX0NVIzhydPpylJepW6zEoukYRTIrXPj-nUTiG8NMDYGyKVFpes3YH4CETRY2Uyd5JsYY90P2IXJuWX0v7qGY6z6e6FOZrFSpC31mqaPITcGLXkeao-PIhJFEEuQhAyE7x1FXH1cizitwRaV8p3cOoAfQy0ZGL1VAHvHFMcrhVmXze8xRh-VDAq00gTGR1OHbu2p74P-FtABn-qqRxiKbf2em-mOOuVABNtBgjupnHeY4UM8FQH2oBsiOlypYUApLrdSeU7I3fuWwgmiSeyx9R4ugI3n4-tDFhWiO4RRY-0GPaFA_pvW6k2ZaK0NB1VpTKlncXk8I4lE8YW4SluWxY0CvsrKB8PXNFQ701ilv3ofu9cUATrjPB9KTEd6-eS4i3KgeYNxpQgo1LqU7HRzVNFJZoz66SGLn8LnkLbfd-Y6l7hRvEMfz_hAmSPaRrDTDe-cUFIulduQMEKEcMhg4zLH1v35-7O6acDfZF9gao6jtxTO9J_vxHXnhJcywoIOCPdZLlNOzS7vlJCzAVmX_Gawi1qWghYFpxZIvW_QSoNGDskEFNunkrGsUIrLwILfU_KG3Vqt3RUw4k7U70FEaGhh2dfSjaxx-O2eCxtEYRXx8e5DdO0SicAH54iQelkia6A7nFaKe_0irDnI-j_1YzHnkMvuUWywbHH2N-8S8j5r06v4_d0L4BChHMWzmaggb00iEPNow6yqh-Orb0MR9RybSi1x_SUTjXdHawAbe49Xcopwyn9-L6jyVWbA5fzfCMroXA0_0dilfQc8FAQ==\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Confirming required tools**\"}]}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f"}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_sta

... [92111 bytes truncated] ...

Id":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3"}}
{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":".","partial":{"role":"assistant","content":[{"type":"text","text":"The retry succeeded."}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3"}},"message":{"role":"assistant","content":[{"type":"text","text":"The retry succeeded."}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3"}}
{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"The retry succeeded.","partial":{"role":"assistant","content":[{"type":"text","text":"The retry succeeded.","textSignature":"{\"v\":1,\"id\":\"msg_0b7595a3d438998a016a6cadd31cec8191a8e8c39b0f46aea6\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3"}},"message":{"role":"assistant","content":[{"type":"text","text":"The retry succeeded.","textSignature":"{\"v\":1,\"id\":\"msg_0b7595a3d438998a016a6cadd31cec8191a8e8c39b0f46aea6\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3"}}
{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"The retry succeeded.","textSignature":"{\"v\":1,\"id\":\"msg_0b7595a3d438998a016a6cadd31cec8191a8e8c39b0f46aea6\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1038,"output":8,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1046,"cost":{"input":0.00519,"output":0.00024,"cacheRead":0,"cacheWrite":0,"total":0.00543}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3","rawStopReason":"completed"}}
{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"The retry succeeded.","textSignature":"{\"v\":1,\"id\":\"msg_0b7595a3d438998a016a6cadd31cec8191a8e8c39b0f46aea6\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1038,"output":8,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1046,"cost":{"input":0.00519,"output":0.00024,"cacheRead":0,"cacheWrite":0,"total":0.00543}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3","rawStopReason":"completed"},"toolResults":[]}
{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"Test the installed STE write gate. Make exactly two write tool attempts to proof.md. First, call write with the exact content `This isn't permitted.`. This intentionally tests the hard-violation feedback. After that tool call is blocked, retry by calling write with the exact content `This is permitted.`. Do not use another tool and do not create another file. Then state whether the retry succeeded."}],"timestamp":1785507273729},{"role":"assistant","content":[{"type":"thinking","thinking":"**Confirming required tools**","thinkingSignature":"{\"id\":\"rs_0b7595a3d438998a016a6cadcbfa9c81918f6124e14ff0c465\",\"type\":\"reasoning\",\"content\":[],\"encrypted_content\":\"gAAAAABqbK3PF6bOQ0gMARZtg8iWb_o3IXOxUjJoayzQNSRuJtpSxm2GfjbOZjW_pjrVOgtHY6Nx1OWPR1ZT1DisF8h738ibLIxg4kaTuY-1VxkSWaxK5VzJJ55uozlcCKuQ4sZwkTmYokHyTpVjC7vtvFh6y765h7wLvliNJtBHd8CpKeDaAlwZt_yKIXA3boUST4tirCDA_n9MX0NVIzhydPpylJepW6zEoukYRTIrXPj-nUTiG8NMDYGyKVFpes3YH4CETRY2Uyd5JsYY90P2IXJuWX0v7qGY6z6e6FOZrFSpC31mqaPITcGLXkeao-PIhJFEEuQhAyE7x1FXH1cizitwRaV8p3cOoAfQy0ZGL1VAHvHFMcrhVmXze8xRh-VDAq00gTGR1OHbu2p74P-FtABn-qqRxiKbf2em-mOOuVABNtBgjupnHeY4UM8FQH2oBsiOlypYUApLrdSeU7I3fuWwgmiSeyx9R4ugI3n4-tDFhWiO4RRY-0GPaFA_pvW6k2ZaK0NB1VpTKlncXk8I4lE8YW4SluWxY0CvsrKB8PXNFQ701ilv3ofu9cUATrjPB9KTEd6-eS4i3KgeYNxpQgo1LqU7HRzVNFJZoz66SGLn8LnkLbfd-Y6l7hRvEMfz_hAmSPaRrDTDe-cUFIulduQMEKEcMhg4zLH1v35-7O6acDfZF9gao6jtxTO9J_vxHXnhJcywoIOCPdZLlNOzS7vlJCzAVmX_Gawi1qWghYFpxZIvW_QSoNGDskEFNunkrGsUIrLwILfU_KG3Vqt3RUw4k7U70FEaGhh2dfSjaxx-O2eCxtEYRXx8e5DdO0SicAH54iQelkia6A7nFaKe_0irDnI-j_1YzHnkMvuUWywbHH2N-8S8j5r06v4_d0L4BChHMWzmaggb00iEPNow6yqh-Orb0MR9RybSi1x_SUTjXdHawAbe49Xcopwyn9-L6jyVWbA5fzfCMroXA0_0dilfQc8FAQ==\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Confirming required tools**\"}]}"},{"type":"toolCall","id":"call_4yI8ZftvLs0pLmAJINNB9LnF|fc_0b7595a3d438998a016a6cadcfe9248191ac4a211eb3e5c457","name":"write","arguments":{"path":"proof.md","content":"This isn't permitted."}}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":853,"output":38,"cacheRead":0,"cacheWrite":0,"reasoning":11,"totalTokens":891,"cost":{"input":0.0042650000000000006,"output":0.00114,"cacheRead":0,"cacheWrite":0,"total":0.005405}},"stopReason":"toolUse","timestamp":1785507273736,"responseId":"resp_0b7595a3d438998a016a6cadcab034819194d429494a33699f","rawStopReason":"completed"},{"role":"toolResult","toolCallId":"call_4yI8ZftvLs0pLmAJINNB9LnF|fc_0b7595a3d438998a016a6cadcfe9248191ac4a211eb3e5c457","toolName":"write","content":[{"type":"text","text":"STE blocked write for proof.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}],"details":{},"isError":true,"timestamp":1785507280057},{"role":"assistant","content":[{"type":"toolCall","id":"call_gzzc5PNnf4yNiZ4SlZJ616pk|fc_0b7595a3d438998a016a6cadd18c68819184f8a845c38b16bd","name":"write","arguments":{"path":"proof.md","content":"This is permitted."}}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":947,"output":25,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":972,"cost":{"input":0.0047350000000000005,"output":0.00075,"cacheRead":0,"cacheWrite":0,"total":0.005485}},"stopReason":"toolUse","timestamp":1785507280057,"responseId":"resp_0b7595a3d438998a016a6cadd07dc881919e1f4b7e44aa536c","rawStopReason":"completed"},{"role":"toolResult","toolCallId":"call_gzzc5PNnf4yNiZ4SlZJ616pk|fc_0b7595a3d438998a016a6cadd18c68819184f8a845c38b16bd","toolName":"write","content":[{"type":"text","text":"Successfully wrote 18 bytes to proof.md"},{"type":"text","text":"STE warnings for proof.md:\n- line 1, column 6 [verb-passive]: Use the active voice, unless the actor is unknown. Found: \"is permitted\". Suggested fix: Name the actor and use active voice."}],"isError":false,"timestamp":1785507281920},{"role":"assistant","content":[{"type":"text","text":"The retry succeeded.","textSignature":"{\"v\":1,\"id\":\"msg_0b7595a3d438998a016a6cadd31cec8191a8e8c39b0f46aea6\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1038,"output":8,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1046,"cost":{"input":0.00519,"output":0.00024,"cacheRead":0,"cacheWrite":0,"total":0.00543}},"stopReason":"stop","timestamp":1785507281921,"responseId":"resp_0b7595a3d438998a016a6cadd246a08191b772422c9e0747b3","rawStopReason":"completed"}],"willRetry":false}
{"type":"agent_settled"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `src/extension/index.ts:224` - The intent requires &#34;lint edits diff-only against the previous file text&#34; and &#34;Block hard violations&#34;, but the gate uses different path and edit semantics from pi and then permits failures at line 232. For example, `~/notes.md` resolves differently, and a multiline LF edit against a CRLF or BOM file returns undefined here even though pi normalizes and applies it. Such an edit can introduce a contraction without linting. Use pi-equivalent path resolution and edit normalization, and fail closed when the proposed result cannot be derived.
- 🚨 `src/extension/index.ts:227` - The intent requires hard violations to be blocked, but each parallel sibling edit is linted against the same pre-execution file. Two edits to a 24-word sentence can each add one word and pass independently, then pi&#39;s mutation queue applies both and leaves a prohibited 26-word sentence. Gate the read, proposal, lint, and mutation atomically at the shared file-mutation queue boundary, or provide equivalent projected-state coordination.
- ⚠️ `src/extension/index.ts:190` - A globally installed extension loads `.pi/simple-english.json` without checking `ctx.isProjectTrusted()`. An untrusted repository can therefore disable every rule or weaken severities before the user trusts it. Confirm whether project configuration should apply to untrusted projects; otherwise load only global configuration until trust is active.

🔧 Fix: Harden edit gating and project config trust
1 error still open:
- 🚨 `src/extension/index.ts:228` - The criterion requires &#34;Block hard violations&#34;, but this handler lints before later pi `tool_call` handlers run. Pi explicitly permits later handlers to mutate `event.input` without revalidation, so a later extension can replace clean content or change a `.ts` path to `.md` after this check, and the built-in write then writes an unlinted hard violation. Gate the actual write operation with a `createWriteToolDefinition` override so linting occurs after handler mutation and inside the shared file-mutation queue.

🔧 Fix: Gate writes after tool-call mutations
1 warning still open:
- ⚠️ `src/extension/index.ts:173` - The real directory creation is moved inside the custom write operation without an abort check afterward. If the user aborts while `mkdir` is pending, the file is still written and the tool only reports &#34;Operation aborted&#34; afterward. Check `_signal` after `mkdir` and before `writeFile`.

🔧 Fix: Prevent writes after cancellation during directory creation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bunx vitest run test/extension/extension.test.ts` before and after strengthening the active-settings prompt assertion</code>
- `bunx vitest run test/cli/cli.test.ts test/cli/config.test.ts -t 'maps \\.ts|maps \\.sh|maps a dotless|project config deep-merges'`
- <code>`npm pack --pack-destination .test-huf138/pack` followed by `npm install --prefix .test-huf138/install --omit=dev --ignore-scripts &lt;package-tarball&gt;` and packaged entry/runtime dependency checks</code>
- <code>Isolated manual pi session using the production-installed package, `--no-session`, `--tools write`, and a prompt requiring a blocked contraction followed by a corrected retry</code>
- <code>Parsed the pi JSON event stream and asserted the first write failed, the second succeeded, and `proof.md` contained `This is permitted.`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
