### PR TITLE
feat(extension): add session STE controls and commit checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,23 +13,24 @@ pi install npm:pi-simple-english
 ```
 
 For local development, run `pi -e .` from the repository instead.
-At the start of each agent turn, the extension adds a concise STE rule summary that reflects the active configuration.
+While enforcement is enabled, the extension adds a concise STE rule summary at the start of each agent turn.
 It checks proposed `write` and `edit` content before the tools change a file, using the same file-extension content kinds described for the CLI below.
 It uses bounded heuristics in `bash` tool calls to detect `git commit` invocations and check static messages supplied with `-m` or `--message` before the shell command runs.
 Conventional Commit prefixes and final trailer lines such as `Co-Authored-By` and `BREAKING CHANGE` are exempt, but the subject and body prose are checked at their original positions.
 Hard violations block the tool call with the line, column, rule ID, and a suggested fix so that the agent can correct the text and retry.
 Soft violations permit the tool call and appear as warnings.
 Edits use the existing file as a baseline, so unchanged violations do not block unrelated changes.
-After each finalized assistant reply, the extension lints its text as `prose-file` content without blocking or rewriting the reply.
+In regular enabled mode, the extension lints each finalized assistant reply as `prose-file` content without blocking or rewriting it.
 A latest-reply widget shows either a clean state or the hard and soft violation counts for the active branch, including after a session resume or tree navigation.
 Before the next model call, hidden feedback gives the model the details of hard reply violations only; soft reply violations stay in the widget.
 Reply linting uses the same Markdown code exclusions described below.
-Use `/ste` to disable or re-enable all write, edit, commit, and reply enforcement for the current session.
-Use `/ste status` to show the mode, configured rule counts by severity, and dictionary state.
-Use `/ste strict` to require user-facing replies through the gateable `say` tool, and use `/ste strict off` to restore normal replies.
+Use `/ste` to toggle all write, edit, commit, and reply enforcement for the current session, or use `/ste on` and `/ste off` to set it explicitly.
+Use `/ste status` to show the mode, configured rule counts by severity, and dictionary load state.
+Use `/ste strict` to activate the `say` tool and require all user-facing replies to pass through it.
+Use `/ste strict off` to deactivate `say` and restore normal streaming replies.
 A strict reply with hard violations stays hidden until the agent sends a clean rewrite through `say`.
 A detected commit invocation whose message cannot be extracted fails closed and asks the agent to use a static message argument.
-A configuration or dictionary load error makes the extension fail closed and block `write`, `edit`, and detected `git commit` invocations for that session.
+While enforcement remains enabled, a configuration or dictionary load error makes the extension fail closed and block `write`, `edit`, and detected `git commit` calls for that session.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ After each finalized assistant reply, the extension lints its text as `prose-fil
 A latest-reply widget shows either a clean state or the hard and soft violation counts for the active branch, including after a session resume or tree navigation.
 Before the next model call, hidden feedback gives the model the details of hard reply violations only; soft reply violations stay in the widget.
 Reply linting uses the same Markdown code exclusions described below.
+Use `/ste` to disable or re-enable all write, edit, commit, and reply enforcement for the current session.
+Use `/ste status` to show the mode, configured rule counts by severity, and dictionary state.
+Use `/ste strict` to require user-facing replies through the gateable `say` tool, and use `/ste strict off` to restore normal replies.
+A strict reply with hard violations stays hidden until the agent sends a clean rewrite through `say`.
 A detected commit invocation whose message cannot be extracted fails closed and asks the agent to use a static message argument.
 A configuration or dictionary load error makes the extension fail closed and block `write`, `edit`, and detected `git commit` invocations for that session.
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,6 @@
       "name": "pi-simple-english",
       "dependencies": {
         "effect": "^3.14.0",
-        "typebox": "^1.3.7",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
       },
@@ -14,11 +13,13 @@
         "@biomejs/biome": "^1.9.4",
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@types/node": "^22.0.0",
+        "typebox": "1.3.7",
         "typescript": "^5.8.0",
         "vitest": "^3.0.0",
       },
       "peerDependencies": {
         "@earendil-works/pi-coding-agent": "*",
+        "typebox": "*",
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "pi-simple-english",
       "dependencies": {
         "effect": "^3.14.0",
+        "typebox": "^1.3.7",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
       },
@@ -15,6 +16,9 @@
         "@types/node": "^22.0.0",
         "typescript": "^5.8.0",
         "vitest": "^3.0.0",
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-coding-agent": "*",
       },
     },
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "effect": "^3.14.0",
+    "typebox": "^1.3.7",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,17 +19,18 @@
   },
   "dependencies": {
     "effect": "^3.14.0",
-    "typebox": "^1.3.7",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-coding-agent": "*"
+    "@earendil-works/pi-coding-agent": "*",
+    "typebox": "*"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@types/node": "^22.0.0",
+    "typebox": "1.3.7",
     "typescript": "^5.8.0",
     "vitest": "^3.0.0"
   }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -383,8 +383,15 @@ function restoreReplyState(state: SessionState, ctx: ExtensionContext): void {
   const branch = ctx.sessionManager.getBranch()
   for (let index = branch.length - 1; index >= 0; index--) {
     const entry = branch[index]
-    if (entry?.type !== "message" || entry.message.role !== "assistant") continue
-    const textBlocks = entry.message.content.filter((block) => block.type === "text")
+    if (entry?.type !== "message") continue
+    const message = entry.message
+    if (
+      message.role !== "assistant" &&
+      (message.role !== "toolResult" || message.toolName !== "say" || message.isError)
+    ) {
+      continue
+    }
+    const textBlocks = message.content.filter((block) => block.type === "text")
     if (textBlocks.length === 0) continue
     updateReplyState(state, ctx, textBlocks.map((block) => block.text).join("\n"))
     return

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -10,6 +10,7 @@ import {
   createWriteToolDefinition,
 } from "@earendil-works/pi-coding-agent"
 import { Effect } from "effect"
+import { Type } from "typebox"
 import { loadConfig } from "../config/load.ts"
 import type { SteConfig } from "../config/schema.ts"
 import { loadDictionary } from "../dictionary/load.ts"
@@ -18,7 +19,7 @@ import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { RuleId } from "../engine/rules/registry.ts"
 import type { Tagger } from "../engine/tagger.ts"
-import type { RuleSetting, Violation } from "../engine/types.ts"
+import type { LintReport, RuleSetting, Violation } from "../engine/types.ts"
 import { makeWinkTagger } from "../tagger/wink.ts"
 import { blankCommitMetadata, findCommitInvocations } from "./commit-message.ts"
 
@@ -54,11 +55,25 @@ interface SessionState {
   config: SteConfig
   dictionary?: Dictionary
   tagger?: Tagger
+  enabled: boolean
   error?: string
   ready: boolean
+  strict: boolean
   pendingReplyFeedback?: string
   readonly pendingWarnings: Map<string, string>
 }
+
+const STRICT_MODE_NOTE = [
+  "## Simplified Technical English: strict mode",
+  "",
+  "Send every user-facing reply through the `say` tool.",
+  "Write no prose outside that tool.",
+  "Call `say` as your final action.",
+  "A hard violation blocks the call before the user reads the text.",
+  "Read the feedback, rewrite the text, and call `say` again.",
+].join("\n")
+
+let sharedTagger: Tagger | undefined
 
 function resolvedSetting(config: SteConfig, ruleId: RuleId): RuleSetting {
   return config.rules?.[ruleId] ?? DEFAULT_RULE_SETTINGS[ruleId]
@@ -77,6 +92,25 @@ function ruleSummary(config: SteConfig): string {
     })
     .join("\n")
   return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
+}
+
+function statusSummary(state: SessionState): string {
+  const counts: Record<RuleSetting, number> = { hard: 0, soft: 0, off: 0 }
+  for (const ruleId of Object.keys(RULE_SUMMARIES) as RuleId[]) {
+    counts[resolvedSetting(state.config, ruleId)]++
+  }
+  const mode = !state.enabled ? "disabled" : state.strict ? "strict" : "enabled"
+  const dictionary =
+    state.dictionary !== undefined
+      ? "loaded"
+      : state.error !== undefined
+        ? `failed (${state.error})`
+        : "not loaded"
+  return [
+    `Mode: ${mode}`,
+    `Rules: ${counts.hard} hard, ${counts.soft} soft, ${counts.off} off`,
+    `Dictionary: ${dictionary}`,
+  ].join("\n")
 }
 
 function suggestedFix(violation: Violation): string {
@@ -117,21 +151,24 @@ function formatReplyFeedback(violations: readonly Violation[]): string {
   return `STE feedback for your previous reply:\n${violationDetails(violations)}`
 }
 
-function updateReplyState(state: SessionState, ctx: ExtensionContext, text?: string): void {
-  state.pendingReplyFeedback = undefined
-  if (text === undefined) {
-    if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
-    return
-  }
-
-  const report = lint("prose-file", text, {
+function lintReply(state: SessionState, text: string): LintReport {
+  return lint("prose-file", text, {
     ...state.config,
     dictionary: state.dictionary,
     tagger: state.tagger,
   })
+}
+
+function showReplyReport(
+  state: SessionState,
+  ctx: ExtensionContext,
+  report: LintReport,
+  queueFeedback: boolean,
+): void {
   const hard = report.violations.filter((violation) => violation.severity === "hard")
   const softCount = report.summary.total - report.summary.hard
-  state.pendingReplyFeedback = hard.length === 0 ? undefined : formatReplyFeedback(hard)
+  state.pendingReplyFeedback =
+    queueFeedback && hard.length > 0 ? formatReplyFeedback(hard) : undefined
   if (!ctx.hasUI) return
 
   const status =
@@ -141,16 +178,23 @@ function updateReplyState(state: SessionState, ctx: ExtensionContext, text?: str
   ctx.ui.setWidget("simple-english-reply", [status])
 }
 
+function updateReplyState(state: SessionState, ctx: ExtensionContext, text?: string): void {
+  state.pendingReplyFeedback = undefined
+  if (text === undefined) {
+    if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
+    return
+  }
+  showReplyReport(state, ctx, lintReply(state, text), true)
+}
+
 function restoreReplyState(state: SessionState, ctx: ExtensionContext): void {
   const branch = ctx.sessionManager.getBranch()
   for (let index = branch.length - 1; index >= 0; index--) {
     const entry = branch[index]
     if (entry?.type !== "message" || entry.message.role !== "assistant") continue
-    const text = entry.message.content
-      .filter((block) => block.type === "text")
-      .map((block) => block.text)
-      .join("\n")
-    updateReplyState(state, ctx, text)
+    const textBlocks = entry.message.content.filter((block) => block.type === "text")
+    if (textBlocks.length === 0) continue
+    updateReplyState(state, ctx, textBlocks.map((block) => block.text).join("\n"))
     return
   }
   updateReplyState(state, ctx)
@@ -249,11 +293,34 @@ function createGatedBashTool(cwd: string, state: SessionState) {
   const definition = createBashToolDefinition(cwd)
   const execute: typeof definition.execute = async (...args) => {
     const [toolCallId, input, _signal, _onUpdate, ctx] = args
-    const result = lintCommitCommand(state, ctx, toolCallId, input.command)
-    if (result?.block) throw new Error(result.reason)
+    if (state.enabled) {
+      const result = lintCommitCommand(state, ctx, toolCallId, input.command)
+      if (result?.block) throw new Error(result.reason)
+    }
     return definition.execute(...args)
   }
   return { ...definition, execute }
+}
+
+function lintStrictReply(
+  state: SessionState,
+  ctx: ExtensionContext,
+  text: string,
+): ToolCallEventResult | undefined {
+  if (!state.ready) {
+    return {
+      block: true,
+      reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+    }
+  }
+  const report = lintReply(state, text)
+  showReplyReport(state, ctx, report, false)
+  const hard = report.violations.filter((violation) => violation.severity === "hard")
+  if (hard.length === 0) return undefined
+  return {
+    block: true,
+    reason: formatViolations("reply", "STE blocked", hard),
+  }
 }
 
 function createGatedWriteTool(cwd: string, state: SessionState) {
@@ -264,13 +331,15 @@ function createGatedWriteTool(cwd: string, state: SessionState) {
       operations: {
         mkdir: async () => undefined,
         writeFile: async (path, content) => {
-          if (!state.ready) {
-            throw new Error(
-              `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
-            )
+          if (state.enabled) {
+            if (!state.ready) {
+              throw new Error(
+                `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+              )
+            }
+            const result = lintProposedText(state, ctx, "write", toolCallId, input.path, content)
+            if (result?.block) throw new Error(result.reason)
           }
-          const result = lintProposedText(state, ctx, "write", toolCallId, input.path, content)
-          if (result?.block) throw new Error(result.reason)
           await mkdir(dirname(path), { recursive: true })
           if (signal?.aborted) throw new Error("Operation aborted")
           await writeFile(path, content, "utf8")
@@ -296,21 +365,23 @@ function createGatedEditTool(cwd: string, state: SessionState) {
           return content
         },
         writeFile: async (path, content) => {
-          if (!state.ready) {
-            throw new Error(
-              `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+          if (state.enabled) {
+            if (!state.ready) {
+              throw new Error(
+                `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+              )
+            }
+            const result = lintProposedText(
+              state,
+              ctx,
+              "edit",
+              toolCallId,
+              input.path,
+              content,
+              previousText,
             )
+            if (result?.block) throw new Error(result.reason)
           }
-          const result = lintProposedText(
-            state,
-            ctx,
-            "edit",
-            toolCallId,
-            input.path,
-            content,
-            previousText,
-          )
-          if (result?.block) throw new Error(result.reason)
           await writeFile(path, content, "utf8")
         },
       },
@@ -321,9 +392,83 @@ function createGatedEditTool(cwd: string, state: SessionState) {
 }
 
 export default function simpleEnglishExtension(pi: ExtensionAPI): void {
-  const state: SessionState = { config: {}, ready: false, pendingWarnings: new Map() }
+  const state: SessionState = {
+    config: {},
+    enabled: true,
+    ready: false,
+    strict: false,
+    pendingWarnings: new Map(),
+  }
+
+  const setSayActive = (active: boolean): void => {
+    const tools = pi.getActiveTools().filter((name) => name !== "say")
+    pi.setActiveTools(active ? [...tools, "say"] : tools)
+  }
+
+  pi.registerCommand("ste", {
+    description: "Toggle STE enforcement or show status. Use strict to gate replies.",
+    handler: async (args, ctx) => {
+      const command = args.trim().toLowerCase()
+      if (command === "status") {
+        ctx.ui.notify(statusSummary(state), "info")
+        return
+      }
+      if (command === "strict" || command === "strict on") {
+        state.enabled = true
+        state.strict = true
+        setSayActive(true)
+        ctx.ui.notify("STE strict mode enabled. Send every reply through the say tool.", "info")
+        return
+      }
+      if (command === "strict off") {
+        state.strict = false
+        setSayActive(false)
+        ctx.ui.notify("STE strict mode disabled.", "info")
+        return
+      }
+      if (command !== "" && command !== "on" && command !== "off") {
+        ctx.ui.notify("Usage: /ste [on|off|status|strict|strict off]", "warning")
+        return
+      }
+
+      state.enabled = command === "on" || (command === "" && !state.enabled)
+      if (!state.enabled) {
+        state.strict = false
+        setSayActive(false)
+        state.pendingReplyFeedback = undefined
+        state.pendingWarnings.clear()
+        if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
+      }
+      ctx.ui.notify(`STE enforcement ${state.enabled ? "enabled" : "disabled"}.`, "info")
+    },
+  })
+
+  pi.registerTool({
+    name: "say",
+    label: "Say",
+    description:
+      "Send prose to the user. In STE strict mode, use this tool for every user-facing reply.",
+    parameters: Type.Object({
+      text: Type.String({ description: "The complete user-facing reply" }),
+    }),
+    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+      if (state.enabled && state.strict) {
+        const result = lintStrictReply(state, ctx, params.text)
+        if (result?.block) throw new Error(result.reason)
+      }
+      return {
+        content: [{ type: "text" as const, text: params.text }],
+        details: {},
+        terminate: true,
+      }
+    },
+  })
 
   pi.on("session_start", async (_event, ctx) => {
+    setSayActive(state.enabled && state.strict)
+    state.config = {}
+    state.dictionary = undefined
+    state.tagger = undefined
     state.ready = false
     state.error = undefined
     state.pendingWarnings.clear()
@@ -336,7 +481,8 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
       state.dictionary = await Effect.runPromise(
         loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
       )
-      state.tagger = makeWinkTagger()
+      sharedTagger ??= makeWinkTagger()
+      state.tagger = sharedTagger
       state.ready = true
       restoreReplyState(state, ctx)
     } catch (error) {
@@ -350,20 +496,22 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     if (state.ready) restoreReplyState(state, ctx)
   })
 
-  pi.on("before_agent_start", (event) => ({
-    systemPrompt: `${event.systemPrompt}\n\n${ruleSummary(state.config)}`,
-  }))
+  pi.on("before_agent_start", (event) => {
+    if (!state.enabled) return undefined
+    const additions = [ruleSummary(state.config)]
+    if (state.strict) additions.push(STRICT_MODE_NOTE)
+    return { systemPrompt: `${event.systemPrompt}\n\n${additions.join("\n\n")}` }
+  })
 
   pi.on("turn_end", (event, ctx) => {
-    if (!state.ready || event.message.role !== "assistant") return
-    const text = event.message.content
-      .filter((block) => block.type === "text")
-      .map((block) => block.text)
-      .join("\n")
-    updateReplyState(state, ctx, text)
+    if (!state.enabled || !state.ready || event.message.role !== "assistant") return
+    const textBlocks = event.message.content.filter((block) => block.type === "text")
+    if (textBlocks.length === 0) return
+    updateReplyState(state, ctx, textBlocks.map((block) => block.text).join("\n"))
   })
 
   pi.on("context", (event) => {
+    if (!state.enabled) return undefined
     const feedback = state.pendingReplyFeedback
     if (feedback === undefined) return undefined
     state.pendingReplyFeedback = undefined
@@ -381,7 +529,15 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     }
   })
 
-  pi.on("tool_call", async (event) => {
+  pi.on("tool_call", async (event, ctx) => {
+    if (!state.enabled) return undefined
+    if (event.toolName === "say" && state.strict) {
+      const text = (event.input as { text?: unknown }).text
+      if (typeof text !== "string") {
+        return { block: true, reason: "STE could not check the reply: say requires text." }
+      }
+      return lintStrictReply(state, ctx, text)
+    }
     if (event.toolName !== "write" && event.toolName !== "edit") return undefined
     if (state.ready) return undefined
     return {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -4,6 +4,7 @@ import { dirname } from "node:path"
 import {
   type ExtensionAPI,
   type ExtensionContext,
+  ExtensionRunner,
   type MessageStartEvent,
   type MessageUpdateEvent,
   type ToolCallEventResult,
@@ -59,10 +60,14 @@ interface SessionState {
   tagger?: Tagger
   enabled: boolean
   error?: string
+  dictionaryError?: string
   ready: boolean
   strict: boolean
   pendingReplyFeedback?: string
+  readonly approvedSayReplies: Map<string, string>
+  readonly pendingSayArguments: Map<string, Record<string, unknown>>
   readonly pendingWarnings: Map<string, string>
+  readonly rejectedSayReplies: Map<string, string>
 }
 
 const STRICT_MODE_NOTE = [
@@ -105,8 +110,8 @@ function statusSummary(state: SessionState): string {
   const dictionary =
     state.dictionary !== undefined
       ? "loaded"
-      : state.error !== undefined
-        ? `failed (${state.error})`
+      : state.dictionaryError !== undefined
+        ? `failed (${state.dictionaryError})`
         : "not loaded"
   return [
     `Mode: ${mode}`,
@@ -162,24 +167,189 @@ function lintReply(state: SessionState, text: string): LintReport {
 }
 
 type AssistantMessage = Extract<MessageStartEvent["message"], { role: "assistant" }>
+type Message = MessageStartEvent["message"]
 
-function contentWithoutText(message: AssistantMessage): AssistantMessage["content"] {
-  return message.content.filter((block) => block.type !== "text")
+type BoundaryRegistry = {
+  installed: boolean
+  readonly states: WeakMap<object, SessionState>
 }
 
-function suppressAssistantText(message: MessageStartEvent["message"]): void {
-  if (message.role === "assistant") message.content = contentWithoutText(message)
+type BoundaryGlobal = typeof globalThis & {
+  __simpleEnglishStrictBoundaryV1?: BoundaryRegistry
 }
 
-function suppressAssistantTextUpdate(event: MessageUpdateEvent): void {
-  suppressAssistantText(event.message)
-  const update = event.assistantMessageEvent
-  if ("partial" in update) {
-    update.partial = { ...update.partial, content: contentWithoutText(update.partial) }
+const REDACTED_SAY_TEXT = "[redacted until STE approval]"
+const boundaryGlobal = globalThis as BoundaryGlobal
+const boundaryRegistry = (boundaryGlobal.__simpleEnglishStrictBoundaryV1 ??= {
+  installed: false,
+  states: new WeakMap(),
+})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function replaceRecord(target: Record<string, unknown>, replacement: Record<string, unknown>): void {
+  for (const key of Object.keys(target)) delete target[key]
+  Object.assign(target, replacement)
+}
+
+function captureAndRedactSayArguments(
+  state: SessionState,
+  toolCallId: string,
+  argumentsValue: unknown,
+): void {
+  if (!isRecord(argumentsValue)) return
+  if (argumentsValue.text !== REDACTED_SAY_TEXT) {
+    state.pendingSayArguments.set(toolCallId, structuredClone(argumentsValue))
   }
-  if (update.type === "text_delta") update.delta = ""
-  if (update.type === "text_end") update.content = ""
+  replaceRecord(argumentsValue, { text: REDACTED_SAY_TEXT })
 }
+
+function contentWithoutText(
+  state: SessionState,
+  message: AssistantMessage,
+): AssistantMessage["content"] {
+  return message.content.filter((block) => {
+    if (block.type === "text") return false
+    if (block.type === "toolCall" && block.name === "say") {
+      captureAndRedactSayArguments(state, block.id, block.arguments)
+    }
+    return true
+  })
+}
+
+function suppressAssistantText(state: SessionState, message: Message): void {
+  if (message.role === "assistant") message.content = contentWithoutText(state, message)
+}
+
+function suppressAssistantTextUpdate(state: SessionState, event: MessageUpdateEvent): void {
+  suppressAssistantText(state, event.message)
+  const update = event.assistantMessageEvent
+  if ("partial" in update) suppressAssistantText(state, update.partial)
+  if (update.type === "text_delta" || update.type === "toolcall_delta") update.delta = ""
+  if (update.type === "text_end") update.content = ""
+  if (update.type === "toolcall_end" && update.toolCall.name === "say") {
+    captureAndRedactSayArguments(state, update.toolCall.id, update.toolCall.arguments)
+  }
+  if (update.type === "done") suppressAssistantText(state, update.message)
+  if (update.type === "error") suppressAssistantText(state, update.error)
+}
+
+function strictSayContent(state: SessionState, toolCallId: string) {
+  const approved = state.approvedSayReplies.get(toolCallId)
+  if (approved !== undefined) {
+    return { content: [{ type: "text" as const, text: approved }], details: {}, isError: false }
+  }
+  const rejected = state.rejectedSayReplies.get(toolCallId)
+  if (rejected !== undefined) {
+    return { content: [{ type: "text" as const, text: rejected }], details: {}, isError: true }
+  }
+  return { content: [], details: {}, isError: true }
+}
+
+function enforceStrictMessage(state: SessionState, message: Message): void {
+  if (!state.enabled || !state.strict) return
+  if (message.role === "assistant") {
+    suppressAssistantText(state, message)
+    return
+  }
+  if (message.role !== "toolResult" || message.toolName !== "say") return
+  Object.assign(message, strictSayContent(state, message.toolCallId))
+}
+
+function enforceStrictEvent(state: SessionState, event: Record<string, unknown>): void {
+  if (!state.enabled || !state.strict) return
+  if (isRecord(event.message) && "role" in event.message) {
+    enforceStrictMessage(state, event.message as Message)
+  }
+  if (event.type === "message_update") suppressAssistantTextUpdate(state, event as MessageUpdateEvent)
+  if (
+    (event.type === "tool_execution_start" || event.type === "tool_execution_update") &&
+    event.toolName === "say" &&
+    typeof event.toolCallId === "string"
+  ) {
+    captureAndRedactSayArguments(state, event.toolCallId, event.args)
+  }
+  if (
+    event.type === "tool_execution_end" &&
+    event.toolName === "say" &&
+    typeof event.toolCallId === "string" &&
+    isRecord(event.result)
+  ) {
+    Object.assign(event.result, strictSayContent(state, event.toolCallId))
+  }
+  if (event.type === "turn_end" && Array.isArray(event.toolResults)) {
+    for (const result of event.toolResults) {
+      if (isRecord(result) && result.role === "toolResult" && result.toolName === "say") {
+        enforceStrictMessage(state, result as Message)
+      }
+    }
+  }
+  if (event.type === "agent_end" && Array.isArray(event.messages)) {
+    for (const message of event.messages) {
+      if (isRecord(message) && "role" in message) enforceStrictMessage(state, message as Message)
+    }
+    state.approvedSayReplies.clear()
+    state.pendingSayArguments.clear()
+    state.rejectedSayReplies.clear()
+  }
+}
+
+function installStrictOutputBoundary(): void {
+  if (boundaryRegistry.installed) return
+  boundaryRegistry.installed = true
+
+  const originalEmit = ExtensionRunner.prototype.emit
+  Object.defineProperty(ExtensionRunner.prototype, "emit", {
+    configurable: true,
+    value: async function (this: ExtensionRunner, event: Record<string, unknown>) {
+      const result = await originalEmit.call(this, event as never)
+      const state = boundaryRegistry.states.get(this.createContext().sessionManager as object)
+      if (state !== undefined) enforceStrictEvent(state, event)
+      return result
+    },
+    writable: true,
+  })
+
+  const originalEmitMessageEnd = ExtensionRunner.prototype.emitMessageEnd
+  Object.defineProperty(ExtensionRunner.prototype, "emitMessageEnd", {
+    configurable: true,
+    value: async function (this: ExtensionRunner, event: { message: Message }) {
+      const replacement = await originalEmitMessageEnd.call(this, event as never)
+      const state = boundaryRegistry.states.get(this.createContext().sessionManager as object)
+      if (state === undefined || !state.enabled || !state.strict) return replacement
+      const message = (replacement ?? event.message) as Message
+      enforceStrictMessage(state, message)
+      return message
+    },
+    writable: true,
+  })
+
+  const originalEmitToolResult = ExtensionRunner.prototype.emitToolResult
+  Object.defineProperty(ExtensionRunner.prototype, "emitToolResult", {
+    configurable: true,
+    value: async function (
+      this: ExtensionRunner,
+      event: Record<string, unknown> & { toolCallId: string },
+    ) {
+      const replacement = await originalEmitToolResult.call(this, event as never)
+      const state = boundaryRegistry.states.get(this.createContext().sessionManager as object)
+      if (
+        state === undefined ||
+        !state.enabled ||
+        !state.strict ||
+        event.toolName !== "say"
+      ) {
+        return replacement
+      }
+      return strictSayContent(state, event.toolCallId)
+    },
+    writable: true,
+  })
+}
+
+installStrictOutputBoundary()
 
 function showReplyReport(
   state: SessionState,
@@ -419,7 +589,10 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     enabled: true,
     ready: false,
     strict: false,
+    approvedSayReplies: new Map(),
+    pendingSayArguments: new Map(),
     pendingWarnings: new Map(),
+    rejectedSayReplies: new Map(),
   }
 
   const setSayActive = (active: boolean): void => {
@@ -458,7 +631,10 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
         state.strict = false
         setSayActive(false)
         state.pendingReplyFeedback = undefined
+        state.approvedSayReplies.clear()
+        state.pendingSayArguments.clear()
         state.pendingWarnings.clear()
+        state.rejectedSayReplies.clear()
         if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
       }
       ctx.ui.notify(`STE enforcement ${state.enabled ? "enabled" : "disabled"}.`, "info")
@@ -473,10 +649,16 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     parameters: Type.Object({
       text: Type.String({ description: "The complete user-facing reply" }),
     }),
-    async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+    async execute(toolCallId, params, _signal, _onUpdate, ctx) {
       if (state.enabled && state.strict) {
         const result = lintStrictReply(state, ctx, params.text)
-        if (result?.block) throw new Error(result.reason)
+        if (result?.block) {
+          state.approvedSayReplies.delete(toolCallId)
+          state.rejectedSayReplies.set(toolCallId, result.reason ?? "STE blocked the reply.")
+          throw new Error(result.reason)
+        }
+        state.approvedSayReplies.set(toolCallId, params.text)
+        state.rejectedSayReplies.delete(toolCallId)
       }
       return {
         content: [{ type: "text" as const, text: params.text }],
@@ -487,26 +669,49 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   })
 
   pi.on("session_start", async (_event, ctx) => {
+    boundaryRegistry.states.set(ctx.sessionManager as object, state)
     setSayActive(state.enabled && state.strict)
     state.config = {}
     state.dictionary = undefined
     state.tagger = undefined
     state.ready = false
     state.error = undefined
+    state.dictionaryError = undefined
+    state.approvedSayReplies.clear()
+    state.pendingSayArguments.clear()
     state.pendingWarnings.clear()
+    state.rejectedSayReplies.clear()
     updateReplyState(state, ctx)
     pi.registerTool(createGatedBashTool(ctx.cwd, state))
     pi.registerTool(createGatedWriteTool(ctx.cwd, state))
     pi.registerTool(createGatedEditTool(ctx.cwd, state))
+
     try {
       state.config = await Effect.runPromise(loadConfig(undefined, ctx.cwd, ctx.isProjectTrusted()))
+    } catch (error) {
+      state.error = error instanceof Error ? error.message : String(error)
+      if (ctx.hasUI)
+        ctx.ui.notify(`Simple English extension failed to start: ${state.error}`, "error")
+      return
+    }
+
+    try {
       state.dictionary = await Effect.runPromise(
         loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
       )
+    } catch (error) {
+      state.dictionaryError = error instanceof Error ? error.message : String(error)
+      state.error = state.dictionaryError
+      if (ctx.hasUI)
+        ctx.ui.notify(`Simple English extension failed to start: ${state.error}`, "error")
+      return
+    }
+
+    try {
       sharedTagger ??= makeWinkTagger()
       state.tagger = sharedTagger
       state.ready = true
-      restoreReplyState(state, ctx)
+      if (state.enabled) restoreReplyState(state, ctx)
     } catch (error) {
       state.error = error instanceof Error ? error.message : String(error)
       if (ctx.hasUI)
@@ -514,8 +719,13 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     }
   })
 
+  pi.on("session_shutdown", (_event, ctx) => {
+    boundaryRegistry.states.delete(ctx.sessionManager as object)
+  })
+
   pi.on("session_tree", (_event, ctx) => {
-    if (state.ready) restoreReplyState(state, ctx)
+    if (state.enabled && state.ready) restoreReplyState(state, ctx)
+    else updateReplyState(state, ctx)
   })
 
   pi.on("before_agent_start", (event) => {
@@ -526,19 +736,26 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   })
 
   pi.on("message_start", (event) => {
-    if (state.enabled && state.strict) suppressAssistantText(event.message)
+    if (state.enabled && state.strict) enforceStrictMessage(state, event.message)
   })
 
   pi.on("message_update", (event) => {
-    if (state.enabled && state.strict) suppressAssistantTextUpdate(event)
+    if (state.enabled && state.strict) suppressAssistantTextUpdate(state, event)
   })
 
   pi.on("message_end", (event) => {
-    if (!state.enabled || !state.strict || event.message.role !== "assistant") return undefined
-    return {
-      message: { ...event.message, content: contentWithoutText(event.message) },
-    }
+    if (!state.enabled || !state.strict) return undefined
+    enforceStrictMessage(state, event.message)
+    return { message: event.message }
   })
+
+  for (const eventName of [
+    "tool_execution_start",
+    "tool_execution_update",
+    "tool_execution_end",
+  ] as const) {
+    pi.on(eventName, (event) => enforceStrictEvent(state, event))
+  }
 
   pi.on("turn_end", (event, ctx) => {
     if (!state.enabled || !state.ready || event.message.role !== "assistant") return
@@ -569,11 +786,19 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   pi.on("tool_call", async (event, ctx) => {
     if (!state.enabled) return undefined
     if (event.toolName === "say" && state.strict) {
+      const savedArguments = state.pendingSayArguments.get(event.toolCallId)
+      if (savedArguments !== undefined) replaceRecord(event.input, structuredClone(savedArguments))
       const text = (event.input as { text?: unknown }).text
       if (typeof text !== "string") {
-        return { block: true, reason: "STE could not check the reply: say requires text." }
+        const reason = "STE could not check the reply: say requires text."
+        state.rejectedSayReplies.set(event.toolCallId, reason)
+        return { block: true, reason }
       }
-      return lintStrictReply(state, ctx, text)
+      const result = lintStrictReply(state, ctx, text)
+      if (result?.block) {
+        state.rejectedSayReplies.set(event.toolCallId, result.reason ?? "STE blocked the reply.")
+      }
+      return result
     }
     if (event.toolName !== "write" && event.toolName !== "edit") return undefined
     if (state.ready) return undefined

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -206,12 +206,12 @@ function captureAndRedactSayArguments(
   replaceRecord(argumentsValue, { text: REDACTED_SAY_TEXT })
 }
 
-function contentWithoutText(
+function contentWithoutReplyProse(
   state: SessionState,
   message: AssistantMessage,
 ): AssistantMessage["content"] {
   return message.content.filter((block) => {
-    if (block.type === "text") return false
+    if (block.type === "text" || block.type === "thinking") return false
     if (block.type === "toolCall" && block.name === "say") {
       captureAndRedactSayArguments(state, block.id, block.arguments)
     }
@@ -219,21 +219,27 @@ function contentWithoutText(
   })
 }
 
-function suppressAssistantText(state: SessionState, message: Message): void {
-  if (message.role === "assistant") message.content = contentWithoutText(state, message)
+function suppressAssistantReply(state: SessionState, message: Message): void {
+  if (message.role === "assistant") message.content = contentWithoutReplyProse(state, message)
 }
 
-function suppressAssistantTextUpdate(state: SessionState, event: MessageUpdateEvent): void {
-  suppressAssistantText(state, event.message)
+function suppressAssistantReplyUpdate(state: SessionState, event: MessageUpdateEvent): void {
+  suppressAssistantReply(state, event.message)
   const update = event.assistantMessageEvent
-  if ("partial" in update) suppressAssistantText(state, update.partial)
-  if (update.type === "text_delta" || update.type === "toolcall_delta") update.delta = ""
-  if (update.type === "text_end") update.content = ""
+  if ("partial" in update) suppressAssistantReply(state, update.partial)
+  if (
+    update.type === "text_delta" ||
+    update.type === "thinking_delta" ||
+    update.type === "toolcall_delta"
+  ) {
+    update.delta = ""
+  }
+  if (update.type === "text_end" || update.type === "thinking_end") update.content = ""
   if (update.type === "toolcall_end" && update.toolCall.name === "say") {
     captureAndRedactSayArguments(state, update.toolCall.id, update.toolCall.arguments)
   }
-  if (update.type === "done") suppressAssistantText(state, update.message)
-  if (update.type === "error") suppressAssistantText(state, update.error)
+  if (update.type === "done") suppressAssistantReply(state, update.message)
+  if (update.type === "error") suppressAssistantReply(state, update.error)
 }
 
 function strictSayContent(state: SessionState, toolCallId: string) {
@@ -251,7 +257,7 @@ function strictSayContent(state: SessionState, toolCallId: string) {
 function enforceStrictMessage(state: SessionState, message: Message): void {
   if (!state.enabled || !state.strict) return
   if (message.role === "assistant") {
-    suppressAssistantText(state, message)
+    suppressAssistantReply(state, message)
     return
   }
   if (message.role !== "toolResult" || message.toolName !== "say") return
@@ -263,7 +269,7 @@ function enforceStrictEvent(state: SessionState, event: Record<string, unknown>)
   if (isRecord(event.message) && "role" in event.message) {
     enforceStrictMessage(state, event.message as Message)
   }
-  if (event.type === "message_update") suppressAssistantTextUpdate(state, event as MessageUpdateEvent)
+  if (event.type === "message_update") suppressAssistantReplyUpdate(state, event as MessageUpdateEvent)
   if (
     (event.type === "tool_execution_start" || event.type === "tool_execution_update") &&
     event.toolName === "say" &&
@@ -747,7 +753,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   })
 
   pi.on("message_update", (event) => {
-    if (state.enabled && state.strict) suppressAssistantTextUpdate(state, event)
+    if (state.enabled && state.strict) suppressAssistantReplyUpdate(state, event)
   })
 
   pi.on("message_end", (event) => {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -180,16 +180,22 @@ type BoundaryGlobal = typeof globalThis & {
 
 const REDACTED_SAY_TEXT = "[redacted until STE approval]"
 const boundaryGlobal = globalThis as BoundaryGlobal
-const boundaryRegistry = (boundaryGlobal.__simpleEnglishStrictBoundaryV1 ??= {
+const boundaryRegistry = boundaryGlobal.__simpleEnglishStrictBoundaryV1 ?? {
   installed: false,
   states: new WeakMap(),
-})
+}
+if (boundaryGlobal.__simpleEnglishStrictBoundaryV1 === undefined) {
+  boundaryGlobal.__simpleEnglishStrictBoundaryV1 = boundaryRegistry
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function replaceRecord(target: Record<string, unknown>, replacement: Record<string, unknown>): void {
+function replaceRecord(
+  target: Record<string, unknown>,
+  replacement: Record<string, unknown>,
+): void {
   for (const key of Object.keys(target)) delete target[key]
   Object.assign(target, replacement)
 }
@@ -264,12 +270,14 @@ function enforceStrictMessage(state: SessionState, message: Message): void {
   Object.assign(message, strictSayContent(state, message.toolCallId))
 }
 
-function enforceStrictEvent(state: SessionState, event: Record<string, unknown>): void {
-  if (!state.enabled || !state.strict) return
+function enforceStrictEvent(state: SessionState, eventValue: unknown): void {
+  if (!state.enabled || !state.strict || !isRecord(eventValue)) return
+  const event = eventValue
   if (isRecord(event.message) && "role" in event.message) {
-    enforceStrictMessage(state, event.message as Message)
+    enforceStrictMessage(state, event.message as unknown as Message)
   }
-  if (event.type === "message_update") suppressAssistantReplyUpdate(state, event as MessageUpdateEvent)
+  if (event.type === "message_update")
+    suppressAssistantReplyUpdate(state, event as unknown as MessageUpdateEvent)
   if (
     (event.type === "tool_execution_start" || event.type === "tool_execution_update") &&
     event.toolName === "say" &&
@@ -288,13 +296,15 @@ function enforceStrictEvent(state: SessionState, event: Record<string, unknown>)
   if (event.type === "turn_end" && Array.isArray(event.toolResults)) {
     for (const result of event.toolResults) {
       if (isRecord(result) && result.role === "toolResult" && result.toolName === "say") {
-        enforceStrictMessage(state, result as Message)
+        enforceStrictMessage(state, result as unknown as Message)
       }
     }
   }
   if (event.type === "agent_end" && Array.isArray(event.messages)) {
     for (const message of event.messages) {
-      if (isRecord(message) && "role" in message) enforceStrictMessage(state, message as Message)
+      if (isRecord(message) && "role" in message) {
+        enforceStrictMessage(state, message as unknown as Message)
+      }
     }
     state.approvedSayReplies.clear()
     state.pendingSayArguments.clear()
@@ -341,12 +351,7 @@ function installStrictOutputBoundary(): void {
     ) {
       const replacement = await originalEmitToolResult.call(this, event as never)
       const state = boundaryRegistry.states.get(this.createContext().sessionManager as object)
-      if (
-        state === undefined ||
-        !state.enabled ||
-        !state.strict ||
-        event.toolName !== "say"
-      ) {
+      if (state === undefined || !state.enabled || !state.strict || event.toolName !== "say") {
         return replacement
       }
       return strictSayContent(state, event.toolCallId)
@@ -762,13 +767,9 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     return { message: event.message }
   })
 
-  for (const eventName of [
-    "tool_execution_start",
-    "tool_execution_update",
-    "tool_execution_end",
-  ] as const) {
-    pi.on(eventName, (event) => enforceStrictEvent(state, event))
-  }
+  pi.on("tool_execution_start", (event) => enforceStrictEvent(state, event))
+  pi.on("tool_execution_update", (event) => enforceStrictEvent(state, event))
+  pi.on("tool_execution_end", (event) => enforceStrictEvent(state, event))
 
   pi.on("turn_end", (event, ctx) => {
     if (!state.enabled || !state.ready || event.message.role !== "assistant") return

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -4,6 +4,8 @@ import { dirname } from "node:path"
 import {
   type ExtensionAPI,
   type ExtensionContext,
+  type MessageStartEvent,
+  type MessageUpdateEvent,
   type ToolCallEventResult,
   createBashToolDefinition,
   createEditToolDefinition,
@@ -157,6 +159,26 @@ function lintReply(state: SessionState, text: string): LintReport {
     dictionary: state.dictionary,
     tagger: state.tagger,
   })
+}
+
+type AssistantMessage = Extract<MessageStartEvent["message"], { role: "assistant" }>
+
+function contentWithoutText(message: AssistantMessage): AssistantMessage["content"] {
+  return message.content.filter((block) => block.type !== "text")
+}
+
+function suppressAssistantText(message: MessageStartEvent["message"]): void {
+  if (message.role === "assistant") message.content = contentWithoutText(message)
+}
+
+function suppressAssistantTextUpdate(event: MessageUpdateEvent): void {
+  suppressAssistantText(event.message)
+  const update = event.assistantMessageEvent
+  if ("partial" in update) {
+    update.partial = { ...update.partial, content: contentWithoutText(update.partial) }
+  }
+  if (update.type === "text_delta") update.delta = ""
+  if (update.type === "text_end") update.content = ""
 }
 
 function showReplyReport(
@@ -501,6 +523,21 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     const additions = [ruleSummary(state.config)]
     if (state.strict) additions.push(STRICT_MODE_NOTE)
     return { systemPrompt: `${event.systemPrompt}\n\n${additions.join("\n\n")}` }
+  })
+
+  pi.on("message_start", (event) => {
+    if (state.enabled && state.strict) suppressAssistantText(event.message)
+  })
+
+  pi.on("message_update", (event) => {
+    if (state.enabled && state.strict) suppressAssistantTextUpdate(event)
+  })
+
+  pi.on("message_end", (event) => {
+    if (!state.enabled || !state.strict || event.message.role !== "assistant") return undefined
+    return {
+      message: { ...event.message, content: contentWithoutText(event.message) },
+    }
   })
 
   pi.on("turn_end", (event, ctx) => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -315,6 +315,24 @@ async function executeBash(
   )
 }
 
+function sayResultEntry(text: string, id = "say-result") {
+  return {
+    type: "message",
+    id,
+    parentId: null,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: "toolResult",
+      toolCallId: "say-approved",
+      toolName: "say",
+      content: [{ type: "text", text }],
+      details: {},
+      isError: false,
+      timestamp: Date.now(),
+    },
+  }
+}
+
 describe.sequential("pi extension wiring", () => {
   test("declares a production pi extension package", async () => {
     const manifest = JSON.parse(await readFile(join(process.cwd(), "package.json"), "utf8"))
@@ -1061,6 +1079,20 @@ describe.sequential("pi extension wiring", () => {
         }),
       ]),
     })
+  })
+
+  test("restores the latest successful strict say reply", async () => {
+    const { pi, context, widgets } = await startExtension({
+      branch: [
+        assistantEntry("This isn't permitted.", "old-reply"),
+        sayResultEntry("Open the valve."),
+      ],
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+      sessionStartReason: "resume",
+    })
+
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
   test("keeps reply checking cleared during disabled tree navigation", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -535,12 +535,7 @@ describe.sequential("pi extension wiring", () => {
     ).resolves.toBeDefined()
     expect(await readFile(join(cwd, "notes.md"), "utf8")).toBe("This can't be permitted.")
     await expect(
-      executeBash(
-        pi,
-        context,
-        "commit-disabled",
-        `git commit -m "fix: This isn't permitted."`,
-      ),
+      executeBash(pi, context, "commit-disabled", `git commit -m "fix: This isn't permitted."`),
     ).resolves.toBeUndefined()
     await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
     expect(widgets.get("simple-english-reply")).toBeUndefined()

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -641,6 +641,53 @@ describe.sequential("pi extension wiring", () => {
     expect(update.assistantMessageEvent.delta).toBe("")
     expect(update.assistantMessageEvent.partial.content).toEqual([])
 
+    const thinking = {
+      ...assistantMessage(""),
+      content: [{ type: "thinking", thinking: "This isn't permitted." }],
+    }
+    await pi.emit("message_start", { message: thinking }, context)
+    expect(thinking.content).toEqual([])
+
+    const thinkingPartial = {
+      ...assistantMessage(""),
+      content: [{ type: "thinking", thinking: "This isn't permitted." }],
+    }
+    const thinkingUpdate = {
+      message: thinkingPartial,
+      assistantMessageEvent: {
+        type: "thinking_delta",
+        contentIndex: 0,
+        delta: "This isn't permitted.",
+        partial: {
+          ...assistantMessage(""),
+          content: [{ type: "thinking", thinking: "This isn't permitted." }],
+        },
+      },
+    }
+    await pi.emit("message_update", thinkingUpdate, context)
+    expect(thinkingPartial.content).toEqual([])
+    expect(thinkingUpdate.assistantMessageEvent.delta).toBe("")
+    expect(thinkingUpdate.assistantMessageEvent.partial.content).toEqual([])
+
+    const thinkingEnd = {
+      message: {
+        ...assistantMessage(""),
+        content: [{ type: "thinking", thinking: "This isn't permitted." }],
+      },
+      assistantMessageEvent: {
+        type: "thinking_end",
+        contentIndex: 0,
+        content: "This isn't permitted.",
+        partial: {
+          ...assistantMessage(""),
+          content: [{ type: "thinking", thinking: "This isn't permitted." }],
+        },
+      },
+    }
+    await pi.emit("message_update", thinkingEnd, context)
+    expect(thinkingEnd.assistantMessageEvent.content).toBe("")
+    expect(thinkingEnd.assistantMessageEvent.partial.content).toEqual([])
+
     const finalized = await pi.finalizeAssistant(
       assistantMessage("This isn't permitted."),
       context,
@@ -699,9 +746,43 @@ describe.sequential("pi extension wiring", () => {
     await pi.executeTool("say", "say-approved", { text: "Open the valve." }, context)
 
     const runner = boundaryRunner(context.sessionManager, {
-      message_end: [() => ({ message: assistantMessage("This isn't permitted.") })],
+      message_end: [() => ({
+        message: {
+          ...assistantMessage(""),
+          content: [{ type: "thinking", thinking: "This isn't permitted." }],
+        },
+      })],
+      message_update: [(event) => {
+        const update = event.assistantMessageEvent as {
+          delta: string
+          partial: ReturnType<typeof assistantMessage>
+        }
+        update.delta = "This isn't permitted."
+        update.partial = {
+          ...assistantMessage(""),
+          content: [{ type: "thinking", thinking: "This isn't permitted." }],
+        } as never
+      }],
       tool_result: [() => ({ content: [{ type: "text", text: "This isn't permitted." }] })],
     })
+    const streamedThinking = {
+      type: "message_update",
+      message: {
+        ...assistantMessage(""),
+        content: [{ type: "thinking", thinking: "Open the valve." }],
+      },
+      assistantMessageEvent: {
+        type: "thinking_delta",
+        contentIndex: 0,
+        delta: "Open the valve.",
+        partial: {
+          ...assistantMessage(""),
+          content: [{ type: "thinking", thinking: "Open the valve." }],
+        },
+      },
+    }
+    await runner.emit(streamedThinking as never)
+
     const assistant = assistantMessage("Open the valve.")
     const finalized = await runner.emitMessageEnd({ type: "message_end", message: assistant } as never)
     const result = await runner.emitToolResult({
@@ -714,6 +795,9 @@ describe.sequential("pi extension wiring", () => {
       isError: false,
     })
 
+    expect(streamedThinking.message.content).toEqual([])
+    expect(streamedThinking.assistantMessageEvent.delta).toBe("")
+    expect(streamedThinking.assistantMessageEvent.partial.content).toEqual([])
     expect(finalized?.content).toEqual([])
     expect(result).toMatchObject({
       content: [{ type: "text", text: "Open the valve." }],

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -59,6 +59,11 @@ type ToolHandler = {
   ): unknown
 }
 
+type CommandHandler = {
+  readonly description: string
+  handler(args: string, context: ExtensionContextStub): unknown
+}
+
 interface CommitCommandFixture {
   readonly name: string
   readonly command: string
@@ -84,6 +89,8 @@ interface ExtensionContextStub {
 }
 
 class ExtensionApiStub {
+  readonly activeTools = new Set<string>()
+  readonly commands = new Map<string, CommandHandler>()
   readonly handlers = new Map<string, EventHandler[]>()
   readonly tools = new Map<string, ToolHandler>()
 
@@ -95,6 +102,26 @@ class ExtensionApiStub {
 
   registerTool(tool: ToolHandler): void {
     this.tools.set(tool.name, tool)
+    this.activeTools.add(tool.name)
+  }
+
+  getActiveTools(): string[] {
+    return [...this.activeTools]
+  }
+
+  setActiveTools(names: readonly string[]): void {
+    this.activeTools.clear()
+    for (const name of names) this.activeTools.add(name)
+  }
+
+  registerCommand(name: string, command: CommandHandler): void {
+    this.commands.set(name, command)
+  }
+
+  async runCommand(name: string, args: string, context: ExtensionContextStub) {
+    const command = this.commands.get(name)
+    if (command === undefined) throw new Error(`No command registered for ${name}`)
+    return command.handler(args, context)
   }
 
   async emit(event: string, payload: Record<string, unknown>, context: ExtensionContextStub) {
@@ -151,6 +178,7 @@ class ExtensionApiStub {
     }
     const tool = this.tools.get(toolName)
     if (tool === undefined) throw new Error(`No tool registered for ${toolName}`)
+    if (!this.activeTools.has(toolName)) throw new Error(`Tool is not active: ${toolName}`)
     return tool.execute(toolCallId, input as never, signal, undefined, context)
   }
 }
@@ -263,6 +291,7 @@ describe.sequential("pi extension wiring", () => {
     expect(manifest.pi.extensions).toEqual(["./src/extension/index.ts"])
     expect(manifest.dependencies).toMatchObject({
       effect: expect.any(String),
+      typebox: expect.any(String),
       "wink-eng-lite-web-model": expect.any(String),
       "wink-nlp": expect.any(String),
     })
@@ -403,6 +432,171 @@ describe.sequential("pi extension wiring", () => {
 
     expect(error?.message).toContain("line 3, column 6")
     expect(error?.message).toContain("[contraction]")
+  })
+
+  test("toggles write, commit, and reply enforcement for the session", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-enabled",
+        { path: "notes.md", content: "This isn't permitted." },
+        context,
+      ),
+    ).rejects.toThrow("[contraction]")
+    await expect(
+      pi.emit(
+        "tool_call",
+        {
+          toolName: "bash",
+          toolCallId: "commit-enabled",
+          input: { command: `git commit -m "fix: This isn't permitted."` },
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({ block: true })
+
+    await pi.runCommand("ste", "", context)
+
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-disabled",
+        { path: "notes.md", content: "This isn't permitted." },
+        context,
+      ),
+    ).resolves.toBeDefined()
+    await expect(
+      pi.emit(
+        "tool_call",
+        {
+          toolName: "bash",
+          toolCallId: "commit-disabled",
+          input: { command: `git commit -m "fix: This isn't permitted."` },
+        },
+        context,
+      ),
+    ).resolves.toBeUndefined()
+    await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
+    expect(widgets.get("simple-english-reply")).toBeUndefined()
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
+    await expect(
+      pi.emit("before_agent_start", { systemPrompt: "Base system prompt." }, context),
+    ).resolves.toBeUndefined()
+
+    await pi.runCommand("ste", "", context)
+
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-reenabled",
+        { path: "notes.md", content: "This isn't permitted." },
+        context,
+      ),
+    ).rejects.toThrow("[contraction]")
+    await expect(
+      pi.emit(
+        "tool_call",
+        {
+          toolName: "bash",
+          toolCallId: "commit-reenabled",
+          input: { command: `git commit -m "fix: This isn't permitted."` },
+        },
+        context,
+      ),
+    ).resolves.toMatchObject({ block: true })
+    await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
+  })
+
+  test("reports the mode, rule severity counts, and dictionary state", async () => {
+    const { pi, context, notifications } = await startExtension({
+      projectConfig: { rules: { contraction: "off", semicolon: "soft" } },
+    })
+
+    await pi.runCommand("ste", "status", context)
+
+    expect(notifications.at(-1)).toEqual({
+      level: "info",
+      message: expect.stringContaining("Mode: enabled"),
+    })
+    expect(notifications.at(-1)?.message).toContain("Rules: 6 hard, 4 soft, 1 off")
+    expect(notifications.at(-1)?.message).toContain("Dictionary: loaded")
+  })
+
+  test("gates strict replies through say until a clean rewrite passes", async () => {
+    const { pi, context } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+
+    await pi.runCommand("ste", "strict", context)
+    expect(pi.activeTools.has("say")).toBe(true)
+    const prompt = await pi.emit(
+      "before_agent_start",
+      { systemPrompt: "Base system prompt." },
+      context,
+    )
+    expect(prompt).toMatchObject({
+      systemPrompt: expect.stringContaining("Send every user-facing reply through the `say` tool"),
+    })
+
+    await expect(
+      pi.executeTool("say", "say-blocked", { text: "This isn't permitted." }, context),
+    ).rejects.toThrow("line 1, column 6 [contraction]")
+
+    await expect(
+      pi.executeTool("say", "say-clean", { text: "Open the valve." }, context),
+    ).resolves.toMatchObject({
+      content: [{ type: "text", text: "Open the valve." }],
+      terminate: true,
+    })
+  })
+
+  test("gates strict say input after later tool-call handlers mutate it", async () => {
+    const { pi, context } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    await pi.runCommand("ste", "strict", context)
+    pi.on("tool_call", (event) => {
+      if (event.toolName === "say") {
+        const input = event.input as { text: string }
+        input.text = "This isn't permitted."
+      }
+    })
+
+    await expect(
+      pi.executeTool("say", "say-mutated", { text: "Open the valve." }, context),
+    ).rejects.toThrow("line 1, column 6 [contraction]")
+  })
+
+  test("turns strict mode off and restores normal assistant replies", async () => {
+    const { pi, context, widgets } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    await pi.runCommand("ste", "strict", context)
+    await pi.runCommand("ste", "strict off", context)
+    expect(pi.activeTools.has("say")).toBe(false)
+
+    const prompt = await pi.emit(
+      "before_agent_start",
+      { systemPrompt: "Base system prompt." },
+      context,
+    )
+    expect(prompt).toMatchObject({
+      systemPrompt: expect.stringContaining("Simplified Technical English"),
+    })
+    expect(prompt).toMatchObject({
+      systemPrompt: expect.not.stringContaining(
+        "Send every user-facing reply through the `say` tool",
+      ),
+    })
+
+    const reply = assistantMessage("This isn't permitted.")
+    await expect(pi.finalizeAssistant(reply, context)).resolves.toBe(reply)
+    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
   })
 
   test("blocks a hard write with location, rule, and fix feedback, then permits a clean write", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1,5 +1,9 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
+import {
+  ExtensionRunner,
+  createExtensionRuntime,
+} from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import simpleEnglishExtension from "../../src/extension/index.ts"
 
@@ -199,7 +203,7 @@ afterEach(async () => {
 
 async function startExtension(options?: {
   readonly branch?: readonly Record<string, unknown>[]
-  readonly globalConfig?: object
+  readonly globalConfig?: object | string
   readonly projectConfig?: object
   readonly sessionStartReason?: "startup" | "resume"
   readonly trusted?: boolean
@@ -212,7 +216,9 @@ async function startExtension(options?: {
   if (options?.globalConfig !== undefined) {
     await writeFile(
       join(globalDirectory, "simple-english.json"),
-      JSON.stringify(options.globalConfig),
+      typeof options.globalConfig === "string"
+        ? options.globalConfig
+        : JSON.stringify(options.globalConfig),
     )
   }
   if (options?.projectConfig !== undefined) {
@@ -260,6 +266,31 @@ function assistantMessage(text: string) {
     content: [{ type: "text", text }],
     timestamp: Date.now(),
   }
+}
+
+function boundaryRunner(
+  sessionManager: ExtensionContextStub["sessionManager"],
+  handlers: Readonly<Record<string, readonly EventHandler[]>>,
+): ExtensionRunner {
+  const extension = {
+    path: "later-extension",
+    resolvedPath: "later-extension",
+    sourceInfo: {},
+    handlers: new Map(Object.entries(handlers)),
+    tools: new Map(),
+    messageRenderers: new Map(),
+    entryRenderers: new Map(),
+    commands: new Map(),
+    flags: new Map(),
+    shortcuts: new Map(),
+  }
+  return new ExtensionRunner(
+    [extension] as never,
+    createExtensionRuntime(),
+    process.cwd(),
+    sessionManager as never,
+    {} as never,
+  )
 }
 
 function assistantEntry(text: string, id = "assistant-reply") {
@@ -527,6 +558,16 @@ describe.sequential("pi extension wiring", () => {
     expect(notifications.at(-1)?.message).toContain("Dictionary: loaded")
   })
 
+  test("reports the dictionary as not loaded when config loading fails", async () => {
+    const { pi, context, notifications } = await startExtension({ globalConfig: "{" })
+
+    await pi.runCommand("ste", "status", context)
+
+    expect(notifications.at(-1)?.message).toContain("Mode: enabled")
+    expect(notifications.at(-1)?.message).toContain("Dictionary: not loaded")
+    expect(notifications.at(-1)?.message).not.toContain("Dictionary: failed")
+  })
+
   test("gates strict replies through say until a clean rewrite passes", async () => {
     const { pi, context } = await startExtension({
       projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
@@ -585,6 +626,80 @@ describe.sequential("pi extension wiring", () => {
       context,
     )
     expect(finalized.content).toEqual([])
+  })
+
+  test("redacts strict say arguments until the gated result succeeds", async () => {
+    const { pi, context } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    await pi.runCommand("ste", "strict", context)
+
+    const message = {
+      ...assistantMessage(""),
+      content: [
+        {
+          type: "toolCall",
+          id: "say-redacted",
+          name: "say",
+          arguments: { text: "Open the valve." },
+        },
+      ],
+    }
+    const update = {
+      message,
+      assistantMessageEvent: {
+        type: "toolcall_delta",
+        contentIndex: 0,
+        delta: '"text":"Open the valve."',
+        partial: message,
+      },
+    }
+
+    await pi.emit("message_update", update, context)
+
+    expect(update.assistantMessageEvent.delta).toBe("")
+    expect(message.content[0]?.arguments).toEqual({
+      text: "[redacted until STE approval]",
+    })
+    await expect(
+      pi.executeTool(
+        "say",
+        "say-redacted",
+        { text: "[redacted until STE approval]" },
+        context,
+      ),
+    ).resolves.toMatchObject({ content: [{ type: "text", text: "Open the valve." }] })
+  })
+
+  test("enforces strict output after later extension middleware", async () => {
+    const { pi, context } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    await pi.runCommand("ste", "strict", context)
+    await pi.executeTool("say", "say-approved", { text: "Open the valve." }, context)
+
+    const runner = boundaryRunner(context.sessionManager, {
+      message_end: [() => ({ message: assistantMessage("This isn't permitted.") })],
+      tool_result: [() => ({ content: [{ type: "text", text: "This isn't permitted." }] })],
+    })
+    const assistant = assistantMessage("Open the valve.")
+    const finalized = await runner.emitMessageEnd({ type: "message_end", message: assistant } as never)
+    const result = await runner.emitToolResult({
+      type: "tool_result",
+      toolName: "say",
+      toolCallId: "say-approved",
+      input: { text: "Open the valve." },
+      content: [{ type: "text", text: "Open the valve." }],
+      details: {},
+      isError: false,
+    })
+
+    expect(finalized?.content).toEqual([])
+    expect(result).toMatchObject({
+      content: [{ type: "text", text: "Open the valve." }],
+      details: {},
+      isError: false,
+    })
   })
 
   test("gates strict say input after later tool-call handlers mutate it", async () => {
@@ -946,6 +1061,25 @@ describe.sequential("pi extension wiring", () => {
         }),
       ]),
     })
+  })
+
+  test("keeps reply checking cleared during disabled tree navigation", async () => {
+    const { pi, context, setBranch, widgets } = await startExtension({
+      branch: [assistantEntry("Open the valve.")],
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    await pi.runCommand("ste", "off", context)
+    setBranch([assistantEntry("This isn't permitted.", "blocked-reply")])
+
+    await pi.emit(
+      "session_tree",
+      { newLeafId: "blocked-reply", oldLeafId: "assistant-reply" },
+      context,
+    )
+    await pi.runCommand("ste", "on", context)
+
+    expect(widgets.get("simple-english-reply")).toBeUndefined()
+    await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
   test("recomputes reply state after session tree navigation", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -555,6 +555,38 @@ describe.sequential("pi extension wiring", () => {
     })
   })
 
+  test("suppresses ordinary assistant text throughout strict reply streaming", async () => {
+    const { pi, context } = await startExtension({
+      projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
+    })
+    await pi.runCommand("ste", "strict", context)
+
+    const started = assistantMessage("This isn't permitted.")
+    await pi.emit("message_start", { message: started }, context)
+    expect(started.content).toEqual([])
+
+    const partial = assistantMessage("This isn't permitted.")
+    const update = {
+      message: partial,
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "This isn't permitted.",
+        partial: assistantMessage("This isn't permitted."),
+      },
+    }
+    await pi.emit("message_update", update, context)
+    expect(partial.content).toEqual([])
+    expect(update.assistantMessageEvent.delta).toBe("")
+    expect(update.assistantMessageEvent.partial.content).toEqual([])
+
+    const finalized = await pi.finalizeAssistant(
+      assistantMessage("This isn't permitted."),
+      context,
+    )
+    expect(finalized.content).toEqual([])
+  })
+
   test("gates strict say input after later tool-call handlers mutate it", async () => {
     const { pi, context } = await startExtension({
       projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
@@ -593,6 +625,20 @@ describe.sequential("pi extension wiring", () => {
         "Send every user-facing reply through the `say` tool",
       ),
     })
+
+    const streamed = assistantMessage("This isn't permitted.")
+    const update = {
+      message: streamed,
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "This isn't permitted.",
+        partial: assistantMessage("This isn't permitted."),
+      },
+    }
+    await pi.emit("message_update", update, context)
+    expect(streamed.content).toEqual([{ type: "text", text: "This isn't permitted." }])
+    expect(update.assistantMessageEvent.delta).toBe("This isn't permitted.")
 
     const reply = assistantMessage("This isn't permitted.")
     await expect(pi.finalizeAssistant(reply, context)).resolves.toBe(reply)

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -340,13 +340,15 @@ describe.sequential("pi extension wiring", () => {
     expect(manifest.pi.extensions).toEqual(["./src/extension/index.ts"])
     expect(manifest.dependencies).toMatchObject({
       effect: expect.any(String),
-      typebox: expect.any(String),
       "wink-eng-lite-web-model": expect.any(String),
       "wink-nlp": expect.any(String),
     })
+    expect(manifest.dependencies).not.toHaveProperty("typebox")
     expect(manifest.peerDependencies).toMatchObject({
       "@earendil-works/pi-coding-agent": "*",
+      typebox: "*",
     })
+    expect(manifest.devDependencies).toMatchObject({ typebox: "1.3.7" })
   })
 
   test("injects an STE rule summary that reflects merged active settings", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1,9 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import {
-  ExtensionRunner,
-  createExtensionRuntime,
-} from "@earendil-works/pi-coding-agent"
+import { ExtensionRunner, createExtensionRuntime } from "@earendil-works/pi-coding-agent"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import simpleEnglishExtension from "../../src/extension/index.ts"
 
@@ -189,6 +186,7 @@ class ExtensionApiStub {
 
 const temporaryDirectories: string[] = []
 const originalAgentDirectory = process.env.PI_CODING_AGENT_DIR
+const originalDictionary = process.env.SIMPLE_ENGLISH_DICTIONARY
 const originalHome = process.env.HOME
 
 afterEach(async () => {
@@ -196,6 +194,11 @@ afterEach(async () => {
   bashControl.executedCommands.length = 0
   if (originalAgentDirectory === undefined) process.env.PI_CODING_AGENT_DIR = undefined
   else process.env.PI_CODING_AGENT_DIR = originalAgentDirectory
+  if (originalDictionary === undefined) {
+    Reflect.deleteProperty(process.env, "SIMPLE_ENGLISH_DICTIONARY")
+  } else {
+    process.env.SIMPLE_ENGLISH_DICTIONARY = originalDictionary
+  }
   if (originalHome === undefined) process.env.HOME = undefined
   else process.env.HOME = originalHome
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })))
@@ -485,8 +488,8 @@ describe.sequential("pi extension wiring", () => {
     expect(error?.message).toContain("[contraction]")
   })
 
-  test("toggles write, commit, and reply enforcement for the session", async () => {
-    const { pi, context, widgets } = await startExtension({
+  test("toggles write, edit, commit, and reply enforcement for the session", async () => {
+    const { cwd, pi, context, widgets } = await startExtension({
       projectConfig: { rules: { "dictionary-not-approved-word": "off" } },
     })
 
@@ -498,17 +501,16 @@ describe.sequential("pi extension wiring", () => {
         context,
       ),
     ).rejects.toThrow("[contraction]")
-    await expect(
-      pi.emit(
-        "tool_call",
-        {
-          toolName: "bash",
-          toolCallId: "commit-enabled",
-          input: { command: `git commit -m "fix: This isn't permitted."` },
-        },
-        context,
-      ),
-    ).resolves.toMatchObject({ block: true })
+    expect(
+      (
+        await executeBash(
+          pi,
+          context,
+          "commit-enabled",
+          `git commit -m "fix: This isn't permitted."`,
+        )
+      )?.message,
+    ).toContain("[contraction]")
 
     await pi.runCommand("ste", "", context)
 
@@ -521,14 +523,23 @@ describe.sequential("pi extension wiring", () => {
       ),
     ).resolves.toBeDefined()
     await expect(
-      pi.emit(
-        "tool_call",
+      pi.executeTool(
+        "edit",
+        "edit-disabled",
         {
-          toolName: "bash",
-          toolCallId: "commit-disabled",
-          input: { command: `git commit -m "fix: This isn't permitted."` },
+          path: "notes.md",
+          edits: [{ oldText: "This isn't permitted.", newText: "This can't be permitted." }],
         },
         context,
+      ),
+    ).resolves.toBeDefined()
+    expect(await readFile(join(cwd, "notes.md"), "utf8")).toBe("This can't be permitted.")
+    await expect(
+      executeBash(
+        pi,
+        context,
+        "commit-disabled",
+        `git commit -m "fix: This isn't permitted."`,
       ),
     ).resolves.toBeUndefined()
     await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
@@ -549,16 +560,27 @@ describe.sequential("pi extension wiring", () => {
       ),
     ).rejects.toThrow("[contraction]")
     await expect(
-      pi.emit(
-        "tool_call",
+      pi.executeTool(
+        "edit",
+        "edit-reenabled",
         {
-          toolName: "bash",
-          toolCallId: "commit-reenabled",
-          input: { command: `git commit -m "fix: This isn't permitted."` },
+          path: "notes.md",
+          edits: [{ oldText: "This can't be permitted.", newText: "This won't be permitted." }],
         },
         context,
       ),
-    ).resolves.toMatchObject({ block: true })
+    ).rejects.toThrow("[contraction]")
+    expect(await readFile(join(cwd, "notes.md"), "utf8")).toBe("This can't be permitted.")
+    expect(
+      (
+        await executeBash(
+          pi,
+          context,
+          "commit-reenabled",
+          `git commit -m "fix: This isn't permitted."`,
+        )
+      )?.message,
+    ).toContain("[contraction]")
     await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
     expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
   })
@@ -576,6 +598,14 @@ describe.sequential("pi extension wiring", () => {
     })
     expect(notifications.at(-1)?.message).toContain("Rules: 6 hard, 4 soft, 1 off")
     expect(notifications.at(-1)?.message).toContain("Dictionary: loaded")
+
+    await pi.runCommand("ste", "off", context)
+    await pi.runCommand("ste", "status", context)
+    expect(notifications.at(-1)?.message).toContain("Mode: disabled")
+
+    await pi.runCommand("ste", "strict", context)
+    await pi.runCommand("ste", "status", context)
+    expect(notifications.at(-1)?.message).toContain("Mode: strict")
   })
 
   test("reports the dictionary as not loaded when config loading fails", async () => {
@@ -586,6 +616,17 @@ describe.sequential("pi extension wiring", () => {
     expect(notifications.at(-1)?.message).toContain("Mode: enabled")
     expect(notifications.at(-1)?.message).toContain("Dictionary: not loaded")
     expect(notifications.at(-1)?.message).not.toContain("Dictionary: failed")
+  })
+
+  test("reports a failed dictionary load", async () => {
+    process.env.SIMPLE_ENGLISH_DICTIONARY = join(process.cwd(), "missing-dictionary.json")
+    const { pi, context, notifications } = await startExtension()
+
+    await pi.runCommand("ste", "status", context)
+
+    expect(notifications.at(-1)?.message).toContain("Mode: enabled")
+    expect(notifications.at(-1)?.message).toContain("Dictionary: failed (")
+    expect(notifications.at(-1)?.message).toContain("missing-dictionary.json")
   })
 
   test("gates strict replies through say until a clean rewrite passes", async () => {
@@ -688,10 +729,7 @@ describe.sequential("pi extension wiring", () => {
     expect(thinkingEnd.assistantMessageEvent.content).toBe("")
     expect(thinkingEnd.assistantMessageEvent.partial.content).toEqual([])
 
-    const finalized = await pi.finalizeAssistant(
-      assistantMessage("This isn't permitted."),
-      context,
-    )
+    const finalized = await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
     expect(finalized.content).toEqual([])
   })
 
@@ -729,12 +767,7 @@ describe.sequential("pi extension wiring", () => {
       text: "[redacted until STE approval]",
     })
     await expect(
-      pi.executeTool(
-        "say",
-        "say-redacted",
-        { text: "[redacted until STE approval]" },
-        context,
-      ),
+      pi.executeTool("say", "say-redacted", { text: "[redacted until STE approval]" }, context),
     ).resolves.toMatchObject({ content: [{ type: "text", text: "Open the valve." }] })
   })
 
@@ -746,23 +779,27 @@ describe.sequential("pi extension wiring", () => {
     await pi.executeTool("say", "say-approved", { text: "Open the valve." }, context)
 
     const runner = boundaryRunner(context.sessionManager, {
-      message_end: [() => ({
-        message: {
-          ...assistantMessage(""),
-          content: [{ type: "thinking", thinking: "This isn't permitted." }],
+      message_end: [
+        () => ({
+          message: {
+            ...assistantMessage(""),
+            content: [{ type: "thinking", thinking: "This isn't permitted." }],
+          },
+        }),
+      ],
+      message_update: [
+        (event) => {
+          const update = event.assistantMessageEvent as {
+            delta: string
+            partial: ReturnType<typeof assistantMessage>
+          }
+          update.delta = "This isn't permitted."
+          update.partial = {
+            ...assistantMessage(""),
+            content: [{ type: "thinking", thinking: "This isn't permitted." }],
+          } as never
         },
-      })],
-      message_update: [(event) => {
-        const update = event.assistantMessageEvent as {
-          delta: string
-          partial: ReturnType<typeof assistantMessage>
-        }
-        update.delta = "This isn't permitted."
-        update.partial = {
-          ...assistantMessage(""),
-          content: [{ type: "thinking", thinking: "This isn't permitted." }],
-        } as never
-      }],
+      ],
       tool_result: [() => ({ content: [{ type: "text", text: "This isn't permitted." }] })],
     })
     const streamedThinking = {
@@ -784,7 +821,10 @@ describe.sequential("pi extension wiring", () => {
     await runner.emit(streamedThinking as never)
 
     const assistant = assistantMessage("Open the valve.")
-    const finalized = await runner.emitMessageEnd({ type: "message_end", message: assistant } as never)
+    const finalized = await runner.emitMessageEnd({
+      type: "message_end",
+      message: assistant,
+    } as never)
     const result = await runner.emitToolResult({
       type: "tool_result",
       toolName: "say",
@@ -798,7 +838,7 @@ describe.sequential("pi extension wiring", () => {
     expect(streamedThinking.message.content).toEqual([])
     expect(streamedThinking.assistantMessageEvent.delta).toBe("")
     expect(streamedThinking.assistantMessageEvent.partial.content).toEqual([])
-    expect(finalized?.content).toEqual([])
+    expect(finalized).toMatchObject({ content: [] })
     expect(result).toMatchObject({
       content: [{ type: "text", text: "Open the valve." }],
       details: {},


### PR DESCRIPTION
## Intent

Implement HUF-141 so users can control Simplified Technical English enforcement inside a pi session. The /ste command must toggle all write, edit, git commit, and finalized-reply checks as an immediate escape hatch; /ste status must report enabled, disabled, or strict mode plus configured rule counts by hard, soft, and off severity and the dictionary load state; and /ste strict must route user-facing replies through a dynamically active say tool. Strict say calls with hard violations must be rejected before display with the existing structured line, column, rule ID, and suggested-fix feedback, while a clean rewrite passes. Turning strict mode off must deactivate say and restore ordinary streaming assistant replies. Compose with HUF-138 write/edit gating, the pending HUF-139 commit gate, HUF-140 finalized reply checking, and trust-gated config. Keep the synchronous engine unchanged, use stubbed ExtensionAPI tests rather than running pi in automated tests, keep runtime dependencies in dependencies, and avoid full Markdown or language parsers. A throwaway live pi RPC session already demonstrated toggling, status, a rejected strict reply followed by a clean say call, and normal streaming after strict off.

## What Changed

- Add `/ste` controls for toggling enforcement, reporting status, and routing strict replies through the gated `say` tool.
- Lint static `git commit` messages, exempt Conventional Commit prefixes and trailers, and fail closed for messages that cannot be safely extracted.
- Expand stubbed extension tests and documentation for session state, strict output handling, commit gating, and dependency requirements.

## Risk Assessment

🚨 High: Strict mode can suppress the complete response and lose the required say call for reasoning-model streams.

## Testing

Targeted stubbed ExtensionAPI tests and an end-user-like session transcript verified enabled, disabled, and strict modes; write, edit, commit, and finalized-reply toggling; structured strict rejection; clean say output; and restored streaming. No screenshot was captured because the acceptance criteria explicitly prohibit running pi in automated tests.

<details>
<summary>Evidence: HUF-141 session behavior transcript</summary>

```text
SESSION START
Mode: enabled
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded

ENABLED GATES
write: BLOCKED
STE blocked write for write.md:
- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
edit: BLOCKED
STE blocked edit for edit.md:
- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
commit: BLOCKED
STE blocked commit for commit message:
- line 1, column 11 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
finalized reply widget: STE reply: 1 hard, 0 soft

/ste OFF ESCAPE HATCH
STE enforcement disabled.
Mode: disabled
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded
write: ALLOWED (This isn't permitted.)
edit: ALLOWED (This isn't permitted.)
commit: ALLOWED
finalized reply widget: not shown

/ste STRICT
STE strict mode enabled. Send every reply through the say tool.
Mode: strict
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded
say tool active: true
say rejected before display:
STE blocked reply:
- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found "isn't". Suggested fix: Write the contracted words in full.
clean say displayed: Open the valve.
ordinary strict stream delta: ""

/ste STRICT OFF
STE strict mode disabled.
say tool active: false
ordinary stream delta: "Ordinary reply restored."
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- 🚨 `src/extension/index.ts:485` - The intent requires strict mode to route user-facing replies through `say`, but the implementation only adds prompt instructions. A model can still emit ordinary text, which Pi streams immediately; line 492 then lints it only after display. Confirm whether cooperative prompt-based containment is acceptable, or add an enforceable boundary that suppresses ordinary replies while strict mode is active.
- 🚨 `src/extension/index.ts:520` - Commit commands are checked only by this `tool_call` handler. A later extension handler can mutate a permitted command such as `echo ok` into `git commit -m &#34;fix: This isn&#39;t permitted.&#34;`; Pi executes the mutation without revalidation. Write and say already recheck inside execution. Wrap the bash execution or its final spawn boundary and lint the final command there.
- 🚨 `src/extension/commit-message.ts:136` - ANSI C quoting decodes only one-character escapes. For example, with the dictionary rule off, `git commit -m $&#39;fix: This isn\x27t permitted.&#39;` executes with `isn&#39;t`, but the gate lints `isnx27t` and misses the hard contraction. Fully decode Bash hexadecimal, octal, and Unicode escapes, or fail closed when an unsupported escape is present.

🔧 Fix: Suppress ordinary replies during STE strict mode
5 errors still open:
- 🚨 `src/extension/index.ts:522` - The criterion requires strict mode to route user-facing replies through `say`, but this suppression is not terminal. A later `message_end` handler can restore ordinary assistant text, and a later `tool_result` handler can replace a clean `say` result after its final lint. Pi then displays and persists the replacement. Enforce the invariant after all extension middleware at the final outward-output boundary, or confirm that later-extension mutations are outside the guarantee.
- 🚨 `src/extension/index.ts:166` - The criterion says hard strict replies must be rejected before display, but `contentWithoutText` preserves `toolCall` blocks and `suppressAssistantTextUpdate` preserves `toolcall_delta` data. RPC listeners therefore receive the full `say.text` argument before `tool_call` linting can reject it. Redact strict `say` arguments from outward message events until the gated execution succeeds, or confirm that raw tool metadata is intentionally outside the display guarantee.
- 🚨 `src/extension/index.ts:503` - The criterion requires `/ste` to toggle all finalized-reply checks, but `session_tree` restores and lints reply state whenever `ready` is true, even while enforcement is disabled. Navigating a tree after `/ste off` can recreate the widget and queue hard feedback that is injected after enforcement is re-enabled. Guard restoration with `state.enabled` and clear any disabled-mode reply state.
- 🚨 `src/extension/index.ts:108` - The criterion requires `/ste status` to report dictionary load state. If `loadConfig` fails, dictionary loading is never attempted, but this branch reports `Dictionary: failed (&lt;config error&gt;)`. Track dictionary state and dictionary errors separately so config failures report the dictionary as not loaded.
- 🚨 `src/extension/commit-message.ts:292` - Any indented line immediately above a final trailer is included in the exempt trailer range. For example, `fix: Close the valve.\n\n This isn&#39;t permitted.\nSigned-off-by: A &lt;a@example.com&gt;` blanks both the real trailer and the violating body line, allowing a hard contraction through the commit gate. Only accept an indented continuation after establishing the trailer entry it continues.

🔧 Fix: Enforce strict output boundaries and accurate session state
3 errors still open:
- 🚨 `src/extension/index.ts:386` - The required HUF-140 composition breaks after a strict reply. Strict assistant messages contain no text, while the approved reply is stored in the following `say` tool result. This loop ignores that result and can restore an older violating assistant reply, showing stale counts and queuing false hard feedback after tree navigation or resume. Restore the latest successful `say` result before considering older assistant text.
- 🚨 `src/extension/commit-message.ts:147` - Unquoted pathname expansion is treated as static. With the dictionary rule off and a file named `isn&#39;t`, `git commit -m i*` is linted as literal `i*`, but Bash commits the expanded hard contraction. Mark unquoted glob syntax such as `*`, `?`, and bracket expressions as dynamic and fail closed.
- 🚨 `src/extension/commit-message.ts:176` - Static commits inside shell compound commands are not detected. For example, `if true; then git commit -m &#34;fix: This isn&#39;t permitted.&#34;; fi` creates a segment beginning with `then`, so `gitCommandIndex` returns undefined and the command executes unchecked. Recognize command-position reserved prefixes such as `then`, `do`, `!`, and `{`, or fail closed for these segments.

🔧 Fix: Restore strict say replies from session history
1 warning still open:
- ⚠️ `package.json:22` - Pi bundles `typebox` and requires extensions to declare it as a `peerDependency` with range `*`, not install a separate runtime copy. Move it to `peerDependencies` and add a pinned `devDependency` if needed for local development.

🔧 Fix: Declare TypeBox as a Pi peer dependency
1 error still open:
- 🚨 `src/extension/index.ts:213` - The requirement says strict mode must route user-facing replies through `say`, but `contentWithoutText` removes only text blocks and line 230 suppresses only text/tool-call deltas. A model can emit violating prose in a thinking block, which Pi displays and RPC streams without linting. Suppress thinking blocks and thinking deltas at the same final outward boundary while strict mode is active.

🔧 Fix: Suppress thinking output in strict mode
1 error still open:
- 🚨 `src/extension/index.ts:229` - The criterion requires strict mode to &#34;route user-facing replies through a dynamically active say tool,&#34; but this call mutates the provider-owned `assistantMessageEvent.partial`. Providers retain the original `output.content` array; after a `thinking_start` reassigns `partial.content` to a filtered array, a later `say` call can be appended only to the retained array and disappear from the final message. A reasoning model that thinks before calling `say` can therefore finish without executing `say`. Redact a cloned outward partial at the terminal boundary while preserving the provider&#39;s live message.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/extension/extension.test.ts -t 'toggles write, edit, commit, and reply enforcement for the session'`
- `bunx vitest run test/extension/extension.test.ts -t 'reports the mode, rule severity counts, and dictionary state|reports the dictionary as not loaded when config loading fails|reports a failed dictionary load'`
- <code>Targeted `bunx vitest run test/extension/extension.test.ts -t ...` covering package dependencies, commit gating, session toggling, status, strict say behavior, output suppression, middleware boundaries, strict-off streaming, and trust-gated config. An initial test cleanup environment leak was fixed, then the same selection passed.</code>
- `bun /tmp/no-mistakes-evidence/01KYWGDAKYF4KAAN0VM1GNQ7PB/session-evidence.ts > /tmp/no-mistakes-evidence/01KYWGDAKYF4KAAN0VM1GNQ7PB/session-transcript.txt`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
