### PR TITLE
feat(plugin): add automatic Claude Code STE gates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "agent-simple-english",
+  "owner": {
+    "name": "JIA YI"
+  },
+  "metadata": {
+    "description": "Local install source for the Simple English Claude Code plugin."
+  },
+  "plugins": [
+    {
+      "name": "simple-english",
+      "description": "Apply Simplified Technical English rules to writes, edits, and git commit messages.",
+      "version": "0.1.0",
+      "author": {
+        "name": "JIA YI"
+      },
+      "source": "./",
+      "category": "development",
+      "homepage": "https://github.com/jyooi/agent-simple-english"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "simple-english",
+  "version": "0.1.0",
+  "description": "Apply Simplified Technical English rules to writes, edits, and git commit messages.",
+  "repository": "https://github.com/jyooi/agent-simple-english",
+  "license": "MIT",
+  "keywords": ["simplified-technical-english", "lint", "hooks"],
+  "author": {
+    "name": "JIA YI"
+  }
+}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,5 +34,5 @@ _Avoid_: guard, filter
 A hard violation blocks the gated action; a soft violation only produces a warning.
 
 **Strict mode**:
-The reply-gating mode where the assistant's user-facing prose is checked before the user reads it.
-On pi this uses the `say` tool with redaction; other hosts approximate it up to their ceiling.
+The reply gate mode that checks the assistant's user-facing prose before the user reads it.
+Host support follows the [per-host enforcement ceilings](docs/adr/0001-per-host-enforcement-ceiling.md).

--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # simple-english
 
 `simple-english` checks ASD-STE100 Simplified Technical English (STE).
-It supplies one Engine, one CLI, and a pi Adapter.
-The CLI also supplies a `PreToolUse` hook for Claude Code.
-The [pi coding agent](https://pi.dev) can use the Adapter to enforce the same rules.
+It supplies one Engine, one CLI, a pi Adapter, and a Claude Code Adapter.
+The Claude Code plugin uses CLI Hook mode to enforce the same rules.
 
 This package reports deterministic writing problems.
 It does not rewrite text because an automatic rewrite can change its meaning.
 
-## What the extension does
+## What the pi Adapter does
 
-The extension adds its active STE rules to the model prompt before each agent turn.
+The pi Adapter adds its active STE rules to the model prompt before each agent turn.
 It then applies the rules at three layers.
 
 1. **Write and edit gate.**
@@ -32,9 +31,41 @@ It then applies the rules at three layers.
    Strict mode makes the model send each reply through the `say` tool.
    A strict reply stays hidden until it has no hard violations.
 
-The extension checks Markdown prose and source comments according to the [content kinds](#content-kinds).
+The pi Adapter checks Markdown prose and source comments according to the [content kinds](#content-kinds).
 It gives the line, column, rule ID, and suggested correction for a blocked tool call.
 A config or dictionary load error makes enabled write, edit, and commit gates fail closed.
+
+## Install the Claude Code Adapter
+
+Install [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [Bun](https://bun.sh) first.
+Then use the standard local plugin flow:
+
+```sh
+claude plugin marketplace add jyooi/agent-simple-english
+claude plugin install simple-english@agent-simple-english
+```
+
+Start a new Claude Code session after installation.
+Bun installs the plugin dependencies when the first hook starts.
+You do not need a global `simple-english` package or manual hook settings.
+The repository supplies the local marketplace manifest.
+Marketplace publication is outside this package release.
+
+At `SessionStart`, the Adapter loads the merged config from the session working directory.
+It adds the active STE rule summary to context.
+The summary honors `hard`, `soft`, and `off` rule settings plus `maxSentenceWords`.
+
+The `PreToolUse` gate checks `Write`, `Edit`, and `Bash` events.
+A hard write or edit violation blocks the tool and returns its location, rule ID, and suggested correction.
+The Adapter checks only new edit violations, so old prose does not block an unrelated edit.
+Correct the text and retry the tool.
+A clean retry succeeds.
+
+For `Bash`, the gate checks static messages in detected `git commit` commands.
+It blocks a hard violation before Git starts.
+It also blocks a detected commit without a static `-m` or `--message` argument.
+A compliant static message passes.
+Soft violations allow the event and add warning text.
 
 ## Install the pi Adapter
 
@@ -51,8 +82,8 @@ Pi packages run with your user permissions, so inspect third-party package code 
 Use the checkout without a persistent installation during development:
 
 ```sh
-git clone https://github.com/jyooi/ste.git
-cd ste
+git clone https://github.com/jyooi/agent-simple-english.git
+cd agent-simple-english
 bun install
 pi -e .
 ```
@@ -83,40 +114,14 @@ Install it from the same npm package:
 bun add --global simple-english
 ```
 
-### Claude Code `PreToolUse` hook
+### Claude Code Hook mode
 
-Add this command hook to the project `.claude/settings.json` file:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Write|Edit|Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "simple-english hook"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-The `hook` subcommand reads one Claude Code `PreToolUse` event from standard input.
-It writes one hook decision as JSON.
-A `Write` event checks the proposed content.
-An `Edit` event reconstructs the proposed file and reports only new violations.
-A `Bash` event checks static messages in detected `git commit` commands.
-The hook denies a detected commit that has no static message.
-
-A hard violation denies the event with its line, column, rule ID, and suggested correction.
-A soft violation alone allows the event and adds warning text.
-The hook allows clean events.
+The `hook` subcommand reads one Claude Code hook event from standard input.
+It writes one hook result as JSON.
+A `SessionStart` event returns the active rule summary as added context.
+A `PreToolUse` event applies the write, edit, and commit gates that the plugin registers.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
-The hook allows a valid event when configuration, dictionary, tagger, or file processing fails.
+The gate allows a valid event when configuration, dictionary, tagger, or file processing fails.
 It adds warning text.
 
 ### Lint files and standard input

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ The project fallback is `.pi/simple-english.json`.
 The global fallback is `simple-english.json` in the pi agent config directory.
 The default pi agent config directory is `~/.pi/agent`.
 `PI_CODING_AGENT_DIR` can change that directory.
+The loader resolves a relative value from the working directory that requested the config.
 The loader reads a fallback file only when the new file at the same level is absent.
 
 This example contains every config key and every rule:
@@ -367,8 +368,9 @@ This project has no affiliation with or endorsement from ASD.
 
 The package dictionary format and match rules are in [`src/dictionary/README.md`](src/dictionary/README.md).
 Set `SIMPLE_ENGLISH_DICTIONARY` to a replacement dictionary file if necessary.
-The CLI reports a replacement dictionary load error and continues with all other rules.
-The enabled extension fails closed after that error.
+Hook mode resolves a relative replacement path from the session working directory.
+A lint command reports a replacement dictionary load error and continues with all other rules.
+The enabled pi Adapter fails closed after that error.
 
 ## Development
 

--- a/docs/adr/0001-per-host-enforcement-ceiling.md
+++ b/docs/adr/0001-per-host-enforcement-ceiling.md
@@ -4,11 +4,10 @@ We design adapters for pi and Claude Code.
 Each adapter uses the strongest enforcement that its host allows.
 We do not reduce all hosts to one common enforcement level or limit new hosts to warnings.
 
-The planned host ceilings differ.
+The host ceilings differ.
 Pi gets prompt rules, write and edit gates, commit gates, reply feedback, and strict reply gates.
 Claude Code gets prompt rules through SessionStart and write, edit, and commit gates through PreToolUse.
-It gets reply feedback through UserPromptSubmit.
-A Stop hook approximates strict mode because it cannot hide text that Claude Code sent.
+Claude Code has no reply check or strict mode.
 We accept and document the host differences.
 
 A host ceiling can increase when its extension surface changes.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/src/cli/main.ts\" hook",
+            "command": "cd \"${CLAUDE_PLUGIN_ROOT}\" && bun \"src/cli/main.ts\" hook",
             "timeout": 120
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/src/cli/main.ts\" hook",
+            "command": "cd \"${CLAUDE_PLUGIN_ROOT}\" && bun \"src/cli/main.ts\" hook",
             "timeout": 120
           }
         ]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "Inject active STE rules and gate writes, edits, and git commit messages.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/src/cli/main.ts\" hook",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"${CLAUDE_PLUGIN_ROOT}/src/cli/main.ts\" hook",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "pi": {
     "extensions": ["./src/extension/index.ts"]
   },
-  "files": ["src", "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md"],
+  "files": [".claude-plugin", "hooks", "src", "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md"],
   "bin": {
     "simple-english": "src/cli/main.ts"
   },

--- a/src/adapter/rule-summary.ts
+++ b/src/adapter/rule-summary.ts
@@ -1,0 +1,51 @@
+import type { SteConfig } from "../config/schema.ts"
+import { DEFAULT_MAX_SENTENCE_WORDS } from "../engine/lint.ts"
+import type { RuleId } from "../engine/rules/registry.ts"
+import type { RuleSetting } from "../engine/types.ts"
+
+const DEFAULT_RULE_SETTINGS: Readonly<Record<RuleId, RuleSetting>> = {
+  contraction: "hard",
+  "dictionary-not-approved-word": "hard",
+  hedging: "soft",
+  marketing: "soft",
+  "paragraph-length": "hard",
+  "phrasal-verb": "hard",
+  semicolon: "hard",
+  "sentence-length": "hard",
+  "verb-progressive": "hard",
+  "verb-passive": "soft",
+  "verb-perfect": "hard",
+}
+
+export const RULE_SUMMARIES: Readonly<Record<RuleId, string>> = {
+  contraction: "Do not use contractions. Write the words in full.",
+  "dictionary-not-approved-word": "Use approved words from the STE dictionary.",
+  hedging: "Remove hedging phrases.",
+  marketing: "Use factual language instead of marketing language.",
+  "paragraph-length": "Use no more than six sentences in one paragraph.",
+  "phrasal-verb": "Use an approved single-word verb instead of a phrasal verb.",
+  semicolon: "Do not use semicolons. Write two sentences.",
+  "sentence-length": "Keep each sentence within the configured word limit.",
+  "verb-progressive": "Do not use progressive verb forms.",
+  "verb-passive": "Prefer active voice.",
+  "verb-perfect": "Do not use perfect verb forms.",
+}
+
+export function resolvedRuleSetting(config: SteConfig, ruleId: RuleId): RuleSetting {
+  return config.rules?.[ruleId] ?? DEFAULT_RULE_SETTINGS[ruleId]
+}
+
+export function ruleSummary(config: SteConfig): string {
+  const maxSentenceWords = config.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS
+  const rules = (Object.keys(RULE_SUMMARIES) as RuleId[])
+    .filter((ruleId) => resolvedRuleSetting(config, ruleId) !== "off")
+    .map((ruleId) => {
+      const summary =
+        ruleId === "sentence-length"
+          ? `Keep each sentence to ${maxSentenceWords} words or fewer.`
+          : RULE_SUMMARIES[ruleId]
+      return `- [${resolvedRuleSetting(config, ruleId)}] ${summary}`
+    })
+    .join("\n")
+  return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
+}

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -190,11 +190,15 @@ const readEditFile = (path: string) =>
     catch: (cause) => new Error(`cannot read edit file ${path}: ${cause}`),
   })
 
-const loadLintOptions = (cwd: string, tagger: Tagger) =>
-  Effect.all({
+const loadLintOptions = (cwd: string, tagger: Tagger) => {
+  const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
+  return Effect.all({
     config: loadConfig(undefined, cwd),
-    dictionary: loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+    dictionary: loadDictionary(
+      dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
+    ),
   }).pipe(Effect.map(({ config, dictionary }): LintOptions => ({ ...config, dictionary, tagger })))
+}
 
 function splitViolations(violations: readonly Violation[]): {
   readonly hard: Violation[]

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path"
 import { Cause, Effect } from "effect"
 import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-message.ts"
 import { formatViolations } from "../adapter/feedback.ts"
+import { ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import { loadDictionary } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
@@ -11,8 +12,14 @@ import type { Tagger } from "../engine/tagger.ts"
 import type { LintOptions, Violation } from "../engine/types.ts"
 import { TaggerService } from "../tagger/wink.ts"
 
+interface SessionStartEvent {
+  readonly cwd: string
+  readonly hookEventName: "SessionStart"
+}
+
 interface WriteEvent {
   readonly cwd: string
+  readonly hookEventName: "PreToolUse"
   readonly toolName: "Write"
   readonly filePath: string
   readonly content: string
@@ -20,6 +27,7 @@ interface WriteEvent {
 
 interface EditEvent {
   readonly cwd: string
+  readonly hookEventName: "PreToolUse"
   readonly toolName: "Edit"
   readonly filePath: string
   readonly oldString: string
@@ -29,11 +37,13 @@ interface EditEvent {
 
 interface BashEvent {
   readonly cwd: string
+  readonly hookEventName: "PreToolUse"
   readonly toolName: "Bash"
   readonly command: string
 }
 
-type HookEvent = WriteEvent | EditEvent | BashEvent
+type PreToolUseEvent = WriteEvent | EditEvent | BashEvent
+type HookEvent = SessionStartEvent | PreToolUseEvent
 
 interface HookSpecificOutput {
   readonly hookEventName: "PreToolUse"
@@ -46,12 +56,19 @@ interface HookDecision {
   readonly hookSpecificOutput: HookSpecificOutput
 }
 
+interface SessionStartOutput {
+  readonly hookSpecificOutput: {
+    readonly hookEventName: "SessionStart"
+    readonly additionalContext: string
+  }
+}
+
 interface HookError {
   readonly continue: true
   readonly systemMessage: string
 }
 
-export type HookOutput = HookDecision | HookError
+export type HookOutput = HookDecision | SessionStartOutput | HookError
 
 function record(value: unknown, name: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -68,16 +85,19 @@ function stringField(value: Record<string, unknown>, name: string): string {
 
 function decodeEvent(raw: string): HookEvent {
   const event = record(JSON.parse(raw) as unknown, "event")
-  if (stringField(event, "hook_event_name") !== "PreToolUse") {
-    throw new Error("hook_event_name must be PreToolUse")
-  }
+  const hookEventName = stringField(event, "hook_event_name")
   const cwd = stringField(event, "cwd")
+  if (hookEventName === "SessionStart") return { cwd, hookEventName }
+  if (hookEventName !== "PreToolUse") {
+    throw new Error("hook_event_name must be SessionStart or PreToolUse")
+  }
   const toolName = stringField(event, "tool_name")
   const input = record(event.tool_input, "tool_input")
 
   if (toolName === "Write") {
     return {
       cwd,
+      hookEventName,
       toolName,
       filePath: stringField(input, "file_path"),
       content: stringField(input, "content"),
@@ -90,6 +110,7 @@ function decodeEvent(raw: string): HookEvent {
     }
     return {
       cwd,
+      hookEventName,
       toolName,
       filePath: stringField(input, "file_path"),
       oldString: stringField(input, "old_string"),
@@ -98,7 +119,7 @@ function decodeEvent(raw: string): HookEvent {
     }
   }
   if (toolName === "Bash") {
-    return { cwd, toolName, command: stringField(input, "command") }
+    return { cwd, hookEventName, toolName, command: stringField(input, "command") }
   }
   throw new Error(`unsupported PreToolUse tool: ${toolName}`)
 }
@@ -119,6 +140,15 @@ function deny(reason: string): HookDecision {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
       permissionDecisionReason: reason,
+    },
+  }
+}
+
+function addSessionContext(context: string): SessionStartOutput {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: context,
     },
   }
 }
@@ -196,7 +226,7 @@ function textDecision(
   return allow(soft.length === 0 ? [] : [formatViolations(path, "STE warnings for", soft)])
 }
 
-function evaluateEvent(event: HookEvent, tagger: Tagger): Effect.Effect<HookDecision, Error> {
+function evaluateEvent(event: PreToolUseEvent, tagger: Tagger): Effect.Effect<HookDecision, Error> {
   if (event.toolName === "Bash") {
     const invocations = findCommitInvocations(event.command)
     if (invocations.length === 0) return Effect.succeed(allow())
@@ -243,14 +273,23 @@ export function runHookMode(raw: string): Effect.Effect<HookOutput, never, Tagge
   }).pipe(
     Effect.matchEffect({
       onFailure: (error) => Effect.succeed(nonBlockingError(error.message)),
-      onSuccess: (event) =>
-        Effect.gen(function* () {
+      onSuccess: (event) => {
+        if (event.hookEventName === "SessionStart") {
+          return loadConfig(undefined, event.cwd).pipe(
+            Effect.match({
+              onFailure: (error) => nonBlockingError(error.message),
+              onSuccess: (config) => addSessionContext(ruleSummary(config)),
+            }),
+          )
+        }
+        return Effect.gen(function* () {
           const tagger = yield* TaggerService
           return yield* evaluateEvent(event, tagger)
         }).pipe(
           Effect.catchAll((error) => Effect.succeed(nonBlockingWarning(error.message))),
           Effect.catchAllCause((cause) => Effect.succeed(hookInternalFailure(cause))),
-        ),
+        )
+      },
     }),
   )
 }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,18 +1,20 @@
 import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { isAbsolute, join } from "node:path"
+import { isAbsolute, join, resolve } from "node:path"
 import { Effect } from "effect"
 import { mergeConfigs } from "./merge.ts"
 import { ConfigError, type SteConfig, decodeConfig } from "./schema.ts"
 
-const legacyAgentConfigDirectory = (): string => {
+const legacyAgentConfigDirectory = (cwd: string): string => {
   const configured = process.env.PI_CODING_AGENT_DIR
   if (!configured) return join(homedir(), ".pi", "agent")
   if (configured === "~") return homedir()
-  return configured.startsWith("~/") ||
+  const expanded =
+    configured.startsWith("~/") ||
     (process.platform === "win32" && configured.startsWith("~\\"))
-    ? join(homedir(), configured.slice(2))
-    : configured
+      ? join(homedir(), configured.slice(2))
+      : configured
+  return isAbsolute(expanded) ? expanded : resolve(cwd, expanded)
 }
 
 const xdgConfigDirectory = (): string => {
@@ -25,8 +27,8 @@ export const globalConfigPath = (): string =>
 
 export const projectConfigPath = (cwd: string): string => join(cwd, ".simple-english.json")
 
-export const legacyGlobalConfigPath = (): string =>
-  join(legacyAgentConfigDirectory(), "simple-english.json")
+export const legacyGlobalConfigPath = (cwd = process.cwd()): string =>
+  join(legacyAgentConfigDirectory(cwd), "simple-english.json")
 
 export const legacyProjectConfigPath = (cwd: string): string =>
   join(cwd, ".pi", "simple-english.json")
@@ -75,7 +77,7 @@ export const loadConfig = (
   if (explicitPath !== undefined) {
     return readConfigFile(explicitPath, false).pipe(Effect.map((config) => config ?? {}))
   }
-  const globalConfig = readConfigWithFallback(globalConfigPath(), legacyGlobalConfigPath())
+  const globalConfig = readConfigWithFallback(globalConfigPath(), legacyGlobalConfigPath(cwd))
   if (!includeProjectConfig) return globalConfig
   const projectConfig = readConfigWithFallback(projectConfigPath(cwd), legacyProjectConfigPath(cwd))
   return Effect.all([globalConfig, projectConfig]).pipe(

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -10,8 +10,7 @@ const legacyAgentConfigDirectory = (cwd: string): string => {
   if (!configured) return join(homedir(), ".pi", "agent")
   if (configured === "~") return homedir()
   const expanded =
-    configured.startsWith("~/") ||
-    (process.platform === "win32" && configured.startsWith("~\\"))
+    configured.startsWith("~/") || (process.platform === "win32" && configured.startsWith("~\\"))
       ? join(homedir(), configured.slice(2))
       : configured
   return isAbsolute(expanded) ? expanded : resolve(cwd, expanded)

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -17,6 +17,7 @@ import { Effect } from "effect"
 import { Type } from "typebox"
 import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-message.ts"
 import { formatViolations, violationDetails } from "../adapter/feedback.ts"
+import { RULE_SUMMARIES, resolvedRuleSetting, ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import type { SteConfig } from "../config/schema.ts"
 import { loadDictionary } from "../dictionary/load.ts"
@@ -34,34 +35,6 @@ const STE_COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
   { value: "status", label: "status", description: "Show STE status" },
   { value: "strict", label: "strict", description: "Enable strict reply gating" },
 ]
-
-const DEFAULT_RULE_SETTINGS: Readonly<Record<RuleId, RuleSetting>> = {
-  contraction: "hard",
-  "dictionary-not-approved-word": "hard",
-  hedging: "soft",
-  marketing: "soft",
-  "paragraph-length": "hard",
-  "phrasal-verb": "hard",
-  semicolon: "hard",
-  "sentence-length": "hard",
-  "verb-progressive": "hard",
-  "verb-passive": "soft",
-  "verb-perfect": "hard",
-}
-
-const RULE_SUMMARIES: Readonly<Record<RuleId, string>> = {
-  contraction: "Do not use contractions. Write the words in full.",
-  "dictionary-not-approved-word": "Use approved words from the STE dictionary.",
-  hedging: "Remove hedging phrases.",
-  marketing: "Use factual language instead of marketing language.",
-  "paragraph-length": "Use no more than six sentences in one paragraph.",
-  "phrasal-verb": "Use an approved single-word verb instead of a phrasal verb.",
-  semicolon: "Do not use semicolons. Write two sentences.",
-  "sentence-length": "Keep each sentence within the configured word limit.",
-  "verb-progressive": "Do not use progressive verb forms.",
-  "verb-passive": "Prefer active voice.",
-  "verb-perfect": "Do not use perfect verb forms.",
-}
 
 interface SessionState {
   config: SteConfig
@@ -91,29 +64,10 @@ const STRICT_MODE_NOTE = [
 
 let sharedTagger: Tagger | undefined
 
-function resolvedSetting(config: SteConfig, ruleId: RuleId): RuleSetting {
-  return config.rules?.[ruleId] ?? DEFAULT_RULE_SETTINGS[ruleId]
-}
-
-function ruleSummary(config: SteConfig): string {
-  const maxSentenceWords = config.maxSentenceWords ?? 25
-  const rules = (Object.keys(RULE_SUMMARIES) as RuleId[])
-    .filter((ruleId) => resolvedSetting(config, ruleId) !== "off")
-    .map((ruleId) => {
-      const summary =
-        ruleId === "sentence-length"
-          ? `Keep each sentence to ${maxSentenceWords} words or fewer.`
-          : RULE_SUMMARIES[ruleId]
-      return `- [${resolvedSetting(config, ruleId)}] ${summary}`
-    })
-    .join("\n")
-  return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
-}
-
 function statusSummary(state: SessionState): string {
   const counts: Record<RuleSetting, number> = { hard: 0, soft: 0, off: 0 }
   for (const ruleId of Object.keys(RULE_SUMMARIES) as RuleId[]) {
-    counts[resolvedSetting(state.config, ruleId)]++
+    counts[resolvedRuleSetting(state.config, ruleId)]++
   }
   const mode = !state.enabled ? "disabled" : state.strict ? "strict" : "enabled"
   const dictionary =

--- a/src/tagger/wink.ts
+++ b/src/tagger/wink.ts
@@ -33,4 +33,12 @@ export function makeWinkTagger(): Tagger {
 
 export class TaggerService extends Context.Tag("TaggerService")<TaggerService, Tagger>() {}
 
-export const WinkTaggerLive = Layer.sync(TaggerService, makeWinkTagger)
+const makeLazyWinkTagger = (): Tagger => {
+  let tagger: Tagger | undefined
+  return (text) => {
+    tagger ??= makeWinkTagger()
+    return tagger(text)
+  }
+}
+
+export const WinkTaggerLive = Layer.sync(TaggerService, makeLazyWinkTagger)

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -128,10 +128,7 @@ describe("simple-english CLI hook mode", () => {
   test("resolves a custom dictionary from the event directory", async () => {
     const cwd = await makeProject()
     const dictionaryPath = join(cwd, "dictionary.json")
-    await copyFile(
-      join(repoRoot, "test", "fixtures", "hyphenated-dictionary.json"),
-      dictionaryPath,
-    )
+    await copyFile(join(repoRoot, "test", "fixtures", "hyphenated-dictionary.json"), dictionaryPath)
     const input = event(cwd, "Write", {
       file_path: join(cwd, "notes.md"),
       content: "Use state-of-the-art parts.",
@@ -144,9 +141,7 @@ describe("simple-english CLI hook mode", () => {
       expect(result.code).toBe(0)
       const output = decision(result.output)
       expect(output.permissionDecision).toBe("deny")
-      expect(output.permissionDecisionReason).toContain(
-        'Use "advanced", not "state-of-the-art".',
-      )
+      expect(output.permissionDecisionReason).toContain('Use "advanced", not "state-of-the-art".')
     }
   })
 

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, test } from "vitest"
@@ -6,7 +6,7 @@ import { repoRoot, runCli } from "./run-cli.ts"
 
 interface HookSpecificOutput {
   readonly hookEventName: string
-  readonly permissionDecision: string
+  readonly permissionDecision?: string
   readonly permissionDecisionReason?: string
   readonly additionalContext?: string
 }
@@ -45,8 +45,19 @@ function event(cwd: string, toolName: "Write" | "Edit" | "Bash", toolInput: obje
   })
 }
 
-async function runHook(stdin: string, cwd?: string, preload?: string) {
-  const result = await runCli(["hook"], { stdin, cwd, preload })
+function sessionStartEvent(cwd: string): string {
+  return JSON.stringify({
+    session_id: "session-1",
+    transcript_path: join(cwd, "transcript.jsonl"),
+    cwd,
+    permission_mode: "default",
+    hook_event_name: "SessionStart",
+    source: "startup",
+  })
+}
+
+async function runHook(stdin: string, cwd?: string, preload?: string, xdgConfigHome?: string) {
+  const result = await runCli(["hook"], { stdin, cwd, preload, xdgConfigHome })
   return { ...result, output: JSON.parse(result.stdout) as HookOutput }
 }
 
@@ -56,6 +67,50 @@ function decision(output: HookOutput): HookSpecificOutput {
 }
 
 describe("simple-english CLI hook mode", () => {
+  test("adds the merged active rule summary to SessionStart context", async () => {
+    const cwd = await makeProject({
+      maxSentenceWords: 8,
+      rules: { contraction: "off", semicolon: "soft" },
+    })
+    const xdgConfigHome = await mkdtemp(join(tmpdir(), "ste-hook-config-"))
+    temporaryDirectories.push(xdgConfigHome)
+    const configDirectory = join(xdgConfigHome, "simple-english")
+    await mkdir(configDirectory)
+    await writeFile(
+      join(configDirectory, "config.json"),
+      JSON.stringify({
+        maxSentenceWords: 30,
+        rules: { contraction: "hard", marketing: "hard", semicolon: "hard" },
+      }),
+    )
+
+    const result = await runHook(sessionStartEvent(cwd), cwd, undefined, xdgConfigHome)
+
+    expect(result.code).toBe(0)
+    const output = decision(result.output)
+    expect(output.hookEventName).toBe("SessionStart")
+    expect(output.additionalContext).toContain("Simplified Technical English")
+    expect(output.additionalContext).toContain("[hard] Use factual language")
+    expect(output.additionalContext).toContain("[soft] Do not use semicolons")
+    expect(output.additionalContext).toContain("Keep each sentence to 8 words or fewer")
+    expect(output.additionalContext).not.toContain("Do not use contractions")
+  })
+
+  test("adds SessionStart context without tagger setup", async () => {
+    const cwd = await makeProject()
+
+    const result = await runHook(
+      sessionStartEvent(cwd),
+      cwd,
+      join(repoRoot, "test", "fixtures", "failing-tagger-preload.js"),
+    )
+
+    expect(result.code).toBe(0)
+    const output = decision(result.output)
+    expect(output.hookEventName).toBe("SessionStart")
+    expect(output.additionalContext).toContain("Simplified Technical English")
+  })
+
   test("denies a Write event and lists every hard violation with a suggested fix", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const result = await runHook(

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, test } from "vitest"
@@ -56,8 +56,20 @@ function sessionStartEvent(cwd: string): string {
   })
 }
 
-async function runHook(stdin: string, cwd?: string, preload?: string, xdgConfigHome?: string) {
-  const result = await runCli(["hook"], { stdin, cwd, preload, xdgConfigHome })
+async function runHook(
+  stdin: string,
+  cwd?: string,
+  preload?: string,
+  xdgConfigHome?: string,
+  dictionaryPath?: string,
+) {
+  const result = await runCli(["hook"], {
+    stdin,
+    cwd,
+    preload,
+    xdgConfigHome,
+    dictionaryPath,
+  })
   return { ...result, output: JSON.parse(result.stdout) as HookOutput }
 }
 
@@ -109,6 +121,31 @@ describe("simple-english CLI hook mode", () => {
     const output = decision(result.output)
     expect(output.hookEventName).toBe("SessionStart")
     expect(output.additionalContext).toContain("Simplified Technical English")
+  })
+
+  test("resolves a custom dictionary from the event directory", async () => {
+    const cwd = await makeProject()
+    const dictionaryPath = join(cwd, "dictionary.json")
+    await copyFile(
+      join(repoRoot, "test", "fixtures", "hyphenated-dictionary.json"),
+      dictionaryPath,
+    )
+    const input = event(cwd, "Write", {
+      file_path: join(cwd, "notes.md"),
+      content: "Use state-of-the-art parts.",
+    })
+
+    const relativeResult = await runHook(input, repoRoot, undefined, undefined, "dictionary.json")
+    const absoluteResult = await runHook(input, repoRoot, undefined, undefined, dictionaryPath)
+
+    for (const result of [relativeResult, absoluteResult]) {
+      expect(result.code).toBe(0)
+      const output = decision(result.output)
+      expect(output.permissionDecision).toBe("deny")
+      expect(output.permissionDecisionReason).toContain(
+        'Use "advanced", not "state-of-the-art".',
+      )
+    }
   })
 
   test("denies a Write event and lists every hard violation with a suggested fix", async () => {

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -62,6 +62,7 @@ async function runHook(
   preload?: string,
   xdgConfigHome?: string,
   dictionaryPath?: string,
+  agentDir?: string,
 ) {
   const result = await runCli(["hook"], {
     stdin,
@@ -69,6 +70,7 @@ async function runHook(
     preload,
     xdgConfigHome,
     dictionaryPath,
+    agentDir,
   })
   return { ...result, output: JSON.parse(result.stdout) as HookOutput }
 }
@@ -146,6 +148,44 @@ describe("simple-english CLI hook mode", () => {
         'Use "advanced", not "state-of-the-art".',
       )
     }
+  })
+
+  test("resolves a relative legacy config directory from the event directory", async () => {
+    const cwd = await makeProject()
+    const agentDir = join(".pi", "agent")
+    await mkdir(join(cwd, agentDir), { recursive: true })
+    await writeFile(
+      join(cwd, agentDir, "simple-english.json"),
+      JSON.stringify({ rules: { "dictionary-not-approved-word": "off", marketing: "hard" } }),
+    )
+
+    const writeResult = await runHook(
+      event(cwd, "Write", {
+        file_path: join(cwd, "notes.md"),
+        content: "Use robust parts.",
+      }),
+      repoRoot,
+      undefined,
+      undefined,
+      undefined,
+      agentDir,
+    )
+    const sessionResult = await runHook(
+      sessionStartEvent(cwd),
+      repoRoot,
+      undefined,
+      undefined,
+      undefined,
+      agentDir,
+    )
+
+    expect(writeResult.code).toBe(0)
+    expect(decision(writeResult.output).permissionDecision).toBe("deny")
+    expect(decision(writeResult.output).permissionDecisionReason).toContain("[marketing]")
+    expect(sessionResult.code).toBe(0)
+    expect(decision(sessionResult.output).additionalContext).toContain(
+      "[hard] Use factual language",
+    )
   })
 
   test("denies a Write event and lists every hard violation with a suggested fix", async () => {

--- a/test/cli/run-cli.ts
+++ b/test/cli/run-cli.ts
@@ -20,6 +20,7 @@ export interface CliOptions {
   xdgConfigHome?: string
   agentDir?: string
   preload?: string
+  dictionaryPath?: string
 }
 
 export const makeTempDir = (): Promise<string> => mkdtemp(join(tmpdir(), "ste-cli-"))
@@ -34,6 +35,9 @@ export async function runCli(args: string[], options: CliOptions = {}): Promise<
     HOME: home,
     XDG_CONFIG_HOME: options.xdgConfigHome ?? join(home, ".config"),
     PI_CODING_AGENT_DIR: options.agentDir,
+    ...(options.dictionaryPath === undefined
+      ? {}
+      : { SIMPLE_ENGLISH_DICTIONARY: options.dictionaryPath }),
   }
   return new Promise((resolve, reject) => {
     const child = execFile(

--- a/test/extension/claude-plugin.test.ts
+++ b/test/extension/claude-plugin.test.ts
@@ -90,7 +90,9 @@ describe("Claude Code plugin wiring", () => {
 
     expect(commands).toHaveLength(2)
     for (const command of commands) {
-      const match = command.match(/^bun "\$\{CLAUDE_PLUGIN_ROOT\}\/([^"]+)" hook$/u)
+      const match = command.match(
+        /^cd "\$\{CLAUDE_PLUGIN_ROOT\}" && bun "([^"]+)" hook$/u,
+      )
       expect(match).not.toBeNull()
       await expect(access(join(repoRoot, match?.[1] ?? ""))).resolves.toBeUndefined()
     }

--- a/test/extension/claude-plugin.test.ts
+++ b/test/extension/claude-plugin.test.ts
@@ -1,0 +1,98 @@
+import { access, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { describe, expect, test } from "vitest"
+
+interface CommandHook {
+  readonly type: "command"
+  readonly command: string
+}
+
+interface HookRegistration {
+  readonly matcher?: string
+  readonly hooks: readonly CommandHook[]
+}
+
+interface HooksFile {
+  readonly hooks: Readonly<Record<string, readonly HookRegistration[]>>
+}
+
+const repoRoot = process.cwd()
+const pluginManifestPath = join(repoRoot, ".claude-plugin", "plugin.json")
+const marketplaceManifestPath = join(repoRoot, ".claude-plugin", "marketplace.json")
+const hooksPath = join(repoRoot, "hooks", "hooks.json")
+
+async function readJson(path: string): Promise<unknown> {
+  return JSON.parse(await readFile(path, "utf8")) as unknown
+}
+
+describe("Claude Code plugin wiring", () => {
+  test("declares a local marketplace plugin", async () => {
+    const plugin = (await readJson(pluginManifestPath)) as Record<string, unknown>
+    const marketplace = (await readJson(marketplaceManifestPath)) as {
+      name: string
+      plugins: Array<Record<string, unknown>>
+    }
+    const packageManifest = (await readJson(join(repoRoot, "package.json"))) as {
+      version: string
+      files: string[]
+    }
+
+    expect(plugin).toMatchObject({
+      name: "simple-english",
+      version: packageManifest.version,
+      repository: "https://github.com/jyooi/agent-simple-english",
+    })
+    expect(packageManifest.files).toEqual(
+      expect.arrayContaining([".claude-plugin", "hooks", "src"]),
+    )
+    expect(marketplace.name).toBe("agent-simple-english")
+    expect(marketplace.plugins).toEqual([
+      expect.objectContaining({
+        name: "simple-english",
+        version: packageManifest.version,
+        source: "./",
+      }),
+    ])
+  })
+
+  test("registers only the SessionStart and gated PreToolUse hooks", async () => {
+    const hookFile = (await readJson(hooksPath)) as HooksFile
+
+    expect(Object.keys(hookFile.hooks).sort()).toEqual(["PreToolUse", "SessionStart"])
+    expect(hookFile.hooks.SessionStart).toEqual([
+      {
+        hooks: [
+          expect.objectContaining({
+            type: "command",
+            command: expect.stringContaining('src/cli/main.ts" hook'),
+          }),
+        ],
+      },
+    ])
+    expect(hookFile.hooks.PreToolUse).toEqual([
+      {
+        matcher: "Write|Edit|Bash",
+        hooks: [
+          expect.objectContaining({
+            type: "command",
+            command: expect.stringContaining('src/cli/main.ts" hook'),
+          }),
+        ],
+      },
+    ])
+  })
+
+  test("references CLI entry points that exist in the plugin", async () => {
+    const hookFile = (await readJson(hooksPath)) as HooksFile
+    const commands = Object.values(hookFile.hooks).flatMap((registrations) =>
+      registrations.flatMap((registration) => registration.hooks.map((hook) => hook.command)),
+    )
+
+    expect(commands).toHaveLength(2)
+    for (const command of commands) {
+      const match = command.match(/^bun "\$\{CLAUDE_PLUGIN_ROOT\}\/([^"]+)" hook$/u)
+      expect(match).not.toBeNull()
+      await expect(access(join(repoRoot, match?.[1] ?? ""))).resolves.toBeUndefined()
+    }
+  })
+})

--- a/test/extension/claude-plugin.test.ts
+++ b/test/extension/claude-plugin.test.ts
@@ -90,9 +90,7 @@ describe("Claude Code plugin wiring", () => {
 
     expect(commands).toHaveLength(2)
     for (const command of commands) {
-      const match = command.match(
-        /^cd "\$\{CLAUDE_PLUGIN_ROOT\}" && bun "([^"]+)" hook$/u,
-      )
+      const match = command.match(/^cd "\$\{CLAUDE_PLUGIN_ROOT\}" && bun "([^"]+)" hook$/u)
       expect(match).not.toBeNull()
       await expect(access(join(repoRoot, match?.[1] ?? ""))).resolves.toBeUndefined()
     }


### PR DESCRIPTION
## Intent

Implement HUF-151 as an installable local Claude Code plugin that makes STE gates active in each session. Register only SessionStart and PreToolUse hooks for Write, Edit, and Bash. SessionStart must inject the shared rule summary from merged host-neutral config and honor severity overrides. PreToolUse must invoke existing CLI Hook mode without changing HUF-150 gate behavior. Hard write, edit, and static commit violations must block with actionable feedback. Clean retries and compliant static commit messages must pass. Soft violations must warn without blocking. Add local marketplace and plugin manifests with automatic hook registration and no manual settings. Add static plugin tests that parse files and verify referenced CLI paths without running Claude Code. Document local plugin installation plus write, edit, and commit behavior in README. Exclude UserPromptSubmit, Stop, slash commands, strict mode, marketplace publication, npm publication, and Linear changes.

## What Changed

- Add local marketplace and plugin manifests, automatic hook registration, installation guidance, and static wiring tests.
- Add SessionStart context from the shared rule summary, including merged severity and sentence-limit settings.
- Extend CLI Hook mode while preserving write, edit, and commit gates plus event-relative config and dictionary paths.

## Risk Assessment

✅ Low: The change is small, preserves existing gates, and adds direct checks for plugin files and event paths.

## Testing

No prior baseline command was reported. Targeted tests and direct CLI events confirmed manifests, session rules, blocks, warnings, and clean retries. This change has no UI surface, so the CLI transcript supplies reviewer evidence.

<details>
<summary>Evidence: Claude Code hook end-to-end transcript</summary>

```text
$ cd "${CLAUDE_PLUGIN_ROOT}" && bun "src/cli/main.ts" hook

SESSION START WITH PROJECT OVERRIDES
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n- [hard] Do not use contractions. Write the words in full.\n- [soft] Remove hedging phrases.\n- [soft] Use factual language instead of marketing language.\n- [hard] Use no more than six sentences in one paragraph.\n- [hard] Use an approved single-word verb instead of a phrasal verb.\n- [soft] Do not use semicolons. Write two sentences.\n- [hard] Keep each sentence to 8 words or fewer.\n- [hard] Do not use progressive verb forms.\n- [soft] Prefer active voice.\n- [hard] Do not use perfect verb forms.\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings."}}

HARD WRITE VIOLATION
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STE blocked write for /tmp/no-mistakes-evidence/01KYXMQ6TD0DS0T2RP8GRMGXXY/demo-project/notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

CLEAN WRITE RETRY
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}

HARD EDIT VIOLATION
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STE blocked edit for /tmp/no-mistakes-evidence/01KYXMQ6TD0DS0T2RP8GRMGXXY/demo-project/notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

CLEAN EDIT RETRY
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}

SOFT WRITE VIOLATION
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":"STE warnings for /tmp/no-mistakes-evidence/01KYXMQ6TD0DS0T2RP8GRMGXXY/demo-project/notes.md:\n- line 1, column 16 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences."}}

HARD STATIC COMMIT VIOLATION
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STE blocked commit for commit message:\n- line 1, column 11 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

COMPLIANT STATIC COMMIT
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `hooks/hooks.json:9` - The required &#34;installable local Claude Code plugin that makes STE gates active in each session&#34; fails in projects with a `node_modules` ancestor. Claude runs hooks from the session directory, where Bun disables automatic installation when `node_modules` exists. Package resolution then cannot find the cached plugin dependencies, so imports fail before hook logic starts. SessionStart injects no rules, and PreToolUse does not apply gates. Start both commands in `${CLAUDE_PLUGIN_ROOT}` or install dependencies in `${CLAUDE_PLUGIN_DATA}`. Make the static wiring test enforce this bootstrap.

🔧 Fix: fix: anchor Claude hooks in plugin root
1 error still open:
- 🚨 `hooks/hooks.json:21` - The plugin root change alters HUF-150 path behavior. A relative SIMPLE_ENGLISH_DICTIONARY path now resolves from the plugin cache, fails, and permits hard violations. Resolve that path from the event cwd before dictionary loading.

🔧 Fix: Resolve hook dictionary paths from event directory
1 error still open:
- 🚨 `hooks/hooks.json:21` - The intent requires: &#34;PreToolUse must invoke existing CLI Hook mode without changing HUF-150 gate behavior.&#34; Both `cd` commands change relative `PI_CODING_AGENT_DIR` resolution. A legacy config under the event directory can set `marketing` to `hard`. The loader now searches under the plugin root and uses the soft default, so the write passes. SessionStart also injects the wrong severity. Resolve the relative legacy directory against the `cwd` argument inside the shared config loader.

🔧 Fix: Resolve relative legacy config paths from event directories
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/cli/hook.test.ts test/extension/claude-plugin.test.ts`
- `bunx vitest run test/extension/extension.test.ts -t "injects an STE rule summary that reflects merged active settings"`
- <code>Invoked `cd &#34;${CLAUDE_PLUGIN_ROOT}&#34; &amp;&amp; bun &#34;src/cli/main.ts&#34; hook` with SessionStart and Write, Edit, and Bash events.</code>
- <code>Reviewed `README.md` for local installation, automatic hooks, and write, edit, and commit behavior.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
