### PR TITLE
feat(extension): add /ste argument autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ pi -e .
 
 The mode applies to the current pi session.
 The extension starts in enabled mode without strict reply gating.
-Type `/ste ` to see its subcommands as autocomplete suggestions, which narrow as you type.
+Type `/ste ` to see autocomplete suggestions for `on`, `off`, `status`, and `strict`.
+The list changes to match the text that you type.
 
 | Command | Result |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pi -e .
 
 The mode applies to the current pi session.
 The extension starts in enabled mode without strict reply gating.
+Type `/ste ` to see its subcommands as autocomplete suggestions, which narrow as you type.
 
 | Command | Result |
 | --- | --- |

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -12,6 +12,7 @@ import {
   createEditToolDefinition,
   createWriteToolDefinition,
 } from "@earendil-works/pi-coding-agent"
+import type { AutocompleteItem } from "@earendil-works/pi-tui"
 import { Effect } from "effect"
 import { Type } from "typebox"
 import { loadConfig } from "../config/load.ts"
@@ -25,6 +26,13 @@ import type { Tagger } from "../engine/tagger.ts"
 import type { LintReport, RuleSetting, Violation } from "../engine/types.ts"
 import { makeWinkTagger } from "../tagger/wink.ts"
 import { blankCommitMetadata, findCommitInvocations } from "./commit-message.ts"
+
+const STE_COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
+  { value: "on", label: "on", description: "Enable STE enforcement" },
+  { value: "off", label: "off", description: "Disable STE enforcement" },
+  { value: "status", label: "status", description: "Show STE status" },
+  { value: "strict", label: "strict", description: "Enable strict reply gating" },
+]
 
 const DEFAULT_RULE_SETTINGS: Readonly<Record<RuleId, RuleSetting>> = {
   contraction: "hard",
@@ -620,6 +628,10 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
 
   pi.registerCommand("ste", {
     description: "Toggle STE enforcement or show status. Use strict to gate replies.",
+    getArgumentCompletions: (prefix) => {
+      const completions = STE_COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(prefix))
+      return completions.length > 0 ? completions : null
+    },
     handler: async (args, ctx) => {
       const command = args.trim().toLowerCase()
       if (command === "status") {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { ExtensionRunner, createExtensionRuntime } from "@earendil-works/pi-coding-agent"
+import type { AutocompleteItem } from "@earendil-works/pi-tui"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import simpleEnglishExtension from "../../src/extension/index.ts"
 
@@ -62,6 +63,7 @@ type ToolHandler = {
 
 type CommandHandler = {
   readonly description: string
+  getArgumentCompletions?(prefix: string): AutocompleteItem[] | null
   handler(args: string, context: ExtensionContextStub): unknown
 }
 
@@ -117,6 +119,12 @@ class ExtensionApiStub {
 
   registerCommand(name: string, command: CommandHandler): void {
     this.commands.set(name, command)
+  }
+
+  getArgumentCompletions(name: string, prefix: string): AutocompleteItem[] | null {
+    const command = this.commands.get(name)
+    if (command === undefined) throw new Error(`No command registered for ${name}`)
+    return command.getArgumentCompletions?.(prefix) ?? null
   }
 
   async runCommand(name: string, args: string, context: ExtensionContextStub) {
@@ -487,6 +495,22 @@ describe.sequential("pi extension wiring", () => {
 
     expect(error?.message).toContain("line 3, column 6")
     expect(error?.message).toContain("[contraction]")
+  })
+
+  test("suggests STE command arguments and filters them by prefix", async () => {
+    const { pi } = await startExtension()
+
+    expect(pi.getArgumentCompletions("ste", "")).toEqual([
+      { value: "on", label: "on", description: "Enable STE enforcement" },
+      { value: "off", label: "off", description: "Disable STE enforcement" },
+      { value: "status", label: "status", description: "Show STE status" },
+      { value: "strict", label: "strict", description: "Enable strict reply gating" },
+    ])
+    expect(pi.getArgumentCompletions("ste", "s")).toEqual([
+      { value: "status", label: "status", description: "Show STE status" },
+      { value: "strict", label: "strict", description: "Enable strict reply gating" },
+    ])
+    expect(pi.getArgumentCompletions("ste", "missing")).toBeNull()
   })
 
   test("toggles write, edit, commit, and reply enforcement for the session", async () => {


### PR DESCRIPTION
## Intent

Add native argument autocomplete to the existing /ste command in the pi extension. An empty prefix must show on, off, status, and strict with short descriptions. Typed prefixes must filter the list, and unmatched prefixes must return null. Pin the full list and prefix behavior with stubbed ExtensionAPI tests. Do not run pi in automated tests. Verify the list in a throwaway live pi session. Mention the behavior in the README commands section. Do not change deferred HUF-143 through HUF-146 behavior.

## What Changed
- Add native `/ste` suggestions for `on`, `off`, `status`, and `strict`, with descriptions and prefix filters.
- Return no suggestions for unmatched prefixes and add stubbed extension tests for the new behavior.
- Document `/ste` autocomplete in the README.

## Risk Assessment

✅ Low: The focused change follows the native autocomplete API and satisfies all source-verifiable acceptance criteria.

## Testing

Selected tests and a live pi session showed the full list, the `s` filter, no unmatched list, and unchanged command behavior.

- Evidence: Rendered live pi TUI autocomplete states (local file: <code>/tmp/no-mistakes-evidence/01KYWR1SV2VASYHEV6WS8TW8TW/live-pi-autocomplete.png</code>)
<details>
<summary>Evidence: Reviewable live pi TUI transcript</summary>

```text
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Live pi STE autocomplete evidence</title>
<style>
  :root { color-scheme: dark; }
  * { box-sizing: border-box; }
  body { margin: 0; padding: 36px; background: #0b0f14; color: #dce3ea; font-family: Inter, system-ui, sans-serif; }
  h1 { margin: 0 0 8px; font-size: 30px; }
  p { margin: 0 0 28px; color: #9aa7b4; }
  main { display: grid; gap: 22px; }
  section { border: 1px solid #2d3844; border-radius: 12px; overflow: hidden; background: #111820; box-shadow: 0 10px 28px #0008; }
  h2 { margin: 0; padding: 13px 18px; font-size: 17px; background: #18222d; color: #f1f5f9; }
  pre { margin: 0; padding: 18px; min-height: 190px; color: #d9e2ec; font: 16px/1.5 'Adwaita Mono', 'Nimbus Mono PS', monospace; white-space: pre; }
</style>
</head>
<body>
<h1>Live pi STE autocomplete</h1>
<p>Captured from a throwaway pi v0.83.0 TUI session with the worktree extension loaded.</p>
<main><section><h2>Empty prefix</h2><pre>/ste
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
→ on                              Enable STE enforcement
  off                             Disable STE enforcement
  status                          Show STE status
  strict                          Enable strict reply gating
~/.no-mistakes/worktrees/5b49eff34526/01KYWR1SV2VASYHEV6WS8TW8TW (detached)
0.0%/0 (auto)                                                                                          unknown</pre></section><section><h2>Prefix: s</h2><pre>/ste s
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
→ status                          Show STE status
  strict                          Enable strict reply gating
~/.no-mistakes/worktrees/5b49eff34526/01KYWR1SV2VASYHEV6WS8TW8TW (detached)
0.0%/0 (auto)                                                                                          unknown</pre></section><section><h2>Unmatched prefix</h2><pre>/ste missing
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
~/.no-mistakes/worktrees/5b49eff34526/01KYWR1SV2VASYHEV6WS8TW8TW (detached)
0.0%/0 (auto)                                                                                          unknown</pre></section></main>
</body>
</html>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/extension/extension.test.ts -t "suggests STE command arguments and filters them by prefix"`
- `bunx vitest run test/extension/extension.test.ts -t "toggles write, edit, commit, and reply enforcement for the session|reports the mode, rule severity counts, and dictionary state|gates strict replies through say until a clean rewrite passes|turns strict mode off and restores normal assistant replies"`
- <code>Started pi manually with `PI_OFFLINE=1`, `--no-session`, and `-e .`. Entered `/ste `, `/ste s`, and `/ste missing`.</code>
- `Checked the README extension commands section for the autocomplete note.`
- `Rendered the captured live pi TUI states as HTML and PNG evidence.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
