### PR TITLE
feat(extension): gate git commit messages for STE

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ pi install npm:pi-simple-english
 For local development, run `pi -e .` from the repository instead.
 At the start of each agent turn, the extension adds a concise STE rule summary that reflects the active configuration.
 It checks proposed `write` and `edit` content before the tools change a file, using the same file-extension content kinds described for the CLI below.
-It also checks static messages supplied to `git commit` with `-m` or `--message` before the shell command runs.
-Conventional Commit prefixes and final Git trailer lines are exempt, but the subject and body prose are checked at their original positions.
+It uses bounded heuristics in `bash` tool calls to detect `git commit` invocations and check static messages supplied with `-m` or `--message` before the shell command runs.
+Conventional Commit prefixes and final trailer lines such as `Co-Authored-By` and `BREAKING CHANGE` are exempt, but the subject and body prose are checked at their original positions.
 Hard violations block the tool call with the line, column, rule ID, and a suggested fix so that the agent can correct the text and retry.
 Soft violations permit the tool call and appear as warnings.
 Edits use the existing file as a baseline, so unchanged violations do not block unrelated changes.
@@ -24,8 +24,8 @@ After each finalized assistant reply, the extension lints its text as `prose-fil
 A latest-reply widget shows either a clean state or the hard and soft violation counts for the active branch, including after a session resume or tree navigation.
 Before the next model call, hidden feedback gives the model the details of hard reply violations only; soft reply violations stay in the widget.
 Reply linting uses the same Markdown code exclusions described below.
-A commit command whose message cannot be extracted fails closed and asks the agent to use a static message argument.
-A configuration or dictionary load error makes the extension fail closed and block `write`, `edit`, and message-bearing `git commit` calls for that session.
+A detected commit invocation whose message cannot be extracted fails closed and asks the agent to use a static message argument.
+A configuration or dictionary load error makes the extension fail closed and block `write`, `edit`, and detected `git commit` invocations for that session.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ pi install npm:pi-simple-english
 For local development, run `pi -e .` from the repository instead.
 At the start of each agent turn, the extension adds a concise STE rule summary that reflects the active configuration.
 It checks proposed `write` and `edit` content before the tools change a file, using the same file-extension content kinds described for the CLI below.
+It also checks static messages supplied to `git commit` with `-m` or `--message` before the shell command runs.
+Conventional Commit prefixes and final Git trailer lines are exempt, but the subject and body prose are checked at their original positions.
 Hard violations block the tool call with the line, column, rule ID, and a suggested fix so that the agent can correct the text and retry.
 Soft violations permit the tool call and appear as warnings.
 Edits use the existing file as a baseline, so unchanged violations do not block unrelated changes.
@@ -22,7 +24,8 @@ After each finalized assistant reply, the extension lints its text as `prose-fil
 A latest-reply widget shows either a clean state or the hard and soft violation counts for the active branch, including after a session resume or tree navigation.
 Before the next model call, hidden feedback gives the model the details of hard reply violations only; soft reply violations stay in the widget.
 Reply linting uses the same Markdown code exclusions described below.
-A configuration or dictionary load error makes the extension fail closed and block `write` and `edit` for that session.
+A commit command whose message cannot be extracted fails closed and asks the agent to use a static message argument.
+A configuration or dictionary load error makes the extension fail closed and block `write`, `edit`, and message-bearing `git commit` calls for that session.
 
 ## CLI
 

--- a/src/extension/commit-message.ts
+++ b/src/extension/commit-message.ts
@@ -14,12 +14,34 @@ export type CommitInvocation =
   | { readonly message: string; readonly requiresExplicitMessage: false }
   | { readonly requiresExplicitMessage: true }
 
-function ansiEscape(character: string): string {
+interface AnsiEscape {
+  readonly value: string
+  readonly width: number
+  readonly extractable: boolean
+}
+
+function numericEscape(command: string, index: number, pattern: RegExp, limit: number): AnsiEscape {
+  const digits = command.slice(index + 1, index + 1 + limit).match(pattern)?.[0] ?? ""
+  if (digits.length === 0) {
+    return { value: `\\${command[index] ?? ""}`, width: 1, extractable: true }
+  }
+
+  const codePoint = Number.parseInt(digits, 16)
+  const validCodePoint = codePoint <= 0x10ffff && !(codePoint >= 0xd800 && codePoint <= 0xdfff)
+  return {
+    value: validCodePoint ? String.fromCodePoint(codePoint) : "",
+    width: digits.length + 1,
+    extractable: validCodePoint,
+  }
+}
+
+function ansiEscape(command: string, index: number): AnsiEscape {
+  const character = command[index] ?? ""
   const escapes: Readonly<Record<string, string>> = {
-    "0": "\0",
     a: "\x07",
     b: "\b",
     e: "\x1b",
+    E: "\x1b",
     f: "\f",
     n: "\n",
     r: "\r",
@@ -28,8 +50,28 @@ function ansiEscape(character: string): string {
     "\\": "\\",
     "'": "'",
     '"': '"',
+    "?": "?",
   }
-  return escapes[character] ?? character
+  const escaped = escapes[character]
+  if (escaped !== undefined) return { value: escaped, width: 1, extractable: true }
+
+  if (/[0-7]/u.test(character)) {
+    const digits = command.slice(index, index + 3).match(/^[0-7]{1,3}/u)?.[0] ?? character
+    return {
+      value: String.fromCharCode(Number.parseInt(digits, 8) & 0xff),
+      width: digits.length,
+      extractable: true,
+    }
+  }
+  if (character === "x") return numericEscape(command, index, /^[0-9A-Fa-f]{1,2}/u, 2)
+  if (character === "u") return numericEscape(command, index, /^[0-9A-Fa-f]{1,4}/u, 4)
+  if (character === "U") return numericEscape(command, index, /^[0-9A-Fa-f]{1,8}/u, 8)
+  if (character === "c" && command[index + 1] !== undefined) {
+    const controlled = command[index + 1] ?? ""
+    const codePoint = controlled === "?" ? 0x7f : controlled.toUpperCase().charCodeAt(0) & 0x1f
+    return { value: String.fromCharCode(codePoint), width: 2, extractable: true }
+  }
+  return { value: `\\${character}`, width: 1, extractable: true }
 }
 
 function tokenize(command: string): ShellToken[] {
@@ -134,8 +176,10 @@ function tokenize(command: string): ShellToken[] {
       while (index < command.length && command[index] !== "'") {
         const quoted = command[index] ?? ""
         if (quoted === "\\" && command[index + 1] !== undefined) {
-          value += ansiEscape(command[index + 1] ?? "")
-          index += 2
+          const escape = ansiEscape(command, index + 1)
+          value += escape.value
+          dynamic ||= !escape.extractable
+          index += escape.width + 1
         } else {
           value += quoted
           index++
@@ -213,6 +257,47 @@ function commitSubcommandIndex(
   return undefined
 }
 
+const SHORT_OPTIONS_WITHOUT_VALUE = new Set(["a", "p", "s", "n", "e", "i", "o", "v", "q", "z"])
+const SHORT_OPTIONS_WITH_VALUE = new Set(["C", "c", "F", "m", "t", "u"])
+const LONG_OPTIONS_WITH_VALUE = new Set([
+  "--author",
+  "--cleanup",
+  "--date",
+  "--file",
+  "--fixup",
+  "--message",
+  "--pathspec-from-file",
+  "--reedit-message",
+  "--reuse-message",
+  "--squash",
+  "--template",
+  "--trailer",
+])
+
+type ShortOption =
+  | { readonly type: "message"; readonly attached: string }
+  | { readonly type: "next-message" }
+  | { readonly type: "skip-next" }
+  | { readonly type: "other" }
+
+function classifyShortOption(argument: string): ShortOption {
+  for (let index = 1; index < argument.length; index++) {
+    const option = argument[index] ?? ""
+    if (SHORT_OPTIONS_WITHOUT_VALUE.has(option)) continue
+    if (option === "S") return { type: "other" }
+    if (!SHORT_OPTIONS_WITH_VALUE.has(option)) return { type: "other" }
+
+    const attached = argument.slice(index + 1)
+    if (option === "m") {
+      return attached.length > 0
+        ? { type: "message", attached }
+        : { type: "next-message" }
+    }
+    return attached.length > 0 ? { type: "other" } : { type: "skip-next" }
+  }
+  return { type: "other" }
+}
+
 function invocation(segment: readonly WordToken[]): CommitInvocation | undefined {
   const gitIndex = gitCommandIndex(segment)
   if (gitIndex === undefined) return undefined
@@ -225,6 +310,7 @@ function invocation(segment: readonly WordToken[]): CommitInvocation | undefined
   for (let index = commitIndex + 1; index < segment.length; index++) {
     const argument = segment[index]
     if (argument === undefined) continue
+    if (argument.value === "--") break
     if (argument.value === "-m" || argument.value === "--message") {
       const message = segment[++index]
       if (message === undefined) return { requiresExplicitMessage: true }
@@ -237,19 +323,28 @@ function invocation(segment: readonly WordToken[]): CommitInvocation | undefined
       messageIsDynamic ||= argument.dynamic
       continue
     }
-    const shortMessage = argument.value.match(/^-[A-Za-z]*?m(.*)$/u)
-    if (shortMessage !== null) {
-      const attached = shortMessage[1] ?? ""
-      if (attached.length > 0) {
-        messageParts.push(attached)
-        messageIsDynamic ||= argument.dynamic
-      } else {
-        const message = segment[++index]
-        if (message === undefined) return { requiresExplicitMessage: true }
-        messageParts.push(message.value)
-        messageIsDynamic ||= message.dynamic
-      }
+    if (LONG_OPTIONS_WITH_VALUE.has(argument.value)) {
+      index++
+      continue
     }
+    if (!argument.value.startsWith("-") || argument.value.startsWith("--")) continue
+
+    const shortOption = classifyShortOption(argument.value)
+    if (shortOption.type === "skip-next") {
+      index++
+      continue
+    }
+    if (shortOption.type === "other") continue
+    if (shortOption.type === "message") {
+      messageParts.push(shortOption.attached)
+      messageIsDynamic ||= argument.dynamic
+      continue
+    }
+
+    const message = segment[++index]
+    if (message === undefined) return { requiresExplicitMessage: true }
+    messageParts.push(message.value)
+    messageIsDynamic ||= message.dynamic
   }
 
   if (messageParts.length > 0) {

--- a/src/extension/commit-message.ts
+++ b/src/extension/commit-message.ts
@@ -292,6 +292,8 @@ type ShortOption =
   | { readonly type: "other" }
 
 function classifyShortOption(argument: string): ShortOption {
+  if (argument === "-u") return { type: "other" }
+
   for (let index = 1; index < argument.length; index++) {
     const option = argument[index] ?? ""
     if (SHORT_OPTIONS_WITHOUT_VALUE.has(option)) continue

--- a/src/extension/commit-message.ts
+++ b/src/extension/commit-message.ts
@@ -176,10 +176,10 @@ function tokenize(command: string): ShellToken[] {
       while (index < command.length && command[index] !== "'") {
         const quoted = command[index] ?? ""
         if (quoted === "\\" && command[index + 1] !== undefined) {
-          const escape = ansiEscape(command, index + 1)
-          value += escape.value
-          dynamic ||= !escape.extractable
-          index += escape.width + 1
+          const ansiSequence = ansiEscape(command, index + 1)
+          value += ansiSequence.value
+          dynamic ||= !ansiSequence.extractable
+          index += ansiSequence.width + 1
         } else {
           value += quoted
           index++
@@ -302,9 +302,7 @@ function classifyShortOption(argument: string): ShortOption {
 
     const attached = argument.slice(index + 1)
     if (option === "m") {
-      return attached.length > 0
-        ? { type: "message", attached }
-        : { type: "next-message" }
+      return attached.length > 0 ? { type: "message", attached } : { type: "next-message" }
     }
     return attached.length > 0 ? { type: "other" } : { type: "skip-next" }
   }

--- a/src/extension/commit-message.ts
+++ b/src/extension/commit-message.ts
@@ -188,7 +188,18 @@ function tokenize(command: string): ShellToken[] {
       if (command[index] === "'") index++
       continue
     }
-    if (character === "$" || character === "`") dynamic = true
+    if (
+      character === "$" ||
+      character === "`" ||
+      character === "*" ||
+      character === "?" ||
+      character === "[" ||
+      character === "{" ||
+      character === "}" ||
+      (character === "~" && !started)
+    ) {
+      dynamic = true
+    }
     started = true
     value += character
     index++

--- a/src/extension/commit-message.ts
+++ b/src/extension/commit-message.ts
@@ -1,0 +1,305 @@
+interface WordToken {
+  readonly type: "word"
+  readonly value: string
+  readonly dynamic: boolean
+}
+
+interface OperatorToken {
+  readonly type: "operator"
+}
+
+type ShellToken = WordToken | OperatorToken
+
+export type CommitInvocation =
+  | { readonly message: string; readonly requiresExplicitMessage: false }
+  | { readonly requiresExplicitMessage: true }
+
+function ansiEscape(character: string): string {
+  const escapes: Readonly<Record<string, string>> = {
+    "0": "\0",
+    a: "\x07",
+    b: "\b",
+    e: "\x1b",
+    f: "\f",
+    n: "\n",
+    r: "\r",
+    t: "\t",
+    v: "\v",
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+  }
+  return escapes[character] ?? character
+}
+
+function tokenize(command: string): ShellToken[] {
+  const tokens: ShellToken[] = []
+  let value = ""
+  let dynamic = false
+  let started = false
+  let index = 0
+
+  const flush = () => {
+    if (!started) return
+    tokens.push({ type: "word", value, dynamic })
+    value = ""
+    dynamic = false
+    started = false
+  }
+
+  const operator = (width = 1) => {
+    flush()
+    tokens.push({ type: "operator" })
+    index += width
+  }
+
+  while (index < command.length) {
+    const character = command[index] ?? ""
+
+    if (/[^\S\r\n]/u.test(character) || character === "\r") {
+      flush()
+      index++
+      continue
+    }
+    if (character === "\n") {
+      operator()
+      continue
+    }
+    if (character === ";" || character === "(" || character === ")") {
+      operator()
+      continue
+    }
+    if (character === "&" || character === "|") {
+      operator(command[index + 1] === character ? 2 : 1)
+      continue
+    }
+    if (character === "#" && !started) {
+      while (index < command.length && command[index] !== "\n") index++
+      continue
+    }
+    if (character === "\\") {
+      started = true
+      const next = command[index + 1]
+      if (next === "\n") {
+        index += 2
+      } else if (next === undefined) {
+        value += "\\"
+        index++
+      } else {
+        value += next
+        index += 2
+      }
+      continue
+    }
+    if (character === "'") {
+      started = true
+      index++
+      while (index < command.length && command[index] !== "'") {
+        value += command[index]
+        index++
+      }
+      if (command[index] === "'") index++
+      continue
+    }
+    if (character === '"') {
+      started = true
+      index++
+      while (index < command.length && command[index] !== '"') {
+        const quoted = command[index] ?? ""
+        if (quoted === "\\") {
+          const next = command[index + 1]
+          if (next === "\n") {
+            index += 2
+            continue
+          }
+          if (next === "$" || next === "`" || next === '"' || next === "\\") {
+            value += next
+            index += 2
+            continue
+          }
+          value += "\\"
+          index++
+          continue
+        }
+        if (quoted === "$" || quoted === "`") dynamic = true
+        value += quoted
+        index++
+      }
+      if (command[index] === '"') index++
+      continue
+    }
+    if (character === "$" && command[index + 1] === "'") {
+      started = true
+      index += 2
+      while (index < command.length && command[index] !== "'") {
+        const quoted = command[index] ?? ""
+        if (quoted === "\\" && command[index + 1] !== undefined) {
+          value += ansiEscape(command[index + 1] ?? "")
+          index += 2
+        } else {
+          value += quoted
+          index++
+        }
+      }
+      if (command[index] === "'") index++
+      continue
+    }
+    if (character === "$" || character === "`") dynamic = true
+    started = true
+    value += character
+    index++
+  }
+
+  flush()
+  return tokens
+}
+
+function commandSegments(tokens: readonly ShellToken[]): WordToken[][] {
+  const segments: WordToken[][] = []
+  let segment: WordToken[] = []
+  for (const token of tokens) {
+    if (token.type === "operator") {
+      if (segment.length > 0) segments.push(segment)
+      segment = []
+    } else {
+      segment.push(token)
+    }
+  }
+  if (segment.length > 0) segments.push(segment)
+  return segments
+}
+
+function executableName(value: string): string {
+  return value.slice(Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\")) + 1)
+}
+
+function gitCommandIndex(segment: readonly WordToken[]): number | undefined {
+  let index = 0
+  if (segment[index]?.value === "command") {
+    index++
+    while (segment[index]?.value.startsWith("-")) index++
+  }
+  if (segment[index]?.value === "env") {
+    index++
+    while (segment[index]) {
+      const argument = segment[index]
+      if (
+        argument === undefined ||
+        (!argument.value.startsWith("-") && !/^[A-Za-z_][A-Za-z0-9_]*=/u.test(argument.value))
+      ) {
+        break
+      }
+      index++
+    }
+  }
+  while (/^[A-Za-z_][A-Za-z0-9_]*=/u.test(segment[index]?.value ?? "")) index++
+  return executableName(segment[index]?.value ?? "") === "git" ? index : undefined
+}
+
+function commitSubcommandIndex(
+  segment: readonly WordToken[],
+  gitIndex: number,
+): number | undefined {
+  for (let index = gitIndex + 1; index < segment.length; index++) {
+    const argument = segment[index]?.value ?? ""
+    if (argument === "commit") return index
+    if (!argument.startsWith("-")) return undefined
+    if (
+      ["-C", "-c", "--git-dir", "--work-tree", "--namespace", "--config-env"].includes(argument)
+    ) {
+      index++
+    }
+  }
+  return undefined
+}
+
+function invocation(segment: readonly WordToken[]): CommitInvocation | undefined {
+  const gitIndex = gitCommandIndex(segment)
+  if (gitIndex === undefined) return undefined
+  const commitIndex = commitSubcommandIndex(segment, gitIndex)
+  if (commitIndex === undefined) return undefined
+
+  const messageParts: string[] = []
+  let messageIsDynamic = false
+
+  for (let index = commitIndex + 1; index < segment.length; index++) {
+    const argument = segment[index]
+    if (argument === undefined) continue
+    if (argument.value === "-m" || argument.value === "--message") {
+      const message = segment[++index]
+      if (message === undefined) return { requiresExplicitMessage: true }
+      messageParts.push(message.value)
+      messageIsDynamic ||= message.dynamic
+      continue
+    }
+    if (argument.value.startsWith("--message=")) {
+      messageParts.push(argument.value.slice("--message=".length))
+      messageIsDynamic ||= argument.dynamic
+      continue
+    }
+    const shortMessage = argument.value.match(/^-[A-Za-z]*?m(.*)$/u)
+    if (shortMessage !== null) {
+      const attached = shortMessage[1] ?? ""
+      if (attached.length > 0) {
+        messageParts.push(attached)
+        messageIsDynamic ||= argument.dynamic
+      } else {
+        const message = segment[++index]
+        if (message === undefined) return { requiresExplicitMessage: true }
+        messageParts.push(message.value)
+        messageIsDynamic ||= message.dynamic
+      }
+    }
+  }
+
+  if (messageParts.length > 0) {
+    return messageIsDynamic
+      ? { requiresExplicitMessage: true }
+      : { message: messageParts.join("\n\n"), requiresExplicitMessage: false }
+  }
+  return { requiresExplicitMessage: true }
+}
+
+export function findCommitInvocations(command: string): readonly CommitInvocation[] {
+  return commandSegments(tokenize(command)).flatMap((segment) => {
+    const found = invocation(segment)
+    return found === undefined ? [] : [found]
+  })
+}
+
+function blankLine(line: string): string {
+  return " ".repeat(line.length)
+}
+
+export function blankCommitMetadata(message: string): string {
+  const lines = message.split("\n")
+  const prefix = lines[0]?.match(/^[A-Za-z][A-Za-z0-9-]*(?:\([^\r\n)]*\))?!?:[\t ]*/u)?.[0]
+  if (prefix !== undefined && lines[0] !== undefined) {
+    lines[0] = `:${" ".repeat(Math.max(prefix.length - 1, 0))}${lines[0].slice(prefix.length)}`
+  }
+
+  let trailerEnd = lines.length - 1
+  while (trailerEnd > 0 && !/\S/u.test(lines[trailerEnd] ?? "")) trailerEnd--
+  let trailerStart = trailerEnd + 1
+  let hasTrailer = false
+  for (let index = trailerEnd; index > 0; index--) {
+    const line = lines[index] ?? ""
+    if (/^(?:[A-Za-z0-9][A-Za-z0-9-]*|BREAKING CHANGE)[\t ]*(?::| #)[\t ]+\S/u.test(line)) {
+      hasTrailer = true
+      trailerStart = index
+      continue
+    }
+    if (/^[\t ]+\S/u.test(line)) {
+      trailerStart = index
+      continue
+    }
+    break
+  }
+  if (hasTrailer) {
+    for (let index = trailerStart; index <= trailerEnd; index++) {
+      lines[index] = blankLine(lines[index] ?? "")
+    }
+  }
+
+  return lines.join("\n")
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -5,9 +5,9 @@ import {
   type ExtensionAPI,
   type ExtensionContext,
   type ToolCallEventResult,
+  createBashToolDefinition,
   createEditToolDefinition,
   createWriteToolDefinition,
-  isToolCallEventType,
 } from "@earendil-works/pi-coding-agent"
 import { Effect } from "effect"
 import { loadConfig } from "../config/load.ts"
@@ -245,6 +245,17 @@ function lintCommitCommand(
   return undefined
 }
 
+function createGatedBashTool(cwd: string, state: SessionState) {
+  const definition = createBashToolDefinition(cwd)
+  const execute: typeof definition.execute = async (...args) => {
+    const [toolCallId, input, _signal, _onUpdate, ctx] = args
+    const result = lintCommitCommand(state, ctx, toolCallId, input.command)
+    if (result?.block) throw new Error(result.reason)
+    return definition.execute(...args)
+  }
+  return { ...definition, execute }
+}
+
 function createGatedWriteTool(cwd: string, state: SessionState) {
   const definition = createWriteToolDefinition(cwd)
   const execute: typeof definition.execute = async (...args) => {
@@ -317,6 +328,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     state.error = undefined
     state.pendingWarnings.clear()
     updateReplyState(state, ctx)
+    pi.registerTool(createGatedBashTool(ctx.cwd, state))
     pi.registerTool(createGatedWriteTool(ctx.cwd, state))
     pi.registerTool(createGatedEditTool(ctx.cwd, state))
     try {
@@ -369,10 +381,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     }
   })
 
-  pi.on("tool_call", async (event, ctx) => {
-    if (isToolCallEventType("bash", event)) {
-      return lintCommitCommand(state, ctx, event.toolCallId, event.input.command)
-    }
+  pi.on("tool_call", async (event) => {
     if (event.toolName !== "write" && event.toolName !== "edit") return undefined
     if (state.ready) return undefined
     return {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -7,6 +7,7 @@ import {
   type ToolCallEventResult,
   createEditToolDefinition,
   createWriteToolDefinition,
+  isToolCallEventType,
 } from "@earendil-works/pi-coding-agent"
 import { Effect } from "effect"
 import { loadConfig } from "../config/load.ts"
@@ -19,6 +20,7 @@ import type { RuleId } from "../engine/rules/registry.ts"
 import type { Tagger } from "../engine/tagger.ts"
 import type { RuleSetting, Violation } from "../engine/types.ts"
 import { makeWinkTagger } from "../tagger/wink.ts"
+import { blankCommitMetadata, findCommitInvocations } from "./commit-message.ts"
 
 const DEFAULT_RULE_SETTINGS: Readonly<Record<RuleId, RuleSetting>> = {
   contraction: "hard",
@@ -74,7 +76,7 @@ function ruleSummary(config: SteConfig): string {
       return `- [${resolvedSetting(config, ruleId)}] ${summary}`
     })
     .join("\n")
-  return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nThe write and edit tools reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
+  return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
 }
 
 function suggestedFix(violation: Violation): string {
@@ -193,6 +195,54 @@ function lintProposedText(
     block: true,
     reason: formatViolations(path, `STE blocked ${operation} for`, hard),
   }
+}
+
+function lintCommitCommand(
+  state: SessionState,
+  ctx: ExtensionContext,
+  toolCallId: string,
+  command: string,
+): ToolCallEventResult | undefined {
+  const invocations = findCommitInvocations(command)
+  if (invocations.length === 0) return undefined
+  if (!state.ready) {
+    return {
+      block: true,
+      reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+    }
+  }
+
+  const warnings: string[] = []
+  for (const invocation of invocations) {
+    if (invocation.requiresExplicitMessage) {
+      return {
+        block: true,
+        reason:
+          "STE could not check the git commit message. Use git commit with a static -m or --message argument.",
+      }
+    }
+
+    const report = lint("commit-message", blankCommitMetadata(invocation.message), {
+      ...state.config,
+      dictionary: state.dictionary,
+      tagger: state.tagger,
+    })
+    const hard = report.violations.filter((violation) => violation.severity === "hard")
+    const soft = report.violations.filter((violation) => violation.severity === "soft")
+    notifyWarnings(ctx, "commit message", soft)
+    if (hard.length > 0) {
+      return {
+        block: true,
+        reason: formatViolations("commit message", "STE blocked commit for", hard),
+      }
+    }
+    if (soft.length > 0) {
+      warnings.push(formatViolations("commit message", "STE warnings for", soft))
+    }
+  }
+
+  if (warnings.length > 0) state.pendingWarnings.set(toolCallId, warnings.join("\n\n"))
+  return undefined
 }
 
 function createGatedWriteTool(cwd: string, state: SessionState) {
@@ -319,7 +369,10 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     }
   })
 
-  pi.on("tool_call", async (event) => {
+  pi.on("tool_call", async (event, ctx) => {
+    if (isToolCallEventType("bash", event)) {
+      return lintCommitCommand(state, ctx, event.toolCallId, event.input.command)
+    }
     if (event.toolName !== "write" && event.toolName !== "edit") return undefined
     if (state.ready) return undefined
     return {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -32,6 +32,17 @@ type ToolHandler = {
   ): unknown
 }
 
+interface CommitCommandFixture {
+  readonly name: string
+  readonly command: string
+}
+
+type CommitHeuristicFixture = CommitCommandFixture &
+  (
+    | { readonly expected: "pass" | "explicit-message" }
+    | { readonly expected: "contraction"; readonly location: string }
+  )
+
 interface ExtensionContextStub {
   readonly cwd: string
   readonly hasUI: boolean
@@ -250,6 +261,119 @@ describe.sequential("pi extension wiring", () => {
     expect(result).toMatchObject({
       systemPrompt: expect.not.stringContaining("Do not use contractions"),
     })
+    expect(result).toMatchObject({
+      systemPrompt: expect.stringContaining("git commit messages reject hard violations"),
+    })
+  })
+
+  test("blocks a hard commit message with structured feedback", async () => {
+    const { pi, context } = await startExtension()
+
+    const result = await pi.emit(
+      "tool_call",
+      {
+        toolName: "bash",
+        toolCallId: "commit-blocked",
+        input: { command: `git commit -m "fix: This isn't permitted."` },
+      },
+      context,
+    )
+
+    expect(result).toMatchObject({ block: true })
+    expect(result).toMatchObject({ reason: expect.stringContaining("line 1, column 11") })
+    expect(result).toMatchObject({ reason: expect.stringContaining("[contraction]") })
+    expect(result).toMatchObject({ reason: expect.stringContaining("Suggested fix:") })
+  })
+
+  test("permits a clean commit message", async () => {
+    const { pi, context } = await startExtension()
+
+    await expect(
+      pi.emit(
+        "tool_call",
+        {
+          toolName: "bash",
+          toolCallId: "commit-clean",
+          input: { command: `git add notes.md && git commit -m "fix: Close the valve."` },
+        },
+        context,
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  test("exempts Conventional Commit prefixes and trailer lines from fixtures", async () => {
+    const { pi, context } = await startExtension()
+    const fixtures = JSON.parse(
+      await readFile(join(process.cwd(), "test/fixtures/commit-commands.json"), "utf8"),
+    ) as CommitCommandFixture[]
+
+    for (const fixture of fixtures) {
+      await expect(
+        pi.emit(
+          "tool_call",
+          {
+            toolName: "bash",
+            toolCallId: `commit-fixture-${fixture.name}`,
+            input: { command: fixture.command },
+          },
+          context,
+        ),
+        fixture.name,
+      ).resolves.toBeUndefined()
+    }
+  })
+
+  test("pins bounded commit command detection heuristics in fixtures", async () => {
+    const { pi, context } = await startExtension()
+    const fixtures = JSON.parse(
+      await readFile(join(process.cwd(), "test/fixtures/commit-command-heuristics.json"), "utf8"),
+    ) as CommitHeuristicFixture[]
+
+    for (const fixture of fixtures) {
+      const result = await pi.emit(
+        "tool_call",
+        {
+          toolName: "bash",
+          toolCallId: `commit-heuristic-${fixture.name}`,
+          input: { command: fixture.command },
+        },
+        context,
+      )
+      if (fixture.expected === "pass") {
+        expect(result, fixture.name).toBeUndefined()
+      } else if (fixture.expected === "contraction") {
+        expect(result, fixture.name).toMatchObject({
+          block: true,
+          reason: expect.stringContaining("[contraction]"),
+        })
+        expect(result, fixture.name).toMatchObject({
+          reason: expect.stringContaining(fixture.location),
+        })
+      } else {
+        expect(result, fixture.name).toMatchObject({
+          block: true,
+          reason: expect.stringContaining("static -m or --message argument"),
+        })
+      }
+    }
+  })
+
+  test("reports original positions in a multi-line commit subject and body", async () => {
+    const { pi, context } = await startExtension()
+
+    const result = await pi.emit(
+      "tool_call",
+      {
+        toolName: "bash",
+        toolCallId: "commit-multiline",
+        input: { command: `git commit -m "fix: Close the valve." -m "This isn't permitted."` },
+      },
+      context,
+    )
+
+    expect(result).toMatchObject({ block: true })
+    expect(result).toMatchObject({ reason: expect.stringContaining("line 3, column 6") })
+    expect(result).toMatchObject({ reason: expect.stringContaining("[contraction]") })
   })
 
   test("blocks a hard write with location, rule, and fix feedback, then permits a clean write", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -29,6 +29,11 @@ vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
   }
 })
 
+vi.mock("../../src/tagger/wink.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/tagger/wink.ts")>()
+  return { ...actual, makeWinkTagger: () => () => [] }
+})
+
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>()
   return {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -6,6 +6,28 @@ import simpleEnglishExtension from "../../src/extension/index.ts"
 const mkdirControl = vi.hoisted(() => ({
   afterMkdir: undefined as (() => Promise<void>) | undefined,
 }))
+const bashControl = vi.hoisted(() => ({ executedCommands: [] as string[] }))
+
+vi.mock("@earendil-works/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@earendil-works/pi-coding-agent")>()
+  return {
+    ...actual,
+    createBashToolDefinition: (
+      cwd: Parameters<typeof actual.createBashToolDefinition>[0],
+      options?: Parameters<typeof actual.createBashToolDefinition>[1],
+    ) =>
+      actual.createBashToolDefinition(cwd, {
+        ...options,
+        exposeSessionEnvironment: false,
+        operations: {
+          exec: async (command: string) => {
+            bashControl.executedCommands.push(command)
+            return { exitCode: 0 }
+          },
+        },
+      }),
+  }
+})
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>()
@@ -134,6 +156,7 @@ const originalHome = process.env.HOME
 
 afterEach(async () => {
   mkdirControl.afterMkdir = undefined
+  bashControl.executedCommands.length = 0
   if (originalAgentDirectory === undefined) process.env.PI_CODING_AGENT_DIR = undefined
   else process.env.PI_CODING_AGENT_DIR = originalAgentDirectory
   if (originalHome === undefined) process.env.HOME = undefined
@@ -216,6 +239,18 @@ function assistantEntry(text: string, id = "assistant-reply") {
   }
 }
 
+async function executeBash(
+  pi: ExtensionApiStub,
+  context: ExtensionContextStub,
+  toolCallId: string,
+  command: string,
+): Promise<Error | undefined> {
+  return pi.executeTool("bash", toolCallId, { command }, context).then(
+    () => undefined,
+    (error: Error) => error,
+  )
+}
+
 describe.sequential("pi extension wiring", () => {
   test("declares a production pi extension package", async () => {
     const manifest = JSON.parse(await readFile(join(process.cwd(), "package.json"), "utf8"))
@@ -269,36 +304,48 @@ describe.sequential("pi extension wiring", () => {
   test("blocks a hard commit message with structured feedback", async () => {
     const { pi, context } = await startExtension()
 
-    const result = await pi.emit(
-      "tool_call",
-      {
-        toolName: "bash",
-        toolCallId: "commit-blocked",
-        input: { command: `git commit -m "fix: This isn't permitted."` },
-      },
+    const error = await executeBash(
+      pi,
       context,
+      "commit-blocked",
+      `git commit -m "fix: This isn't permitted."`,
     )
 
-    expect(result).toMatchObject({ block: true })
-    expect(result).toMatchObject({ reason: expect.stringContaining("line 1, column 11") })
-    expect(result).toMatchObject({ reason: expect.stringContaining("[contraction]") })
-    expect(result).toMatchObject({ reason: expect.stringContaining("Suggested fix:") })
+    expect(error?.message).toContain("line 1, column 11")
+    expect(error?.message).toContain("[contraction]")
+    expect(error?.message).toContain("Suggested fix:")
+    expect(bashControl.executedCommands).toHaveLength(0)
   })
 
   test("permits a clean commit message", async () => {
     const { pi, context } = await startExtension()
 
     await expect(
-      pi.emit(
-        "tool_call",
-        {
-          toolName: "bash",
-          toolCallId: "commit-clean",
-          input: { command: `git add notes.md && git commit -m "fix: Close the valve."` },
-        },
+      executeBash(
+        pi,
         context,
+        "commit-clean",
+        `git add notes.md && git commit -m "fix: Close the valve."`,
       ),
     ).resolves.toBeUndefined()
+    expect(bashControl.executedCommands).toEqual([
+      `git add notes.md && git commit -m "fix: Close the valve."`,
+    ])
+  })
+
+  test("gates the bash command after later tool-call handlers mutate it", async () => {
+    const { pi, context } = await startExtension()
+    pi.on("tool_call", (event) => {
+      if (event.toolName !== "bash") return undefined
+      const input = event.input as Record<string, unknown>
+      input.command = `git commit -m "fix: This isn't permitted."`
+      return undefined
+    })
+
+    const error = await executeBash(pi, context, "commit-mutated", "printf 'safe'")
+
+    expect(error?.message).toContain("[contraction]")
+    expect(bashControl.executedCommands).toHaveLength(0)
   })
 
   test("exempts Conventional Commit prefixes and trailer lines from fixtures", async () => {
@@ -309,15 +356,7 @@ describe.sequential("pi extension wiring", () => {
 
     for (const fixture of fixtures) {
       await expect(
-        pi.emit(
-          "tool_call",
-          {
-            toolName: "bash",
-            toolCallId: `commit-fixture-${fixture.name}`,
-            input: { command: fixture.command },
-          },
-          context,
-        ),
+        executeBash(pi, context, `commit-fixture-${fixture.name}`, fixture.command),
         fixture.name,
       ).resolves.toBeUndefined()
     }
@@ -330,30 +369,19 @@ describe.sequential("pi extension wiring", () => {
     ) as CommitHeuristicFixture[]
 
     for (const fixture of fixtures) {
-      const result = await pi.emit(
-        "tool_call",
-        {
-          toolName: "bash",
-          toolCallId: `commit-heuristic-${fixture.name}`,
-          input: { command: fixture.command },
-        },
+      const error = await executeBash(
+        pi,
         context,
+        `commit-heuristic-${fixture.name}`,
+        fixture.command,
       )
       if (fixture.expected === "pass") {
-        expect(result, fixture.name).toBeUndefined()
+        expect(error, fixture.name).toBeUndefined()
       } else if (fixture.expected === "contraction") {
-        expect(result, fixture.name).toMatchObject({
-          block: true,
-          reason: expect.stringContaining("[contraction]"),
-        })
-        expect(result, fixture.name).toMatchObject({
-          reason: expect.stringContaining(fixture.location),
-        })
+        expect(error?.message, fixture.name).toContain("[contraction]")
+        expect(error?.message, fixture.name).toContain(fixture.location)
       } else {
-        expect(result, fixture.name).toMatchObject({
-          block: true,
-          reason: expect.stringContaining("static -m or --message argument"),
-        })
+        expect(error?.message, fixture.name).toContain("static -m or --message argument")
       }
     }
   })
@@ -361,19 +389,15 @@ describe.sequential("pi extension wiring", () => {
   test("reports original positions in a multi-line commit subject and body", async () => {
     const { pi, context } = await startExtension()
 
-    const result = await pi.emit(
-      "tool_call",
-      {
-        toolName: "bash",
-        toolCallId: "commit-multiline",
-        input: { command: `git commit -m "fix: Close the valve." -m "This isn't permitted."` },
-      },
+    const error = await executeBash(
+      pi,
       context,
+      "commit-multiline",
+      `git commit -m "fix: Close the valve." -m "This isn't permitted."`,
     )
 
-    expect(result).toMatchObject({ block: true })
-    expect(result).toMatchObject({ reason: expect.stringContaining("line 3, column 6") })
-    expect(result).toMatchObject({ reason: expect.stringContaining("[contraction]") })
+    expect(error?.message).toContain("line 3, column 6")
+    expect(error?.message).toContain("[contraction]")
   })
 
   test("blocks a hard write with location, rule, and fix feedback, then permits a clean write", async () => {

--- a/test/fixtures/commit-command-heuristics.json
+++ b/test/fixtures/commit-command-heuristics.json
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "quoted command text is not an invocation",
+    "command": "printf '%s\\n' \"git commit -m bad\"",
+    "expected": "pass"
+  },
+  {
+    "name": "command wrapper and combined short flags are detected",
+    "command": "git status && command git commit -am \"fix: This isn't permitted.\"",
+    "expected": "contraction",
+    "location": "line 1, column 11"
+  },
+  {
+    "name": "ANSI C quoting preserves multi-line positions",
+    "command": "git commit -m $'fix: Close the valve.\\n\\nThis isn\\'t permitted.'",
+    "expected": "contraction",
+    "location": "line 3, column 6"
+  },
+  {
+    "name": "dynamic messages fail closed",
+    "command": "git commit -m \"$MESSAGE\"",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "dynamic amend messages fail closed even with no-edit",
+    "command": "git commit --amend --no-edit -m \"$MESSAGE\"",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "message files fail closed",
+    "command": "git commit --file message.txt",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "amend without an extractable message fails closed",
+    "command": "git commit --amend --no-edit",
+    "expected": "explicit-message"
+  }
+]

--- a/test/fixtures/commit-command-heuristics.json
+++ b/test/fixtures/commit-command-heuristics.json
@@ -61,6 +61,31 @@
     "expected": "explicit-message"
   },
   {
+    "name": "unquoted star pathname expansion fails closed",
+    "command": "git commit -m *",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "unquoted question mark pathname expansion fails closed",
+    "command": "git commit -m ?",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "unquoted bracket pathname expansion fails closed",
+    "command": "git commit -m [abc]",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "unquoted tilde expansion fails closed",
+    "command": "git commit -m ~",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "unquoted brace expansion fails closed",
+    "command": "git commit -m {allowed,blocked}",
+    "expected": "explicit-message"
+  },
+  {
     "name": "message files fail closed",
     "command": "git commit --file message.txt",
     "expected": "explicit-message"

--- a/test/fixtures/commit-command-heuristics.json
+++ b/test/fixtures/commit-command-heuristics.json
@@ -17,6 +17,40 @@
     "location": "line 3, column 6"
   },
   {
+    "name": "ANSI C hexadecimal escapes consume two digits",
+    "command": "git commit -m $'fix: This isn\\x27t permitted.'",
+    "expected": "contraction",
+    "location": "line 1, column 11"
+  },
+  {
+    "name": "ANSI C octal escapes consume three digits",
+    "command": "git commit -m $'fix: This isn\\047t permitted.'",
+    "expected": "contraction",
+    "location": "line 1, column 11"
+  },
+  {
+    "name": "ANSI C short Unicode escapes are decoded",
+    "command": "git commit -m $'fix: This isn\\u0027t permitted.'",
+    "expected": "contraction",
+    "location": "line 1, column 11"
+  },
+  {
+    "name": "ANSI C long Unicode escapes are decoded",
+    "command": "git commit -m $'fix: This isn\\U00000027t permitted.'",
+    "expected": "contraction",
+    "location": "line 1, column 11"
+  },
+  {
+    "name": "attached reuse-message values are not messages",
+    "command": "git commit -Cmain",
+    "expected": "explicit-message"
+  },
+  {
+    "name": "attached signing keys containing m are not messages",
+    "command": "git commit -Smkey",
+    "expected": "explicit-message"
+  },
+  {
     "name": "dynamic messages fail closed",
     "command": "git commit -m \"$MESSAGE\"",
     "expected": "explicit-message"

--- a/test/fixtures/commit-command-heuristics.json
+++ b/test/fixtures/commit-command-heuristics.json
@@ -51,6 +51,16 @@
     "expected": "explicit-message"
   },
   {
+    "name": "bare include status allows a following message",
+    "command": "git commit -u -m \"fix: Close the valve.\"",
+    "expected": "pass"
+  },
+  {
+    "name": "attached include status modes are not messages",
+    "command": "git commit -uall",
+    "expected": "explicit-message"
+  },
+  {
     "name": "dynamic messages fail closed",
     "command": "git commit -m \"$MESSAGE\"",
     "expected": "explicit-message"

--- a/test/fixtures/commit-commands.json
+++ b/test/fixtures/commit-commands.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "conventional prefix and trailers are exempt",
+    "command": "git commit -m \"feat(core;api): Open the valve.\n\nCo-Authored-By: This isn't checked <author@example.com>\nSigned-off-by: This isn't checked <signer@example.com>\""
+  },
+  {
+    "name": "scoped breaking prefix is exempt",
+    "command": "git -C . commit --message='fix(control;panel)!: Close the valve.'"
+  },
+  {
+    "name": "breaking change footer is exempt",
+    "command": "git commit -m \"fix: Close the valve.\n\nBREAKING CHANGE: This isn't checked.\""
+  }
+]


### PR DESCRIPTION
## Intent

Implement HUF-139 commit-message gating in the pi extension. Detect git commit invocations in bash tool calls with bounded heuristics rather than a full shell or git parser, extract static -m and --message text, and lint it with the existing commit-message engine kind. Block hard violations with line, column, rule ID, and suggested-fix feedback so the agent can retry, while allowing clean messages. Exempt Conventional Commit prefixes and final Git trailer lines, including Co-Authored-By-style and BREAKING CHANGE trailers, without changing subject and body positions. Preserve multi-line message positions, fail closed when a message cannot be extracted, use stubbed ExtensionAPI tests and fixtures, do not run pi in automated tests, and verify a throwaway manual pi demo where a bad commit is blocked and the corrected retry succeeds. Keep the work scoped to commit gating because HUF-140 is changing the same extension in parallel.

## What Changed

- Gate detected `git commit` invocations at bash execution, lint static `-m` and `--message` text, and block hard violations with actionable feedback.
- Preserve multiline positions, exempt Conventional Commit prefixes and final Git trailers, and fail closed for unextractable messages.
- Document the behavior and add stubbed extension tests with fixtures for commit command heuristics.

## Risk Assessment

🚨 High: Two reachable command forms bypass required hard commit-message gating, and trailer handling can suppress a hard violation in body prose.

## Testing

The targeted extension tests passed, and an isolated end-to-end pi demo blocked the contraction with line, column, rule ID, and suggested-fix feedback, then accepted the corrected retry and confirmed it through Git history; temporary worktree files were removed.

<details>
<summary>Evidence: Readable pi commit-gate demonstration transcript</summary>

```text
Manual pi commit-gate demo
Mode: pi 0.83.0 JSON mode, real bash tool, extension loaded with -e
Repository: throwaway Git feature branch demo

$ git commit -m "fix: This isn't permitted."
[tool blocked]
STE blocked commit for commit message:
- line 1, column 11 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
$ git commit -m "fix: Close the valve."
[tool succeeded]
[demo (root-commit) 59d01e6] fix: Close the valve.
 1 file changed, 1 insertion(+)
 create mode 100644 notes.txt

$ git log -1 --format=%s
[tool succeeded]
fix: Close the valve.


Post-run repository verification
## demo
subject=fix: Close the valve.
commit=59d01e60f5ed5c17e3b5844a401ccc5a11afd8f9
```
</details>
<details>
<summary>Evidence: Raw pi JSON event stream from the demonstration</summary>

```text
{"type":"session","version":3,"id":"019fb90c-abf6-7b67-ae7e-d0b3c5a88200","timestamp":"2026-07-31T16:40:43.254Z","cwd":"/home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KYW9Y2134NCHTW55PW7C4HN2/.manual-pi-demo"}
{"type":"agent_start"}
{"type":"turn_start"}
{"type":"message_start","message":{"role":"user","content":[{"type":"text","text":"Use bash only. This is a throwaway Git repository with notes.txt already staged. First, run exactly: git commit -m \"fix: This isn't permitted.\". Do not alter that first command. Observe the tool error. Then retry by running exactly: git commit -m \"fix: Close the valve.\". Finally, run git log -1 --format=%s to prove the corrected commit succeeded. Report what happened."}],"timestamp":1785516043702}}
{"type":"message_end","message":{"role":"user","content":[{"type":"text","text":"Use bash only. This is a throwaway Git repository with notes.txt already staged. First, run exactly: git commit -m \"fix: This isn't permitted.\". Do not alter that first command. Observe the tool error. Then retry by running exactly: git commit -m \"fix: Close the valve.\". Finally, run git log -1 --format=%s to prove the corrected commit succeeded. Report what happened."}],"timestamp":1785516043702}}
{"type":"message_start","message":{"role":"assistant","content":[],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_start","contentIndex":0,"partial":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{},"partialJson":""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}},"message":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{},"partialJson":""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_delta","contentIndex":0,"delta":"{\"","partial":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{},"partialJson":"{\""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}},"message":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{},"partialJson":"{\""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_delta","contentIndex":0,"delta":"command","partial":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{},"partialJson":"{\"command"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}},"message":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{},"partialJson":"{\"command"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_delta","contentIndex":0,"delta":"\":\"","partial":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{"command":""},"partialJson":"{\"command\":\""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}},"message":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{"command":""},"partialJson":"{\"command\":\""}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_delta","contentIndex":0,"delta":"git","partial":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{"command":"git"},"partialJson":"{\"command\":\"git"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}},"message":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{"command":"git"},"partialJson":"{\"command\":\"git"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"pending","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe"}}
{"type":"message_update","assistantMessageEvent":{"type":"toolcall_delta","contentIndex":0,"delta":" commit","partial":{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{"command":"git commit"},"partialJson":"{\"command\":\"git commit"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalToke

... [100504 bytes truncated] ...

"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40"}},"message":{"role":"assistant","content":[{"type":"text","text":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40"}}
{"type":"message_update","assistantMessageEvent":{"type":"text_end","contentIndex":0,"content":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`","partial":{"role":"assistant","content":[{"type":"text","text":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`","textSignature":"{\"v\":1,\"id\":\"msg_0939d5dd53352dd9016a6cd01cf2048191a9c4e0432ab8a53a\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40"}},"message":{"role":"assistant","content":[{"type":"text","text":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`","textSignature":"{\"v\":1,\"id\":\"msg_0939d5dd53352dd9016a6cd01cf2048191a9c4e0432ab8a53a\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40"}}
{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`","textSignature":"{\"v\":1,\"id\":\"msg_0939d5dd53352dd9016a6cd01cf2048191a9c4e0432ab8a53a\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1114,"output":34,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1148,"cost":{"input":0.00557,"output":0.00102,"cacheRead":0,"cacheWrite":0,"total":0.00659}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40","rawStopReason":"completed"}}
{"type":"turn_end","message":{"role":"assistant","content":[{"type":"text","text":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`","textSignature":"{\"v\":1,\"id\":\"msg_0939d5dd53352dd9016a6cd01cf2048191a9c4e0432ab8a53a\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1114,"output":34,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1148,"cost":{"input":0.00557,"output":0.00102,"cacheRead":0,"cacheWrite":0,"total":0.00659}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40","rawStopReason":"completed"},"toolResults":[]}
{"type":"agent_end","messages":[{"role":"user","content":[{"type":"text","text":"Use bash only. This is a throwaway Git repository with notes.txt already staged. First, run exactly: git commit -m \"fix: This isn't permitted.\". Do not alter that first command. Observe the tool error. Then retry by running exactly: git commit -m \"fix: Close the valve.\". Finally, run git log -1 --format=%s to prove the corrected commit succeeded. Report what happened."}],"timestamp":1785516043702},{"role":"assistant","content":[{"type":"toolCall","id":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","name":"bash","arguments":{"command":"git commit -m \"fix: This isn't permitted.\""}}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":910,"output":28,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":938,"cost":{"input":0.00455,"output":0.00084,"cacheRead":0,"cacheWrite":0,"total":0.005390000000000001}},"stopReason":"toolUse","timestamp":1785516043707,"responseId":"resp_0939d5dd53352dd9016a6cd00ce40c81919138a6912df0e9fe","rawStopReason":"completed"},{"role":"toolResult","toolCallId":"call_jFyGFQziFn6JL8y4Y1NAndoX|fc_0939d5dd53352dd9016a6cd00e62ac8191be41e8bcfb14ae68","toolName":"bash","content":[{"type":"text","text":"STE blocked commit for commit message:\n- line 1, column 11 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}],"details":{},"isError":true,"timestamp":1785516046798},{"role":"assistant","content":[{"type":"toolCall","id":"call_QaWvfO5S3KxmbCtlD5FZr7Ft|fc_0939d5dd53352dd9016a6cd010c1488191a58d781bef25721c","name":"bash","arguments":{"command":"git commit -m \"fix: Close the valve.\""}}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":995,"output":28,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1023,"cost":{"input":0.004975,"output":0.00084,"cacheRead":0,"cacheWrite":0,"total":0.005815000000000001}},"stopReason":"toolUse","timestamp":1785516046799,"responseId":"resp_0939d5dd53352dd9016a6cd00f57d08191952b6df50b21b661","rawStopReason":"completed"},{"role":"toolResult","toolCallId":"call_QaWvfO5S3KxmbCtlD5FZr7Ft|fc_0939d5dd53352dd9016a6cd010c1488191a58d781bef25721c","toolName":"bash","content":[{"type":"text","text":"[demo (root-commit) 59d01e6] fix: Close the valve.\n 1 file changed, 1 insertion(+)\n create mode 100644 notes.txt\n"}],"isError":false,"timestamp":1785516049208},{"role":"assistant","content":[{"type":"toolCall","id":"call_U87yDlMflfQR6fGp9mpLTW6v|fc_0939d5dd53352dd9016a6cd017ede081919744fddb1de2959b","name":"bash","arguments":{"command":"git log -1 --format=%s"}}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1072,"output":25,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1097,"cost":{"input":0.00536,"output":0.00075,"cacheRead":0,"cacheWrite":0,"total":0.00611}},"stopReason":"toolUse","timestamp":1785516049208,"responseId":"resp_0939d5dd53352dd9016a6cd01189688191b8d9cab5a1f04e20","rawStopReason":"completed"},{"role":"toolResult","toolCallId":"call_U87yDlMflfQR6fGp9mpLTW6v|fc_0939d5dd53352dd9016a6cd017ede081919744fddb1de2959b","toolName":"bash","content":[{"type":"text","text":"fix: Close the valve.\n"}],"isError":false,"timestamp":1785516059540},{"role":"assistant","content":[{"type":"text","text":"The first commit failed because the message contained the contraction `isn't`. The corrected commit succeeded. Git log confirmed:\n\n`fix: Close the valve.`","textSignature":"{\"v\":1,\"id\":\"msg_0939d5dd53352dd9016a6cd01cf2048191a9c4e0432ab8a53a\",\"phase\":\"final_answer\"}"}],"api":"openai-codex-responses","provider":"openai-codex","model":"gpt-5.6-sol","usage":{"input":1114,"output":34,"cacheRead":0,"cacheWrite":0,"reasoning":0,"totalTokens":1148,"cost":{"input":0.00557,"output":0.00102,"cacheRead":0,"cacheWrite":0,"total":0.00659}},"stopReason":"stop","timestamp":1785516059541,"responseId":"resp_0939d5dd53352dd9016a6cd01be98c8191bcd7ab9e9e7e4c40","rawStopReason":"completed"}],"willRetry":false}
{"type":"agent_settled"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 errors</summary>

- 🚨 `src/extension/index.ts:292` - Intent requires commit messages to be checked before the shell command runs, but this handler checks the command before later tool_call handlers can mutate it. Pi applies later input mutations without revalidation, so a later handler can change `echo ok` to `git commit -m &#34;fix: This isn&#39;t permitted.&#34;` and bypass the gate. Gate the final command at the bash execution boundary.
- 🚨 `src/extension/commit-message.ts:240` - Intent requires failing closed when a message cannot be extracted, but the short-option regex treats any option containing `m` as a message. For example, `git commit -Cmain` reuses the message from commit `main`, while this code lints only `ain` and permits the commit. Parse known commit-option arity and recognize `m` only in valid message-option positions.
- 🚨 `src/extension/commit-message.ts:137` - Intent requires extracting static message text accurately or failing closed. ANSI-C numeric escapes consume only their first character here, so `$&#39;fix: This isn\x27t permitted.&#39;` becomes `fix: This isnx27t permitted.` for linting while Bash supplies `fix: This isn&#39;t permitted.` to Git. Decode supported numeric escapes exactly or classify unsupported escapes as unextractable.

🔧 Fix: fix: harden commit gating at bash execution
1 error still open:
- 🚨 `src/extension/commit-message.ts:191` - Intent requires extracting only static message text and failing closed otherwise, but the tokenizer marks only `$` and backticks as dynamic. In a repository with a staged file named `fix: This isn&#39;t permitted.`, `git commit -m *` lints the literal `*`, while Bash expands it to the violating filename and Git commits with that message. At the tokenization boundary, classify unquoted pathname, tilde, and brace expansion syntax as unextractable and pin these cases in fixtures.

🔧 Fix: fix: fail closed on unquoted shell expansions
4 errors still open:
- 🚨 `src/extension/commit-message.ts:337` - Required behavior says to &#34;fail closed when a message cannot be extracted,&#34; but `--fixup` and `--squash` are skipped as ordinary value options even when combined with `-m`. For example, `git commit --fixup=HEAD -m &#34;Close the valve.&#34;` creates a subject derived from HEAD, such as `fixup! This isn&#39;t permitted.`, while the gate lints only the clean `-m` text. Mark message-generating options as unextractable whenever they contribute repository-derived text.
- 🚨 `src/extension/commit-message.ts:239` - Required behavior says to &#34;Detect git commit invocations in bash tool calls,&#34; but the `env` wrapper loop treats every option as valueless. `env -u NAME git commit -m &#34;fix: This isn&#39;t permitted.&#34;` stops detection at `NAME`, then executes the violating commit. Parse the bounded set of `env` options that consume arguments before locating Git.
- 🚨 `src/extension/commit-message.ts:307` - Required behavior includes &#34;allowing clean messages,&#34; but bare Git `-u` has an optional attached value and does not consume the next argument. This classifier treats it as required, so `git commit -u -m &#34;fix: Close the valve.&#34;` skips `-m` and fails closed despite its static clean message. Classify bare `-u` as valueless while retaining attached modes such as `-uall`.
- 🚨 `src/extension/commit-message.ts:393` - Required behavior says to &#34;Exempt ... final Git trailer lines,&#34; but the hash-separator branch requires whitespace after `#`. A Conventional Commit footer such as `Refs #123 isn&#39;t permitted` has separator ` #` followed immediately by its value, so it remains lintable and is blocked for the contraction. Match colon separators with following whitespace and hash separators with an immediate value.

🔧 Fix: fix: allow messages after bare git -u
3 errors still open:
- 🚨 `src/extension/commit-message.ts:261` - The required criterion says to &#34;Detect git commit invocations in bash tool calls,&#34; but shell redirections remain argument tokens. `git &lt;/dev/null commit -m &#34;fix: This isn&#39;t permitted.&#34;` executes the commit, while this branch returns no invocation upon seeing `&lt;/dev/null`. Remove or skip bounded redirection forms at tokenization before locating Git and its subcommand.
- 🚨 `src/extension/commit-message.ts:32` - The required criteria say to extract static message text and fail closed otherwise, but `\xHH` and octal escapes are decoded as independent Unicode code points instead of shell bytes. `$&#39;fix: This isn\xe2\x80\x99t permitted.&#39;` reaches Git as `This isn’t permitted.` but is linted as `This isnât permitted.`, bypassing the contraction rule. Decode complete byte sequences using the shell encoding or fail closed on non-ASCII byte escapes.
- 🚨 `src/extension/commit-message.ts:400` - The required criterion exempts only &#34;final Git trailer lines,&#34; but the reverse scan blanks every whitespace-prefixed line before a final trailer. In `fix: Close.\n\n  This isn&#39;t permitted.\nSigned-off-by: A &lt;a@b&gt;`, the violating body line is exempted even though continuation lines belong after a trailer token. Group each trailer with only the indented continuation lines that follow it.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bun run test -- test/extension/extension.test.ts`
- <code>Manual pi 0.83.0 JSON-mode run with the real bash tool and `src/extension/index.ts`: attempted the required bad commit, retried with the corrected message, then ran `git log -1 --format=%s`.</code>
- <code>Verified the throwaway repository remained on feature branch `demo` and contained only the corrected commit before removing the repository.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
