### PR TITLE
feat: add host-neutral package and config paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 ## What this project is
 
-A pi extension (TypeScript + Effect) that makes the pi coding agent comply with ASD-STE100 Simplified Technical English, plus a standalone `simple-english` CLI (`src/cli/main.ts`) exposing the same rule engine.
+A host-neutral ASD-STE100 Simplified Technical English toolkit in TypeScript and Effect.
+It supplies a pure Engine, a standalone `simple-english` CLI (`src/cli/main.ts`), and a pi Adapter.
 Behavioral reference: https://github.com/ctotheameron/pi-ste (Gleam) - this is a reimplementation, not a fork.
 Parent spec lives in Linear HUF-130.
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Inline Markdown code is outside every rule except `semicolon`.
 Configuration is an optional JSON object.
 The project file is `.simple-english.json` at the repository root.
 The global file is `$XDG_CONFIG_HOME/simple-english/config.json`.
-Without `XDG_CONFIG_HOME`, the global path is `~/.config/simple-english/config.json`.
+If `XDG_CONFIG_HOME` is unset or not absolute, the global path is `~/.config/simple-english/config.json`.
 
 Global and project files are deep-merged.
 Global values load first, and project values have precedence.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# pi-simple-english
+# simple-english
 
-`pi-simple-english` helps the [pi coding agent](https://pi.dev) use ASD-STE100 Simplified Technical English (STE).
-It also supplies a `simple-english` command that uses the same rules.
+`simple-english` checks ASD-STE100 Simplified Technical English (STE).
+It supplies one Engine, one CLI, and a pi Adapter.
+The [pi coding agent](https://pi.dev) can use the Adapter to enforce the same rules.
 
 This package reports deterministic writing problems.
 It does not rewrite text because an automatic rewrite can change its meaning.
@@ -34,13 +35,13 @@ The extension checks Markdown prose and source comments according to the [conten
 It gives the line, column, rule ID, and suggested correction for a blocked tool call.
 A config or dictionary load error makes enabled write, edit, and commit gates fail closed.
 
-## Install the pi package
+## Install the pi Adapter
 
 Install [pi](https://pi.dev) first.
 Then use the pi package mechanism:
 
 ```sh
-pi install npm:pi-simple-english
+pi install npm:simple-english
 ```
 
 Pi records the package in its user settings and loads the extension in each session.
@@ -78,7 +79,7 @@ The standalone command needs [Bun](https://bun.sh).
 Install it from the same npm package:
 
 ```sh
-bun add --global pi-simple-english
+bun add --global simple-english
 ```
 
 Lint one or more files:
@@ -156,13 +157,21 @@ Inline Markdown code is outside every rule except `semicolon`.
 ## Configuration
 
 Configuration is an optional JSON object.
-The global file is `simple-english.json` in the pi agent config directory.
-That directory is `~/.pi/agent` by default, and `PI_CODING_AGENT_DIR` can change it.
+The project file is `.simple-english.json` at the repository root.
+The global file is `$XDG_CONFIG_HOME/simple-english/config.json`.
+Without `XDG_CONFIG_HOME`, the global path is `~/.config/simple-english/config.json`.
 
-The CLI also reads `.pi/simple-english.json` from the current project.
-Project values merge over global values per key.
-The extension reads the project file only when pi trusts the project.
+Global and project files are deep-merged.
+Global values load first, and project values have precedence.
+The pi Adapter reads the project file only when pi trusts the project.
 The `--config` flag uses only its named file.
+
+Existing pi config paths remain as fallbacks.
+The project fallback is `.pi/simple-english.json`.
+The global fallback is `simple-english.json` in the pi agent config directory.
+The default pi agent config directory is `~/.pi/agent`.
+`PI_CODING_AGENT_DIR` can change that directory.
+The loader reads a fallback file only when the new file at the same level is absent.
 
 This example contains every config key and every rule:
 
@@ -258,17 +267,17 @@ Reports these forms and supplies the listed suggestion:
 
 | Forms | Suggestion |
 | --- | --- |
-| `carry out`, `carries out`, `carried out`, `carrying out` | `do` |
-| `spin up`, `spins up`, `spun up`, `spinning up` | `start` |
-| `spin down`, `spins down`, `spun down`, `spinning down` | `stop` |
-| `tear down`, `tears down`, `tore down`, `torn down`, `tearing down` | `remove` |
-| `reach out`, `reaches out`, `reached out`, `reaching out` | `ask` |
-| `dive into`, `dives into`, `dived into`, `dove into`, `diving into` | `examine` |
-| `kick off`, `kicks off`, `kicked off`, `kicking off` | `start` |
-| `roll out`, `rolls out`, `rolled out`, `rolling out` | `release` |
-| `ramp up`, `ramps up`, `ramped up`, `ramping up` | `increase` |
-| `circle back`, `circles back`, `circled back`, `circling back` | `return` |
-| `drill down`, `drills down`, `drilled down`, `drilling down` | `examine` |
+| `carry out`, `carries out`, `carried out`, `carrying out` | `do`. |
+| `spin up`, `spins up`, `spun up`, `spinning up` | `start`. |
+| `spin down`, `spins down`, `spun down`, `spinning down` | `stop`. |
+| `tear down`, `tears down`, `tore down`, `torn down`, `tearing down` | `remove`. |
+| `reach out`, `reaches out`, `reached out`, `reaching out` | `ask`. |
+| `dive into`, `dives into`, `dived into`, `dove into`, `diving into` | `examine`. |
+| `kick off`, `kicks off`, `kicked off`, `kicking off` | `start`. |
+| `roll out`, `rolls out`, `rolled out`, `rolling out` | `release`. |
+| `ramp up`, `ramps up`, `ramped up`, `ramping up` | `increase`. |
+| `circle back`, `circles back`, `circled back`, `circling back` | `return`. |
+| `drill down`, `drills down`, `drilled down`, `drilling down` | `examine`. |
 
 Matching does not depend on letter case.
 A phrase match stays on one source line.

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "pi-simple-english",
+      "name": "simple-english",
       "dependencies": {
         "effect": "^3.14.0",
         "wink-eng-lite-web-model": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "pi-simple-english",
+  "name": "simple-english",
   "version": "0.1.0",
-  "description": "ASD-STE100 Simplified Technical English lint engine and CLI for the pi coding agent",
+  "description": "ASD-STE100 Simplified Technical English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",
   "keywords": ["pi-package", "simplified-technical-english", "linter"],

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,32 +1,43 @@
 import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { join } from "node:path"
+import { isAbsolute, join } from "node:path"
 import { Effect } from "effect"
 import { mergeConfigs } from "./merge.ts"
 import { ConfigError, type SteConfig, decodeConfig } from "./schema.ts"
 
-const agentConfigDirectory = (): string => {
+const legacyAgentConfigDirectory = (): string => {
   const configured = process.env.PI_CODING_AGENT_DIR
-  if (!configured) {
-    return join(homedir(), ".pi", "agent")
-  }
-  if (configured === "~") {
-    return homedir()
-  }
+  if (!configured) return join(homedir(), ".pi", "agent")
+  if (configured === "~") return homedir()
   return configured.startsWith("~/") ||
     (process.platform === "win32" && configured.startsWith("~\\"))
     ? join(homedir(), configured.slice(2))
     : configured
 }
 
-export const globalConfigPath = (): string => join(agentConfigDirectory(), "simple-english.json")
+const xdgConfigDirectory = (): string => {
+  const configured = process.env.XDG_CONFIG_HOME
+  return configured && isAbsolute(configured) ? configured : join(homedir(), ".config")
+}
 
-export const projectConfigPath = (cwd: string): string => join(cwd, ".pi", "simple-english.json")
+export const globalConfigPath = (): string =>
+  join(xdgConfigDirectory(), "simple-english", "config.json")
+
+export const projectConfigPath = (cwd: string): string => join(cwd, ".simple-english.json")
+
+export const legacyGlobalConfigPath = (): string =>
+  join(legacyAgentConfigDirectory(), "simple-english.json")
+
+export const legacyProjectConfigPath = (cwd: string): string =>
+  join(cwd, ".pi", "simple-english.json")
 
 const isMissingFile = (cause: unknown): boolean =>
   typeof cause === "object" && cause !== null && (cause as { code?: string }).code === "ENOENT"
 
-const readConfigFile = (path: string, optional: boolean): Effect.Effect<SteConfig, ConfigError> =>
+const readConfigFile = (
+  path: string,
+  optional: boolean,
+): Effect.Effect<SteConfig | undefined, ConfigError> =>
   Effect.tryPromise({
     try: () => readFile(path, "utf8"),
     catch: (cause) => cause,
@@ -34,7 +45,7 @@ const readConfigFile = (path: string, optional: boolean): Effect.Effect<SteConfi
     Effect.matchEffect({
       onFailure: (cause) =>
         optional && isMissingFile(cause)
-          ? Effect.succeed<SteConfig>({})
+          ? Effect.succeed(undefined)
           : Effect.fail(new ConfigError(`cannot read config file ${path}: ${cause}`)),
       onSuccess: (text) =>
         Effect.try({
@@ -44,15 +55,30 @@ const readConfigFile = (path: string, optional: boolean): Effect.Effect<SteConfi
     }),
   )
 
+const readConfigWithFallback = (
+  path: string,
+  fallbackPath: string,
+): Effect.Effect<SteConfig, ConfigError> =>
+  readConfigFile(path, true).pipe(
+    Effect.flatMap((config) =>
+      config === undefined
+        ? readConfigFile(fallbackPath, true).pipe(Effect.map((fallback) => fallback ?? {}))
+        : Effect.succeed(config),
+    ),
+  )
+
 export const loadConfig = (
   explicitPath?: string,
   cwd = process.cwd(),
   includeProjectConfig = true,
 ): Effect.Effect<SteConfig, ConfigError> => {
-  if (explicitPath !== undefined) return readConfigFile(explicitPath, false)
-  const globalConfig = readConfigFile(globalConfigPath(), true)
+  if (explicitPath !== undefined) {
+    return readConfigFile(explicitPath, false).pipe(Effect.map((config) => config ?? {}))
+  }
+  const globalConfig = readConfigWithFallback(globalConfigPath(), legacyGlobalConfigPath())
   if (!includeProjectConfig) return globalConfig
-  return Effect.all([globalConfig, readConfigFile(projectConfigPath(cwd), true)]).pipe(
+  const projectConfig = readConfigWithFallback(projectConfigPath(cwd), legacyProjectConfigPath(cwd))
+  return Effect.all([globalConfig, projectConfig]).pipe(
     Effect.map(([global, project]) => mergeConfigs(global, project)),
   )
 }

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -12,19 +12,21 @@ const writeJson = async (path: string, value: unknown): Promise<void> => {
 
 const makeProject = async (config?: unknown): Promise<string> => {
   const cwd = await makeTempDir()
-  if (config !== undefined) {
-    await mkdir(join(cwd, ".pi"), { recursive: true })
-    await writeJson(join(cwd, ".pi", "simple-english.json"), config)
-  }
+  if (config !== undefined) await writeJson(join(cwd, ".simple-english.json"), config)
   return cwd
 }
 
+const writeLegacyProjectConfig = (cwd: string, config: unknown): Promise<void> =>
+  writeJson(join(cwd, ".pi", "simple-english.json"), config)
+
 const makeHome = async (config: unknown): Promise<string> => {
   const home = await makeTempDir()
-  await mkdir(join(home, ".pi", "agent"), { recursive: true })
-  await writeJson(join(home, ".pi", "agent", "simple-english.json"), config)
+  await writeJson(join(home, ".config", "simple-english", "config.json"), config)
   return home
 }
+
+const writeLegacyGlobalConfig = (home: string, config: unknown): Promise<void> =>
+  writeJson(join(home, ".pi", "agent", "simple-english.json"), config)
 
 describe("simple-english CLI config", () => {
   test("project config changes the sentence word cap", async () => {
@@ -35,7 +37,7 @@ describe("simple-english CLI config", () => {
     expect(result.stdout).toContain("maximum is 5")
   })
 
-  test("global config in the pi agent config directory applies", async () => {
+  test("global config in the XDG config directory applies", async () => {
     const home = await makeHome({ maxSentenceWords: 5 })
     const cwd = await makeProject()
     const result = await runCli([], { cwd, home, stdin: tenWords })
@@ -44,8 +46,38 @@ describe("simple-english CLI config", () => {
     expect(result.stdout).toContain("maximum is 5")
   })
 
-  test("PI_CODING_AGENT_DIR overrides the default pi agent config directory", async () => {
+  test("XDG_CONFIG_HOME sets the global config directory", async () => {
     const home = await makeHome({ maxSentenceWords: 20 })
+    const xdgConfigHome = await makeTempDir()
+    await writeJson(join(xdgConfigHome, "simple-english", "config.json"), {
+      maxSentenceWords: 5,
+    })
+    const cwd = await makeProject()
+    const result = await runCli([], { cwd, home, xdgConfigHome, stdin: tenWords })
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("maximum is 5")
+  })
+
+  test("legacy pi project and global configs apply when new configs are absent", async () => {
+    const home = await makeTempDir()
+    await writeLegacyGlobalConfig(home, {
+      maxSentenceWords: 5,
+      rules: { "sentence-length": "soft" },
+    })
+    const cwd = await makeProject()
+    await writeLegacyProjectConfig(cwd, { maxSentenceWords: 8 })
+    const result = await runCli(["--json"], { cwd, home, stdin: tenWords })
+
+    expect(result.code).toBe(0)
+    const report = JSON.parse(result.stdout)
+    expect(report.violations[0].severity).toBe("soft")
+    expect(report.violations[0].message).toContain("maximum is 8")
+  })
+
+  test("PI_CODING_AGENT_DIR sets the legacy global fallback directory", async () => {
+    const home = await makeTempDir()
+    await writeLegacyGlobalConfig(home, { maxSentenceWords: 20 })
     const agentDir = await makeTempDir()
     await writeJson(join(agentDir, "simple-english.json"), { maxSentenceWords: 5 })
     const cwd = await makeProject()
@@ -55,12 +87,27 @@ describe("simple-english CLI config", () => {
     expect(result.stdout).toContain("maximum is 5")
   })
 
+  test("new locations replace legacy locations at each config level", async () => {
+    const home = await makeHome({
+      maxSentenceWords: 5,
+      rules: { "sentence-length": "soft" },
+    })
+    await writeLegacyGlobalConfig(home, { rules: { "sentence-length": "off" } })
+    const cwd = await makeProject({ maxSentenceWords: 8 })
+    await writeLegacyProjectConfig(cwd, { maxSentenceWords: 20 })
+    const result = await runCli(["--json"], { cwd, home, stdin: tenWords })
+
+    expect(result.code).toBe(0)
+    const report = JSON.parse(result.stdout)
+    expect(report.violations[0].severity).toBe("soft")
+    expect(report.violations[0].message).toContain("maximum is 8")
+  })
+
   test("project config deep-merges over global with project winning per key", async () => {
     const home = await makeHome({ maxSentenceWords: 5, rules: { "sentence-length": "soft" } })
     const cwd = await makeProject({ maxSentenceWords: 8 })
     const result = await runCli(["--json"], { cwd, home, stdin: tenWords })
 
-    // Project cap (8) wins; the global soft override survives the merge, so exit is 0.
     expect(result.code).toBe(0)
     const report = JSON.parse(result.stdout)
     expect(report.violations).toHaveLength(1)
@@ -91,7 +138,7 @@ describe("simple-english CLI config", () => {
     const result = await runCli([], { cwd, stdin: "A short sentence." })
 
     expect(result.code).toBe(2)
-    expect(result.stderr).toContain(join(cwd, ".pi", "simple-english.json"))
+    expect(result.stderr).toContain(join(cwd, ".simple-english.json"))
     expect(result.stderr).toContain("sentence-length")
     expect(result.stderr).toContain("warn")
     expect(result.stderr).not.toContain("FiberFailure")
@@ -100,12 +147,11 @@ describe("simple-english CLI config", () => {
 
   test("a config file with malformed JSON exits 2 naming the file", async () => {
     const cwd = await makeProject()
-    await mkdir(join(cwd, ".pi"), { recursive: true })
-    await writeFile(join(cwd, ".pi", "simple-english.json"), "{ not json")
+    await writeFile(join(cwd, ".simple-english.json"), "{ not json")
     const result = await runCli([], { cwd, stdin: "A short sentence." })
 
     expect(result.code).toBe(2)
-    expect(result.stderr).toContain(join(cwd, ".pi", "simple-english.json"))
+    expect(result.stderr).toContain(join(cwd, ".simple-english.json"))
   })
 
   test("a missing explicit --config file exits 2 naming the path", async () => {

--- a/test/cli/run-cli.ts
+++ b/test/cli/run-cli.ts
@@ -17,6 +17,7 @@ export interface CliOptions {
   stdin?: string
   cwd?: string
   home?: string
+  xdgConfigHome?: string
   agentDir?: string
 }
 
@@ -27,7 +28,12 @@ const hermeticHome = makeTempDir()
 
 export async function runCli(args: string[], options: CliOptions = {}): Promise<CliResult> {
   const home = options.home ?? (await hermeticHome)
-  const env = { ...process.env, HOME: home, PI_CODING_AGENT_DIR: options.agentDir }
+  const env = {
+    ...process.env,
+    HOME: home,
+    XDG_CONFIG_HOME: options.xdgConfigHome ?? join(home, ".config"),
+    PI_CODING_AGENT_DIR: options.agentDir,
+  }
   return new Promise((resolve, reject) => {
     const child = execFile(
       "bun",

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -196,6 +196,7 @@ const temporaryDirectories: string[] = []
 const originalAgentDirectory = process.env.PI_CODING_AGENT_DIR
 const originalDictionary = process.env.SIMPLE_ENGLISH_DICTIONARY
 const originalHome = process.env.HOME
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
 
 afterEach(async () => {
   mkdirControl.afterMkdir = undefined
@@ -209,35 +210,54 @@ afterEach(async () => {
   }
   if (originalHome === undefined) process.env.HOME = undefined
   else process.env.HOME = originalHome
+  if (originalXdgConfigHome === undefined) process.env.XDG_CONFIG_HOME = undefined
+  else process.env.XDG_CONFIG_HOME = originalXdgConfigHome
   await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true })))
 })
 
 async function startExtension(options?: {
   readonly branch?: readonly Record<string, unknown>[]
   readonly globalConfig?: object | string
+  readonly legacyGlobalConfig?: object | string
   readonly projectConfig?: object
+  readonly legacyProjectConfig?: object
   readonly sessionStartReason?: "startup" | "resume"
   readonly trusted?: boolean
 }) {
   const cwd = await mkdtemp(join(process.cwd(), ".extension-test-"))
   temporaryDirectories.push(cwd)
   const globalDirectory = join(cwd, "global")
+  const xdgConfigHome = join(cwd, "xdg")
   await mkdir(globalDirectory)
   process.env.PI_CODING_AGENT_DIR = globalDirectory
+  process.env.XDG_CONFIG_HOME = xdgConfigHome
   if (options?.globalConfig !== undefined) {
+    const configDirectory = join(xdgConfigHome, "simple-english")
+    await mkdir(configDirectory, { recursive: true })
     await writeFile(
-      join(globalDirectory, "simple-english.json"),
+      join(configDirectory, "config.json"),
       typeof options.globalConfig === "string"
         ? options.globalConfig
         : JSON.stringify(options.globalConfig),
     )
   }
+  if (options?.legacyGlobalConfig !== undefined) {
+    await writeFile(
+      join(globalDirectory, "simple-english.json"),
+      typeof options.legacyGlobalConfig === "string"
+        ? options.legacyGlobalConfig
+        : JSON.stringify(options.legacyGlobalConfig),
+    )
+  }
   if (options?.projectConfig !== undefined) {
+    await writeFile(join(cwd, ".simple-english.json"), JSON.stringify(options.projectConfig))
+  }
+  if (options?.legacyProjectConfig !== undefined) {
     const projectDirectory = join(cwd, ".pi")
     await mkdir(projectDirectory)
     await writeFile(
       join(projectDirectory, "simple-english.json"),
-      JSON.stringify(options.projectConfig),
+      JSON.stringify(options.legacyProjectConfig),
     )
   }
 
@@ -348,6 +368,7 @@ describe.sequential("pi extension wiring", () => {
   test("declares a production pi extension package", async () => {
     const manifest = JSON.parse(await readFile(join(process.cwd(), "package.json"), "utf8"))
 
+    expect(manifest.name).toBe("simple-english")
     expect(manifest.pi.extensions).toEqual(["./src/extension/index.ts"])
     expect(manifest.bin).toEqual({ "simple-english": "src/cli/main.ts" })
     expect(manifest.dependencies).toMatchObject({
@@ -1342,6 +1363,64 @@ describe.sequential("pi extension wiring", () => {
         context,
       ),
     ).rejects.toThrow("[contraction]")
+  })
+
+  test("uses legacy pi config paths when host-neutral configs are absent", async () => {
+    const { pi, context, notifications } = await startExtension({
+      legacyGlobalConfig: { rules: { contraction: "hard" } },
+      legacyProjectConfig: { rules: { contraction: "soft" } },
+    })
+
+    const result = await pi.executeTool(
+      "write",
+      "write-legacy-config",
+      { path: "notes.md", content: "This isn't blocked." },
+      context,
+    )
+
+    expect(result).toBeDefined()
+    expect(notifications).toContainEqual({
+      level: "warning",
+      message: expect.stringContaining("[contraction]"),
+    })
+  })
+
+  test("host-neutral global config replaces the legacy global config", async () => {
+    const { pi, context, notifications } = await startExtension({
+      globalConfig: { rules: { contraction: "soft" } },
+      legacyGlobalConfig: { rules: { contraction: "off" } },
+    })
+
+    await pi.executeTool(
+      "write",
+      "write-global-precedence",
+      { path: "notes.md", content: "This isn't blocked." },
+      context,
+    )
+
+    expect(notifications).toContainEqual({
+      level: "warning",
+      message: expect.stringContaining("[contraction]"),
+    })
+  })
+
+  test("host-neutral project config replaces the legacy project config", async () => {
+    const { pi, context, notifications } = await startExtension({
+      projectConfig: { rules: { contraction: "soft" } },
+      legacyProjectConfig: { rules: { contraction: "off" } },
+    })
+
+    await pi.executeTool(
+      "write",
+      "write-project-precedence",
+      { path: "notes.md", content: "This isn't blocked." },
+      context,
+    )
+
+    expect(notifications).toContainEqual({
+      level: "warning",
+      message: expect.stringContaining("[contraction]"),
+    })
   })
 
   test("uses project rule settings over global settings in the extension context", async () => {


### PR DESCRIPTION
## Intent

Implement Linear HUF-149 as the host-neutral foundation for the multi-host spec. Rename the npm package from pi-simple-english to simple-english without publishing it, while preserving the simple-english bin and pi extension entry point. Discover .simple-english.json at the repository root and $XDG_CONFIG_HOME/simple-english/config.json globally, with ~/.config as the XDG default. Deep-merge global config first and project config over it. Preserve existing pi project and global paths as same-level fallbacks only when each new path is absent, including PI_CODING_AGENT_DIR behavior. Pin new-path, fallback, merge, and precedence behavior at the CLI and pi Adapter seams. Update the README for the host-neutral identity and config paths. Do not implement later HUF-150 through HUF-153 features, do not publish npm, and do not modify Linear.

## What Changed

- Renames the npm package to `simple-english` and keeps the CLI binary and pi extension entry point.
- Loads `.simple-english.json` and the XDG global config, then uses a deep merge with project precedence.
- Preserves same-level pi fallbacks and `PI_CODING_AGENT_DIR`, with CLI and pi Adapter tests for path and precedence behavior.

## Risk Assessment

✅ Low: The change is well-bounded and satisfies the package, configuration, fallback, precedence, test, and documentation requirements.

## Testing

Initial test commands failed because project dependencies were absent. After a frozen install, targeted CLI and Adapter tests passed. Manual CLI and package evidence matched the intent. The test dependency directory was removed after validation.

<details>
<summary>Evidence: CLI config precedence and fallback transcript</summary>

```text
$ cat $XDG_CONFIG_HOME/simple-english/config.json
{"maxSentenceWords":5,"rules":{"sentence-length":"soft"}}
$ cat .simple-english.json
{"maxSentenceWords":8}
$ cat $HOME/.pi/agent/simple-english.json  # same-level fallback, expected to be ignored
{"rules":{"sentence-length":"off"}}
$ cat .pi/simple-english.json  # same-level fallback, expected to be ignored
{"maxSentenceWords":20}
$ printf "one two three four five six seven eight nine ten.\\n" | simple-english --json
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "sentence-length",
      "severity": "soft",
      "message": "Sentence has 10 words; the maximum is 8.",
      "line": 1,
      "column": 1
    }
  ],
  "summary": {
    "total": 1,
    "hard": 0
  }
}
exit=0

$ PI_CODING_AGENT_DIR=/custom/pi printf "one two three four five six seven eight nine ten.\\n" | simple-english --json  # new global and project paths absent
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "sentence-length",
      "severity": "soft",
      "message": "Sentence has 10 words; the maximum is 5.",
      "line": 1,
      "column": 1
    }
  ],
  "summary": {
    "total": 1,
    "hard": 0
  }
}
exit=0
```
</details>
<details>
<summary>Evidence: Dry-run npm package contents</summary>

```text
[
  {
    "id": "simple-english@0.1.0",
    "name": "simple-english",
    "version": "0.1.0",
    "size": 42158,
    "unpackedSize": 167768,
    "shasum": "ecf65001e9c281c62b8a92938196a541788c8fae",
    "integrity": "sha512-7Ttww4vqnvnxblBc/FZTWuvPO+nBZ2IlbNTC+Cv1DTkDh3DzcOlr2oJa6249jYA7VWQQ9dElSZjIA2WrUYRZ0Q==",
    "filename": "simple-english-0.1.0.tgz",
    "files": [
      {
        "path": "LICENSE",
        "size": 1063,
        "mode": 420
      },
      {
        "path": "README.md",
        "size": 11552,
        "mode": 420
      },
      {
        "path": "THIRD_PARTY_NOTICES.md",
        "size": 926,
        "mode": 420
      },
      {
        "path": "package.json",
        "size": 978,
        "mode": 420
      },
      {
        "path": "src/cli/main.ts",
        "size": 5251,
        "mode": 420
      },
      {
        "path": "src/config/load.ts",
        "size": 3104,
        "mode": 420
      },
      {
        "path": "src/config/merge.ts",
        "size": 737,
        "mode": 420
      },
      {
        "path": "src/config/schema.ts",
        "size": 2211,
        "mode": 420
      },
      {
        "path": "src/dictionary/data/pi-ste.json",
        "size": 5218,
        "mode": 420
      },
      {
        "path": "src/dictionary/form.ts",
        "size": 234,
        "mode": 420
      },
      {
        "path": "src/dictionary/load.ts",
        "size": 1766,
        "mode": 420
      },
      {
        "path": "src/dictionary/README.md",
        "size": 1383,
        "mode": 420
      },
      {
        "path": "src/dictionary/schema.ts",
        "size": 955,
        "mode": 420
      },
      {
        "path": "src/engine/comments.ts",
        "size": 10718,
        "mode": 420
      },
      {
        "path": "src/engine/diff.ts",
        "size": 9737,
        "mode": 420
      },
      {
        "path": "src/engine/identifiers.ts",
        "size": 590,
        "mode": 420
      },
      {
        "path": "src/engine/kinds.ts",
        "size": 1093,
        "mode": 420
      },
      {
        "path": "src/engine/lint.ts",
        "size": 24044,
        "mode": 420
      },
      {
        "path": "src/engine/markdown.ts",
        "size": 10043,
        "mode": 420
      },
      {
        "path": "src/engine/paragraphs.ts",
        "size": 3111,
        "mode": 420
      },
      {
        "path": "src/engine/rules/contraction.ts",
        "size": 809,
        "mode": 420
      },
      {
        "path": "src/engine/rules/dictionary.ts",
        "size": 8402,
        "mode": 420
      },
      {
        "path": "src/engine/rules/hedging.ts",
        "size": 781,
        "mode": 420
      },
      {
        "path": "src/engine/rules/marketing.ts",
        "size": 1613,
        "mode": 420
      },
      {
        "path": "src/engine/rules/paragraph-length.ts",
        "size": 678,
        "mode": 420
      },
      {
        "path": "src/engine/rules/phrasal-verb.ts",
        "size": 2211,
        "mode": 420
      },
      {
        "path": "src/engine/rules/registry.ts",
        "size": 296,
        "mode": 420
      },
      {
        "path": "src/engine/rules/semicolon.ts",
        "size": 404,
        "mode": 420
      },
      {
        "path": "src/engine/rules/sentence-length.ts",
        "size": 691,
        "mode": 420
      },
      {
        "path": "src/engine/rules/verb-form.ts",
        "size": 2678,
        "mode": 420
      },
      {
        "path": "src/engine/scan.ts",
        "size": 376,
        "mode": 420
      },
      {
        "path": "src/engine/sentences.ts",
        "size": 8345,
        "mode": 420
      },
      {
        "path": "src/engine/tagger.ts",
        "size": 194,
        "mode": 420
      },
      {
        "path": "src/engine/tokens.ts",
        "size": 139,
        "mode": 420
      },
      {
        "path": "src/engine/types.ts",
        "size": 1470,
        "mode": 420
      },
      {
        "path": "src/extension/commit-message.ts",
        "size": 12032,
        "mode": 420
      },
      {
        "path": "src/extension/index.ts",
        "size": 30574,
        "mode": 420
      },
      {
        "path": "src/tagger/wink.ts",
        "size": 1361,
        "mode": 420
      }
    ],
    "entryCount": 38,
    "bundled": []
  }
]
```
</details>
<details>
<summary>Evidence: Package name, binary, and pi entry point</summary>

```text
{
  "name": "simple-english",
  "bin": {
    "simple-english": "src/cli/main.ts"
  },
  "pi": {
    "extensions": [
      "./src/extension/index.ts"
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bunx vitest run test/cli/config.test.ts` failed before dependency setup and passed after setup.</code>
- <code>`bunx vitest run test/extension/extension.test.ts -t &#39;declares a production pi extension package|ignores project rule settings until the project is trusted|uses legacy pi config paths when host-neutral configs are absent|host-neutral global config replaces the legacy global config|host-neutral project config replaces the legacy project config|uses project rule settings over global settings in the extension context&#39;` passed after setup.</code>
- <code>`bun install --frozen-lockfile` restored absent project dependencies. The generated dependency directory was removed after validation.</code>
- `Ran the CLI with new global and project configs plus conflicting legacy fallbacks. The output used global severity and the project word limit.`
- <code>Ran the CLI with only a custom `PI_CODING_AGENT_DIR` legacy global config. The output used its word limit and severity.</code>
- <code>`npm pack --dry-run --json` confirmed the renamed package contents without publication.</code>
- <code>`node -e &#39;const p=require(&#34;./package.json&#34;); console.log(JSON.stringify({name:p.name,bin:p.bin,pi:p.pi},null,2))&#39;` confirmed the package contract.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
