### PR TITLE
feat(extension): add STE feedback for assistant replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ It checks proposed `write` and `edit` content before the tools change a file, us
 Hard violations block the tool call with the line, column, rule ID, and a suggested fix so that the agent can correct the text and retry.
 Soft violations permit the tool call and appear as warnings.
 Edits use the existing file as a baseline, so unchanged violations do not block unrelated changes.
+After each finalized assistant reply, the extension lints its text as `prose-file` content without blocking or rewriting the reply.
+A latest-reply widget shows either a clean state or the hard and soft violation counts for the active branch, including after a session resume or tree navigation.
+Before the next model call, hidden feedback gives the model the details of hard reply violations only; soft reply violations stay in the widget.
+Reply linting uses the same Markdown code exclusions described below.
 A configuration or dictionary load error makes the extension fail closed and block `write` and `edit` for that session.
 
 ## CLI

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -54,6 +54,7 @@ interface SessionState {
   tagger?: Tagger
   error?: string
   ready: boolean
+  pendingReplyFeedback?: string
   readonly pendingWarnings: Map<string, string>
 }
 
@@ -97,14 +98,21 @@ function suggestedFix(violation: Violation): string {
   return fixes[violation.ruleId]
 }
 
-function formatViolations(path: string, heading: string, violations: readonly Violation[]): string {
-  const details = violations
+function violationDetails(violations: readonly Violation[]): string {
+  return violations
     .map(
       (violation) =>
         `- line ${violation.line}, column ${violation.column} [${violation.ruleId}]: ${violation.message} Suggested fix: ${suggestedFix(violation)}`,
     )
     .join("\n")
-  return `${heading} ${path}:\n${details}`
+}
+
+function formatViolations(path: string, heading: string, violations: readonly Violation[]): string {
+  return `${heading} ${path}:\n${violationDetails(violations)}`
+}
+
+function formatReplyFeedback(violations: readonly Violation[]): string {
+  return `STE feedback for your previous reply:\n${violationDetails(violations)}`
 }
 
 function notifyWarnings(
@@ -218,6 +226,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     state.ready = false
     state.error = undefined
+    state.pendingReplyFeedback = undefined
     state.pendingWarnings.clear()
     pi.registerTool(createGatedWriteTool(ctx.cwd, state))
     pi.registerTool(createGatedEditTool(ctx.cwd, state))
@@ -238,6 +247,48 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   pi.on("before_agent_start", (event) => ({
     systemPrompt: `${event.systemPrompt}\n\n${ruleSummary(state.config)}`,
   }))
+
+  pi.on("message_end", (event, ctx) => {
+    if (!state.ready || event.message.role !== "assistant") return undefined
+    const text = event.message.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n")
+    const report = lint("prose-file", text, {
+      ...state.config,
+      dictionary: state.dictionary,
+      tagger: state.tagger,
+    })
+    const hard = report.violations.filter((violation) => violation.severity === "hard")
+    const softCount = report.summary.total - report.summary.hard
+    state.pendingReplyFeedback = hard.length === 0 ? undefined : formatReplyFeedback(hard)
+    if (ctx.hasUI) {
+      const status =
+        report.summary.total === 0
+          ? "STE reply: clean"
+          : `STE reply: ${report.summary.hard} hard, ${softCount} soft`
+      ctx.ui.setWidget("simple-english-reply", [status])
+    }
+    return undefined
+  })
+
+  pi.on("context", (event) => {
+    const feedback = state.pendingReplyFeedback
+    if (feedback === undefined) return undefined
+    state.pendingReplyFeedback = undefined
+    return {
+      messages: [
+        ...event.messages,
+        {
+          role: "custom" as const,
+          customType: "simple-english-reply-feedback",
+          content: feedback,
+          display: false,
+          timestamp: Date.now(),
+        },
+      ],
+    }
+  })
 
   pi.on("tool_call", async (event) => {
     if (event.toolName !== "write" && event.toolName !== "edit") return undefined

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -115,6 +115,45 @@ function formatReplyFeedback(violations: readonly Violation[]): string {
   return `STE feedback for your previous reply:\n${violationDetails(violations)}`
 }
 
+function updateReplyState(state: SessionState, ctx: ExtensionContext, text?: string): void {
+  state.pendingReplyFeedback = undefined
+  if (text === undefined) {
+    if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
+    return
+  }
+
+  const report = lint("prose-file", text, {
+    ...state.config,
+    dictionary: state.dictionary,
+    tagger: state.tagger,
+  })
+  const hard = report.violations.filter((violation) => violation.severity === "hard")
+  const softCount = report.summary.total - report.summary.hard
+  state.pendingReplyFeedback = hard.length === 0 ? undefined : formatReplyFeedback(hard)
+  if (!ctx.hasUI) return
+
+  const status =
+    report.summary.total === 0
+      ? "STE reply: clean"
+      : `STE reply: ${report.summary.hard} hard, ${softCount} soft`
+  ctx.ui.setWidget("simple-english-reply", [status])
+}
+
+function restoreReplyState(state: SessionState, ctx: ExtensionContext): void {
+  const branch = ctx.sessionManager.getBranch()
+  for (let index = branch.length - 1; index >= 0; index--) {
+    const entry = branch[index]
+    if (entry?.type !== "message" || entry.message.role !== "assistant") continue
+    const text = entry.message.content
+      .filter((block) => block.type === "text")
+      .map((block) => block.text)
+      .join("\n")
+    updateReplyState(state, ctx, text)
+    return
+  }
+  updateReplyState(state, ctx)
+}
+
 function notifyWarnings(
   ctx: ExtensionContext,
   path: string,
@@ -226,8 +265,8 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     state.ready = false
     state.error = undefined
-    state.pendingReplyFeedback = undefined
     state.pendingWarnings.clear()
+    updateReplyState(state, ctx)
     pi.registerTool(createGatedWriteTool(ctx.cwd, state))
     pi.registerTool(createGatedEditTool(ctx.cwd, state))
     try {
@@ -237,6 +276,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
       )
       state.tagger = makeWinkTagger()
       state.ready = true
+      restoreReplyState(state, ctx)
     } catch (error) {
       state.error = error instanceof Error ? error.message : String(error)
       if (ctx.hasUI)
@@ -244,32 +284,21 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     }
   })
 
+  pi.on("session_tree", (_event, ctx) => {
+    if (state.ready) restoreReplyState(state, ctx)
+  })
+
   pi.on("before_agent_start", (event) => ({
     systemPrompt: `${event.systemPrompt}\n\n${ruleSummary(state.config)}`,
   }))
 
-  pi.on("message_end", (event, ctx) => {
-    if (!state.ready || event.message.role !== "assistant") return undefined
+  pi.on("turn_end", (event, ctx) => {
+    if (!state.ready || event.message.role !== "assistant") return
     const text = event.message.content
       .filter((block) => block.type === "text")
       .map((block) => block.text)
       .join("\n")
-    const report = lint("prose-file", text, {
-      ...state.config,
-      dictionary: state.dictionary,
-      tagger: state.tagger,
-    })
-    const hard = report.violations.filter((violation) => violation.severity === "hard")
-    const softCount = report.summary.total - report.summary.hard
-    state.pendingReplyFeedback = hard.length === 0 ? undefined : formatReplyFeedback(hard)
-    if (ctx.hasUI) {
-      const status =
-        report.summary.total === 0
-          ? "STE reply: clean"
-          : `STE reply: ${report.summary.hard} hard, ${softCount} soft`
-      ctx.ui.setWidget("simple-english-reply", [status])
-    }
-    return undefined
+    updateReplyState(state, ctx, text)
   })
 
   pi.on("context", (event) => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -96,11 +96,7 @@ class ExtensionApiStub {
       typeof result === "object" && result !== null && "message" in result
         ? (result.message as ReturnType<typeof assistantMessage>)
         : message
-    await this.emit(
-      "turn_end",
-      { turnIndex: 0, message: finalized, toolResults: [] },
-      context,
-    )
+    await this.emit("turn_end", { turnIndex: 0, message: finalized, toolResults: [] }, context)
     return finalized
   }
 
@@ -582,10 +578,7 @@ describe.sequential("pi extension wiring", () => {
     })
     pi.on("message_end", () => ({ message: assistantMessage("Open the valve.") }))
 
-    const finalized = await pi.finalizeAssistant(
-      assistantMessage("This isn't permitted."),
-      context,
-    )
+    const finalized = await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
 
     expect(finalized.content).toEqual([{ type: "text", text: "Open the valve." }])
     expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -37,6 +37,7 @@ interface ExtensionContextStub {
   readonly hasUI: boolean
   readonly ui: {
     notify(message: string, level: "info" | "warning" | "error"): void
+    setWidget(key: string, content: readonly string[] | undefined): void
   }
   isProjectTrusted(): boolean
 }
@@ -131,18 +132,28 @@ async function startExtension(options?: {
   }
 
   const notifications: Array<{ message: string; level: string }> = []
+  const widgets = new Map<string, readonly string[] | undefined>()
   const context: ExtensionContextStub = {
     cwd,
     hasUI: true,
     ui: {
       notify: (message, level) => notifications.push({ message, level }),
+      setWidget: (key, content) => widgets.set(key, content),
     },
     isProjectTrusted: () => options?.trusted ?? true,
   }
   const pi = new ExtensionApiStub()
   simpleEnglishExtension(pi as never)
   await pi.emit("session_start", { reason: "startup" }, context)
-  return { cwd, pi, context, notifications }
+  return { cwd, pi, context, notifications, widgets }
+}
+
+function assistantMessage(text: string) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  }
 }
 
 describe.sequential("pi extension wiring", () => {
@@ -437,6 +448,80 @@ describe.sequential("pi extension wiring", () => {
         { type: "text", text: expect.stringContaining("STE warnings for notes.md") },
       ],
     })
+  })
+
+  test("shows reply counts and injects only hard feedback before the next model call", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    const reply = assistantMessage(
+      "This isn't permitted. It is important to note that the valve is open.",
+    )
+
+    const messageResult = await pi.emit("message_end", { message: reply }, context)
+
+    expect(messageResult).toBeUndefined()
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 1 soft"])
+
+    const result = await pi.emit(
+      "context",
+      { messages: [reply, { role: "user", content: "Continue.", timestamp: Date.now() }] },
+      context,
+    )
+    expect(result).toMatchObject({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          role: "custom",
+          customType: "simple-english-reply-feedback",
+          content: expect.stringContaining("[contraction]"),
+          display: false,
+        }),
+      ]),
+    })
+    expect(result).toMatchObject({
+      messages: expect.not.arrayContaining([
+        expect.objectContaining({ content: expect.stringContaining("[hedging]") }),
+      ]),
+    })
+    await expect(pi.emit("context", { messages: [reply] }, context)).resolves.toBeUndefined()
+  })
+
+  test("shows soft reply violations without injecting feedback", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+
+    await pi.emit(
+      "message_end",
+      { message: assistantMessage("It is important to note that the valve is open.") },
+      context,
+    )
+
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 0 hard, 1 soft"])
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
+  })
+
+  test("shows a clean reply without injecting feedback", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+
+    await pi.emit("message_end", { message: assistantMessage("Open the valve.") }, context)
+
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
+  })
+
+  test("excludes fenced code blocks from reply linting", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    const reply = ["```text", "This isn't permitted.", "```", "Open the valve."].join("\n")
+
+    await pi.emit("message_end", { message: assistantMessage(reply) }, context)
+
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
   test("ignores project rule settings until the project is trusted", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -35,6 +35,9 @@ type ToolHandler = {
 interface ExtensionContextStub {
   readonly cwd: string
   readonly hasUI: boolean
+  readonly sessionManager: {
+    getBranch(): readonly Record<string, unknown>[]
+  }
   readonly ui: {
     notify(message: string, level: "info" | "warning" | "error"): void
     setWidget(key: string, content: readonly string[] | undefined): void
@@ -57,12 +60,20 @@ class ExtensionApiStub {
   }
 
   async emit(event: string, payload: Record<string, unknown>, context: ExtensionContextStub) {
-    const handlers = this.handlers.get(event)
-    if (handlers === undefined) throw new Error(`No handler registered for ${event}`)
+    const handlers = this.handlers.get(event) ?? []
+    let currentPayload = payload
     let result: unknown
     for (const handler of handlers) {
-      const next = await handler(payload, context)
+      const next = await handler(currentPayload, context)
       if (next !== undefined) result = next
+      if (
+        event === "message_end" &&
+        typeof next === "object" &&
+        next !== null &&
+        "message" in next
+      ) {
+        currentPayload = { ...payload, message: next.message }
+      }
       if (
         event === "tool_call" &&
         typeof next === "object" &&
@@ -74,6 +85,23 @@ class ExtensionApiStub {
       }
     }
     return result
+  }
+
+  async finalizeAssistant(
+    message: ReturnType<typeof assistantMessage>,
+    context: ExtensionContextStub,
+  ) {
+    const result = await this.emit("message_end", { message }, context)
+    const finalized =
+      typeof result === "object" && result !== null && "message" in result
+        ? (result.message as ReturnType<typeof assistantMessage>)
+        : message
+    await this.emit(
+      "turn_end",
+      { turnIndex: 0, message: finalized, toolResults: [] },
+      context,
+    )
+    return finalized
   }
 
   async executeTool(
@@ -107,8 +135,10 @@ afterEach(async () => {
 })
 
 async function startExtension(options?: {
+  readonly branch?: readonly Record<string, unknown>[]
   readonly globalConfig?: object
   readonly projectConfig?: object
+  readonly sessionStartReason?: "startup" | "resume"
   readonly trusted?: boolean
 }) {
   const cwd = await mkdtemp(join(process.cwd(), ".extension-test-"))
@@ -133,9 +163,13 @@ async function startExtension(options?: {
 
   const notifications: Array<{ message: string; level: string }> = []
   const widgets = new Map<string, readonly string[] | undefined>()
+  let branch = options?.branch ?? []
   const context: ExtensionContextStub = {
     cwd,
     hasUI: true,
+    sessionManager: {
+      getBranch: () => branch,
+    },
     ui: {
       notify: (message, level) => notifications.push({ message, level }),
       setWidget: (key, content) => widgets.set(key, content),
@@ -144,8 +178,17 @@ async function startExtension(options?: {
   }
   const pi = new ExtensionApiStub()
   simpleEnglishExtension(pi as never)
-  await pi.emit("session_start", { reason: "startup" }, context)
-  return { cwd, pi, context, notifications, widgets }
+  await pi.emit("session_start", { reason: options?.sessionStartReason ?? "startup" }, context)
+  return {
+    cwd,
+    pi,
+    context,
+    notifications,
+    setBranch: (nextBranch: readonly Record<string, unknown>[]) => {
+      branch = nextBranch
+    },
+    widgets,
+  }
 }
 
 function assistantMessage(text: string) {
@@ -153,6 +196,16 @@ function assistantMessage(text: string) {
     role: "assistant",
     content: [{ type: "text", text }],
     timestamp: Date.now(),
+  }
+}
+
+function assistantEntry(text: string, id = "assistant-reply") {
+  return {
+    type: "message",
+    id,
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: assistantMessage(text),
   }
 }
 
@@ -458,9 +511,9 @@ describe.sequential("pi extension wiring", () => {
       "This isn't permitted. It is important to note that the valve is open.",
     )
 
-    const messageResult = await pi.emit("message_end", { message: reply }, context)
+    const finalized = await pi.finalizeAssistant(reply, context)
 
-    expect(messageResult).toBeUndefined()
+    expect(finalized).toBe(reply)
     expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 1 soft"])
 
     const result = await pi.emit(
@@ -486,14 +539,66 @@ describe.sequential("pi extension wiring", () => {
     await expect(pi.emit("context", { messages: [reply] }, context)).resolves.toBeUndefined()
   })
 
+  test("restores reply feedback from the active branch on resume", async () => {
+    const reply = assistantMessage("This isn't permitted.")
+    const { pi, context, widgets } = await startExtension({
+      branch: [assistantEntry("This isn't permitted.")],
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+      sessionStartReason: "resume",
+    })
+
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
+    const result = await pi.emit("context", { messages: [reply] }, context)
+    expect(result).toMatchObject({
+      messages: expect.arrayContaining([
+        expect.objectContaining({
+          customType: "simple-english-reply-feedback",
+          content: expect.stringContaining("[contraction]"),
+        }),
+      ]),
+    })
+  })
+
+  test("recomputes reply state after session tree navigation", async () => {
+    const { pi, context, setBranch, widgets } = await startExtension({
+      branch: [assistantEntry("This isn't permitted.")],
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    setBranch([assistantEntry("Open the valve.", "clean-reply")])
+
+    await pi.emit(
+      "session_tree",
+      { newLeafId: "clean-reply", oldLeafId: "assistant-reply" },
+      context,
+    )
+
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
+  })
+
+  test("lints the finalized reply after message-end replacements", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    pi.on("message_end", () => ({ message: assistantMessage("Open the valve.") }))
+
+    const finalized = await pi.finalizeAssistant(
+      assistantMessage("This isn't permitted."),
+      context,
+    )
+
+    expect(finalized.content).toEqual([{ type: "text", text: "Open the valve." }])
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
+  })
+
   test("shows soft reply violations without injecting feedback", async () => {
     const { pi, context, widgets } = await startExtension({
       projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
     })
 
-    await pi.emit(
-      "message_end",
-      { message: assistantMessage("It is important to note that the valve is open.") },
+    await pi.finalizeAssistant(
+      assistantMessage("It is important to note that the valve is open."),
       context,
     )
 
@@ -506,7 +611,7 @@ describe.sequential("pi extension wiring", () => {
       projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
     })
 
-    await pi.emit("message_end", { message: assistantMessage("Open the valve.") }, context)
+    await pi.finalizeAssistant(assistantMessage("Open the valve."), context)
 
     expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
@@ -518,7 +623,7 @@ describe.sequential("pi extension wiring", () => {
     })
     const reply = ["```text", "This isn't permitted.", "```", "Open the valve."].join("\n")
 
-    await pi.emit("message_end", { message: assistantMessage(reply) }, context)
+    await pi.finalizeAssistant(assistantMessage(reply), context)
 
     expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()


### PR DESCRIPTION
## Intent

Build HUF-140 so the pi extension lints each finalized assistant reply as prose and creates a visible feedback loop toward ASD-STE100 compliance. The latest-reply widget must show hard and soft violation counts, including a clean state. Before the next model call, inject a hidden note that names hard violations only; soft violations stay in the widget to avoid noisy model context. Replies must never be blocked or rewritten. Reuse the existing engine and its Markdown code-block exclusion rather than adding a parser or changing merged engine behavior. Keep the work scoped to pi reply events, context injection, widget wiring, and stubbed ExtensionAPI tests; do not run pi in automated tests.

## What Changed

- Lint each finalized assistant reply as prose and show hard and soft violation counts, including a clean state.
- Inject hidden, one-time feedback for hard violations before the next model call, and restore reply state after resume or tree navigation.
- Document the reply feedback loop and add extension tests for finalization, lifecycle restoration, soft-only results, clean replies, and fenced code exclusions.

## Risk Assessment

✅ Low: The change is well-bounded, follows pi event semantics, and satisfies the reply linting, widget, restoration, and hidden hard-feedback requirements.

## Testing

Targeted extension tests and a stubbed end-to-end assistant lifecycle confirmed visible hard, soft, and clean widget states, one-time hidden hard-only feedback, unchanged replies, resume and tree restoration, and fenced-code exclusion. No screenshot was captured because the required test seam explicitly forbids running pi itself; the reviewer-visible transcript records the ExtensionAPI widget and context outputs directly.

<details>
<summary>Evidence: Stubbed pi reply feedback lifecycle transcript</summary>

```text
MIXED REPLY
reply unchanged: true
message_end replacement: none
turn_end block/rewrite: none
visible widget: STE reply: 1 hard, 1 soft
hidden feedback: role=custom, display=false
STE feedback for your previous reply:
- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
soft rule leaked into context: false
feedback consumed after one model context: true

SOFT-ONLY REPLY
visible widget: STE reply: 0 hard, 1 soft
hidden feedback injected: false

CLEAN REPLY
visible widget: STE reply: clean
hidden feedback injected: false

FENCED-CODE REPLY
visible widget: STE reply: clean
hidden feedback injected: false
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/extension/index.ts:229` - Required criteria say the latest-reply widget must show counts and the next model call must receive hard feedback. This line clears pending feedback on every session start, and no session_start or session_tree path rebuilds it from the active branch. A hard reply followed by quit/resume receives no feedback on the next call, while tree navigation can retain feedback and widget state from an abandoned branch. Recompute reply state from the active branch at these lifecycle boundaries, or explicitly approve session-local containment.
- ⚠️ `src/extension/index.ts:251` - The criterion requires linting each finalized assistant reply, but this handler can run before another extension&#39;s message_end handler replaces that reply. The widget and feedback then describe content different from the persisted reply. The earliest supported shared boundary after all message_end replacements is turn_end, which still runs before the next turn&#39;s context event.

🔧 Fix: Restore and finalize reply compliance feedback
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bun run test -- test/extension/extension.test.ts -t 'shows reply counts|restores reply feedback|recomputes reply state|lints the finalized reply|shows soft reply|shows a clean reply|excludes fenced code blocks'`
- `bun /tmp/no-mistakes-evidence/01KYW9MX43D6W0QYKW9SWF5DRV/reply-feedback-e2e.ts | tee /tmp/no-mistakes-evidence/01KYW9MX43D6W0QYKW9SWF5DRV/reply-feedback-e2e.txt`
- <code>`git status --short` and transient test-directory inspection confirmed testing left the worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
