### PR TITLE
feat(cli): add Claude Code reply feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The `Stop` hook does not block or change the reply.
 
 At the next `UserPromptSubmit` event, the Adapter adds the pending feedback to the model context.
 The feedback gives the line, column, rule ID, and suggested fix for each hard violation.
-The Adapter then clears the feedback, so it adds each report only one time.
+The Adapter then clears the pending feedback, so it adds each report only one time.
+The session state retains the processed reply identity and ignores duplicate `Stop` events.
 Soft violations do not enter this feedback loop.
 
 Each session has a separate state file under `$XDG_STATE_HOME/simple-english/sessions`.
@@ -136,7 +137,7 @@ It writes one hook result as JSON.
 A `SessionStart` event returns the active rule summary as added context.
 A `PreToolUse` event applies the write, edit, and commit gates that the plugin registers.
 A `Stop` event records hard reply feedback without blocking the reply.
-A `UserPromptSubmit` event adds pending feedback to context and clears its session state.
+A `UserPromptSubmit` event adds pending feedback to context and clears that feedback.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
 The gate allows a valid event when configuration, dictionary, tagger, or file processing fails.
 It adds warning text.

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ The `Stop` hook does not block or change the reply.
 At the next `UserPromptSubmit` event, the Adapter adds the pending feedback to the model context.
 The feedback gives the line, column, rule ID, and suggested fix for each hard violation.
 The Adapter then clears the pending feedback, so it adds each report only one time.
-The session state retains the processed reply identity and ignores duplicate `Stop` events.
-Soft violations do not enter this feedback loop.
+The session state retains the processed reply turn identity and ignores duplicate `Stop` events.
+Clean and soft-only replies leave no pending feedback.
 
 Each session has a separate state file under `$XDG_STATE_HOME/simple-english/sessions`.
 The default state directory is `~/.local/state/simple-english/sessions`.
@@ -139,7 +139,7 @@ A `PreToolUse` event applies the write, edit, and commit gates that the plugin r
 A `Stop` event records hard reply feedback without blocking the reply.
 A `UserPromptSubmit` event adds pending feedback to context and clears that feedback.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
-The gate allows a valid event when configuration, dictionary, tagger, or file processing fails.
+The hook also allows the event when configuration, dictionary, tagger, transcript, state, or file processing fails.
 It adds warning text.
 
 ### Lint files and standard input

--- a/README.md
+++ b/README.md
@@ -67,6 +67,21 @@ It also blocks a detected commit without a static `-m` or `--message` argument.
 A compliant static message passes.
 Soft violations allow the event and add warning text.
 
+### Reply feedback loop
+
+The `Stop` hook checks each finished assistant reply after Claude Code shows it.
+It records only hard violation details in a state file for that Claude Code session.
+The `Stop` hook does not block or change the reply.
+
+At the next `UserPromptSubmit` event, the Adapter adds the pending feedback to the model context.
+The feedback gives the line, column, rule ID, and suggested fix for each hard violation.
+The Adapter then clears the feedback, so it adds each report only one time.
+Soft violations do not enter this feedback loop.
+
+Each session has a separate state file under `$XDG_STATE_HOME/simple-english/sessions`.
+The default state directory is `~/.local/state/simple-english/sessions`.
+Concurrent sessions in one project do not read or clear feedback from another session.
+
 ## Install the pi Adapter
 
 Install [pi](https://pi.dev) first.
@@ -120,6 +135,8 @@ The `hook` subcommand reads one Claude Code hook event from standard input.
 It writes one hook result as JSON.
 A `SessionStart` event returns the active rule summary as added context.
 A `PreToolUse` event applies the write, edit, and commit gates that the plugin registers.
+A `Stop` event records hard reply feedback without blocking the reply.
+A `UserPromptSubmit` event adds pending feedback to context and clears its session state.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
 The gate allows a valid event when configuration, dictionary, tagger, or file processing fails.
 It adds warning text.

--- a/docs/adr/0001-per-host-enforcement-ceiling.md
+++ b/docs/adr/0001-per-host-enforcement-ceiling.md
@@ -7,11 +7,11 @@ We do not reduce all hosts to one common enforcement level or limit new hosts to
 The host ceilings differ.
 Pi gets prompt rules, write and edit gates, commit gates, reply feedback, and strict reply gates.
 Claude Code gets prompt rules through SessionStart and write, edit, and commit gates through PreToolUse.
-Claude Code has no reply check or strict mode.
+It gets deferred reply feedback through Stop and UserPromptSubmit, but it has no strict reply gate.
 We accept and document the host differences.
 
 A host ceiling can increase when its extension surface changes.
-[ADR 0002](0002-claude-code-reply-feedback.md) increases the Claude Code ceiling with deferred reply feedback.
+[ADR 0002](0002-claude-code-reply-feedback.md) defines the Claude Code reply feedback design.
 
 Codex support is deferred, not designed around: its hook system is feature-flagged, intercepts only the Bash tool, and cannot gate `apply_patch` file writes, so its ceiling today is too low to justify an adapter.
 Revisit when Codex hooks stabilize; under this decision that is a new adapter, not a redesign.

--- a/docs/adr/0001-per-host-enforcement-ceiling.md
+++ b/docs/adr/0001-per-host-enforcement-ceiling.md
@@ -11,6 +11,7 @@ Claude Code has no reply check or strict mode.
 We accept and document the host differences.
 
 A host ceiling can increase when its extension surface changes.
+[ADR 0002](0002-claude-code-reply-feedback.md) increases the Claude Code ceiling with deferred reply feedback.
 
 Codex support is deferred, not designed around: its hook system is feature-flagged, intercepts only the Bash tool, and cannot gate `apply_patch` file writes, so its ceiling today is too low to justify an adapter.
 Revisit when Codex hooks stabilize; under this decision that is a new adapter, not a redesign.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -5,9 +5,11 @@ Claude Code now supplies `Stop` and `UserPromptSubmit` hooks that increase its e
 This decision replaces that part of ADR 0001.
 Strict reply gates remain outside the current ceiling.
 
-The `Stop` hook reads the last assistant message from the Claude Code transcript.
+The `Stop` hook reads `last_assistant_message` from the event.
+This event field is authoritative because the transcript can lag behind the completed reply.
+The hook reads the latest assistant transcript entry when the event field is absent.
 It checks the reply and records only hard violation feedback.
-Session state retains the processed transcript entry identity and ignores duplicate `Stop` events.
+Session state retains the processed reply identity and ignores duplicate `Stop` events.
 It does not block or change the completed reply.
 
 The `UserPromptSubmit` hook adds pending feedback to the next model context.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -1,0 +1,24 @@
+# Claude Code reply feedback through deferred injection
+
+ADR 0001 states that the Claude Code Adapter has no reply check.
+Claude Code now supplies `Stop` and `UserPromptSubmit` hooks that increase its enforcement ceiling.
+This decision replaces that part of ADR 0001.
+Strict reply gates remain outside the current ceiling.
+
+The `Stop` hook reads the last assistant message from the Claude Code transcript.
+It checks the reply and records only hard violation feedback.
+It does not block or change the completed reply.
+
+The `UserPromptSubmit` hook adds pending feedback to the next model context.
+It removes the feedback before it returns, so concurrent calls cannot add the same feedback two times.
+Soft violations never enter the saved feedback.
+
+Session state uses one file for each Claude Code session.
+Files are under `$XDG_STATE_HOME/simple-english/sessions`, with `~/.local/state` as the default state root.
+A SHA-256 key from the session ID gives safe, fixed-length file names.
+State writes use a temporary file and an atomic rename.
+Feedback reads claim the file with an atomic rename before removal.
+
+This design keeps feedback separate for concurrent sessions in the same project.
+It also gives later Adapter work one state location for session mode data.
+State and transcript failures allow the hook event and give a warning.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -1,16 +1,16 @@
 # Claude Code reply feedback through deferred injection
 
-ADR 0001 states that the Claude Code Adapter has no reply check.
-Claude Code now supplies `Stop` and `UserPromptSubmit` hooks that increase its enforcement ceiling.
-This decision replaces that part of ADR 0001.
+ADR 0001 defines the per-host enforcement ceiling policy.
+The `Stop` and `UserPromptSubmit` hooks increase the Claude Code enforcement ceiling.
+This decision adds deferred reply feedback to that ceiling.
 Strict reply gates remain outside the current ceiling.
 
 The `Stop` hook reads `last_assistant_message` from the event.
 This event field is authoritative because the transcript can lag behind the completed reply.
-The latest user transcript record gives the reply turn identity.
-The hook reads the latest assistant transcript entry when the event field is absent.
+When the field is present, the latest user transcript record gives the reply turn identity.
+When the field is absent, the latest assistant transcript entry gives the reply and its identity.
 It checks the reply and records only hard violation feedback.
-Session state retains the processed turn identity and ignores duplicate `Stop` events.
+Session state retains the processed reply turn identity and ignores duplicate `Stop` events.
 It does not block or change the completed reply.
 
 The `UserPromptSubmit` hook adds pending feedback to the next model context.
@@ -22,7 +22,6 @@ Files are under `$XDG_STATE_HOME/simple-english/sessions`, with `~/.local/state`
 A SHA-256 key from the session ID gives safe, fixed-length file names.
 State writes use a temporary file and an atomic rename.
 Feedback reads claim the file with an atomic rename before they clear pending feedback.
-They retain the processed reply identity in the session state.
 
 This design keeps feedback separate for concurrent sessions in the same project.
 It also gives later Adapter work one state location for session mode data.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -7,6 +7,7 @@ Strict reply gates remain outside the current ceiling.
 
 The `Stop` hook reads the last assistant message from the Claude Code transcript.
 It checks the reply and records only hard violation feedback.
+Session state retains the processed transcript entry identity and ignores duplicate `Stop` events.
 It does not block or change the completed reply.
 
 The `UserPromptSubmit` hook adds pending feedback to the next model context.
@@ -17,7 +18,8 @@ Session state uses one file for each Claude Code session.
 Files are under `$XDG_STATE_HOME/simple-english/sessions`, with `~/.local/state` as the default state root.
 A SHA-256 key from the session ID gives safe, fixed-length file names.
 State writes use a temporary file and an atomic rename.
-Feedback reads claim the file with an atomic rename before removal.
+Feedback reads claim the file with an atomic rename before they clear pending feedback.
+They retain the processed reply identity in the session state.
 
 This design keeps feedback separate for concurrent sessions in the same project.
 It also gives later Adapter work one state location for session mode data.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -7,9 +7,10 @@ Strict reply gates remain outside the current ceiling.
 
 The `Stop` hook reads `last_assistant_message` from the event.
 This event field is authoritative because the transcript can lag behind the completed reply.
+The latest user transcript record gives the reply turn identity.
 The hook reads the latest assistant transcript entry when the event field is absent.
 It checks the reply and records only hard violation feedback.
-Session state retains the processed reply identity and ignores duplicate `Stop` events.
+Session state retains the processed turn identity and ignores duplicate `Stop` events.
 It does not block or change the completed reply.
 
 The `UserPromptSubmit` hook adds pending feedback to the next model context.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,23 +1,53 @@
 {
-  "description": "Inject active STE rules and gate writes, edits, and git commit messages.",
+  "description": "Inject active STE rules, gate changes, and return reply feedback on the next prompt.",
+
   "hooks": {
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
+
             "command": "cd \"${CLAUDE_PLUGIN_ROOT}\" && bun \"src/cli/main.ts\" hook",
             "timeout": 120
           }
         ]
       }
     ],
+
     "PreToolUse": [
       {
         "matcher": "Write|Edit|Bash",
         "hooks": [
           {
             "type": "command",
+
+            "command": "cd \"${CLAUDE_PLUGIN_ROOT}\" && bun \"src/cli/main.ts\" hook",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+
+            "command": "cd \"${CLAUDE_PLUGIN_ROOT}\" && bun \"src/cli/main.ts\" hook",
+            "timeout": 120
+          }
+        ]
+      }
+    ],
+
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+
             "command": "cd \"${CLAUDE_PLUGIN_ROOT}\" && bun \"src/cli/main.ts\" hook",
             "timeout": 120
           }

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -12,11 +12,7 @@ import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
 import type { LintOptions, Violation } from "../engine/types.ts"
 import { TaggerService } from "../tagger/wink.ts"
-import {
-  consumePendingFeedback,
-  hasProcessedReply,
-  setReplyFeedback,
-} from "./session-state.ts"
+import { consumePendingFeedback, hasProcessedReply, setReplyFeedback } from "./session-state.ts"
 
 interface CommonEvent {
   readonly cwd: string
@@ -532,9 +528,9 @@ function recordReplyFeedback(
   tagger: Tagger,
 ): Effect.Effect<Record<string, never>, Error> {
   return Effect.gen(function* () {
-    const reply = yield* (event.lastAssistantMessage === undefined
+    const reply = yield* event.lastAssistantMessage === undefined
       ? readAssistantReply(event.transcriptPath)
-      : readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath))
+      : readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath)
     if (yield* replyWasProcessed(event.sessionId, reply.identity)) return {}
     const options = yield* loadLintOptions(event.cwd, tagger)
     const hard = lint("prose-file", reply.text, options).violations.filter(

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -253,58 +253,146 @@ function assistantReply(line: string, path: string, offset: number): AssistantRe
   return { identity, text }
 }
 
-function assistantReplyFromChunks(
-  chunks: readonly Buffer[],
-  path: string,
-  offset: number,
-): AssistantReply | undefined {
-  const first = chunks[0]
-  const line =
-    first === undefined
-      ? ""
-      : chunks.length === 1
-        ? first.toString("utf8")
-        : Buffer.concat(chunks).toString("utf8")
-  return assistantReply(line, path, offset)
+const TRANSCRIPT_CHUNK_SIZE = 64 * 1024
+const TRANSCRIPT_ENTRY_HEADER_SIZE = 64 * 1024
+
+type TranscriptEntryKind = "assistant" | "other" | "unknown"
+
+interface JsonFrame {
+  readonly kind: "array" | "object"
+  readonly message: boolean
+  key?: string
 }
 
-const TRANSCRIPT_CHUNK_SIZE = 64 * 1024
+function jsonStringEnd(text: string, start: number): number | undefined {
+  let escaped = false
+  for (let index = start + 1; index < text.length; index += 1) {
+    const character = text[index]
+    if (escaped) {
+      escaped = false
+    } else if (character === "\\") {
+      escaped = true
+    } else if (character === '"') {
+      return index
+    }
+  }
+  return undefined
+}
+
+function transcriptEntryKind(header: string): TranscriptEntryKind {
+  const stack: JsonFrame[] = []
+  for (let index = 0; index < header.length; index += 1) {
+    const character = header[index]
+    if (character === '"') {
+      const end = jsonStringEnd(header, index)
+      if (end === undefined) return "unknown"
+      const frame = stack.at(-1)
+      if (frame?.kind === "object") {
+        const value = JSON.parse(header.slice(index, end + 1)) as string
+        let next = end + 1
+        while (/\s/.test(header[next] ?? "")) next += 1
+        if (header[next] === ":") {
+          frame.key = value
+          index = next
+          continue
+        }
+        if (stack.length === 1 && frame.key === "type") {
+          return value === "assistant" ? "assistant" : "other"
+        }
+        if (frame.message && frame.key === "role") {
+          return value === "assistant" ? "assistant" : "other"
+        }
+        frame.key = undefined
+      }
+      index = end
+      continue
+    }
+    if (character === "{") {
+      const parent = stack.at(-1)
+      const message = parent?.kind === "object" && stack.length === 1 && parent.key === "message"
+      if (parent?.kind === "object") parent.key = undefined
+      stack.push({ kind: "object", message })
+      continue
+    }
+    if (character === "[") {
+      const parent = stack.at(-1)
+      if (parent?.kind === "object") parent.key = undefined
+      stack.push({ kind: "array", message: false })
+      continue
+    }
+    if (character === "}" || character === "]") {
+      stack.pop()
+      continue
+    }
+    if (character === ",") {
+      const frame = stack.at(-1)
+      if (frame?.kind === "object") frame.key = undefined
+    }
+  }
+  return "unknown"
+}
+
+async function readTranscriptRange(
+  file: Awaited<ReturnType<typeof open>>,
+  path: string,
+  position: number,
+  length: number,
+): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(length)
+  let offset = 0
+  while (offset < length) {
+    const { bytesRead } = await file.read(buffer, offset, length - offset, position + offset)
+    if (bytesRead === 0) throw new Error(`transcript changed while reading ${path}`)
+    offset += bytesRead
+  }
+  return buffer
+}
+
+async function assistantReplyInRange(
+  file: Awaited<ReturnType<typeof open>>,
+  path: string,
+  start: number,
+  end: number,
+): Promise<AssistantReply | undefined> {
+  const length = end - start
+  const headerLength = Math.min(length, TRANSCRIPT_ENTRY_HEADER_SIZE)
+  const header = await readTranscriptRange(file, path, start, headerLength)
+  if (transcriptEntryKind(header.toString("utf8")) !== "assistant") return undefined
+  const line =
+    headerLength === length
+      ? header.toString("utf8")
+      : (await readTranscriptRange(file, path, start, length)).toString("utf8")
+  return assistantReply(line, path, start)
+}
 
 async function assistantReplyFromTranscript(path: string): Promise<AssistantReply> {
   const file = await open(path, "r")
   try {
     const { size } = await file.stat()
     let position = size
-    let pendingLine: Buffer[] = []
+    let entryEnd = size
 
     while (position > 0) {
       const length = Math.min(TRANSCRIPT_CHUNK_SIZE, position)
       position -= length
-      const chunk = Buffer.allocUnsafe(length)
-      let offset = 0
-      while (offset < length) {
-        const { bytesRead } = await file.read(chunk, offset, length - offset, position + offset)
-        if (bytesRead === 0) throw new Error(`transcript changed while reading ${path}`)
-        offset += bytesRead
-      }
-
+      const chunk = await readTranscriptRange(file, path, position, length)
       let lineEnd = chunk.length
       for (;;) {
         const newline = chunk.lastIndexOf(10, lineEnd - 1)
         if (newline === -1) break
-        const lineHead = chunk.subarray(newline + 1, lineEnd)
-        const lineChunks = lineHead.length === 0 ? pendingLine : [lineHead, ...pendingLine]
-        const reply = assistantReplyFromChunks(lineChunks, path, position + newline + 1)
-        if (reply !== undefined) return reply
-        pendingLine = []
+        const entryStart = position + newline + 1
+        if (entryStart < entryEnd) {
+          const reply = await assistantReplyInRange(file, path, entryStart, entryEnd)
+          if (reply !== undefined) return reply
+        }
+        entryEnd = position + newline
         lineEnd = newline
       }
+    }
 
-      if (lineEnd > 0) pendingLine = [chunk.subarray(0, lineEnd), ...pendingLine]
-      if (position === 0) {
-        const reply = assistantReplyFromChunks(pendingLine, path, 0)
-        if (reply !== undefined) return reply
-      }
+    if (entryEnd > 0) {
+      const reply = await assistantReplyInRange(file, path, 0, entryEnd)
+      if (reply !== undefined) return reply
     }
     throw new Error(`cannot find an assistant reply in ${path}`)
   } finally {

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { open, readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { Cause, Effect } from "effect"
 import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-message.ts"
@@ -210,40 +210,91 @@ const readEditFile = (path: string) =>
     catch: (cause) => new Error(`cannot read edit file ${path}: ${cause}`),
   })
 
-function assistantReply(raw: string, path: string): string {
-  for (const line of raw.split("\n").reverse()) {
-    if (line.trim() === "") continue
-    let value: unknown
-    try {
-      value = JSON.parse(line) as unknown
-    } catch {
-      continue
-    }
-    if (typeof value !== "object" || value === null || Array.isArray(value)) continue
-    const entry = value as Record<string, unknown>
-    if (entry.type !== "assistant") continue
-    const message = record(entry.message, "assistant transcript message")
-    const content = message.content
-    if (!Array.isArray(content)) {
-      throw new Error(`assistant transcript message in ${path} must contain content blocks`)
-    }
-    return content
-      .filter(
-        (block): block is { type: "text"; text: string } =>
-          typeof block === "object" &&
-          block !== null &&
-          (block as Record<string, unknown>).type === "text" &&
-          typeof (block as Record<string, unknown>).text === "string",
-      )
-      .map((block) => block.text)
-      .join("\n")
+function assistantReply(line: string, path: string): string | undefined {
+  let value: unknown
+  try {
+    value = JSON.parse(line) as unknown
+  } catch {
+    return undefined
   }
-  throw new Error(`cannot find an assistant reply in ${path}`)
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const entry = value as Record<string, unknown>
+  if (entry.type !== "assistant") return undefined
+  const message = record(entry.message, "assistant transcript message")
+  const content = message.content
+  if (!Array.isArray(content)) {
+    throw new Error(`assistant transcript message in ${path} must contain content blocks`)
+  }
+  return content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as Record<string, unknown>).type === "text" &&
+        typeof (block as Record<string, unknown>).text === "string",
+    )
+    .map((block) => block.text)
+    .join("\n")
+}
+
+function assistantReplyFromChunks(chunks: readonly Buffer[], path: string): string | undefined {
+  const first = chunks[0]
+  const line =
+    first === undefined
+      ? ""
+      : chunks.length === 1
+        ? first.toString("utf8")
+        : Buffer.concat(chunks).toString("utf8")
+  return assistantReply(line, path)
+}
+
+const TRANSCRIPT_CHUNK_SIZE = 64 * 1024
+
+async function assistantReplyFromTranscript(path: string): Promise<string> {
+  const file = await open(path, "r")
+  try {
+    const { size } = await file.stat()
+    let position = size
+    let pendingLine: Buffer[] = []
+
+    while (position > 0) {
+      const length = Math.min(TRANSCRIPT_CHUNK_SIZE, position)
+      position -= length
+      const chunk = Buffer.allocUnsafe(length)
+      let offset = 0
+      while (offset < length) {
+        const { bytesRead } = await file.read(chunk, offset, length - offset, position + offset)
+        if (bytesRead === 0) throw new Error(`transcript changed while reading ${path}`)
+        offset += bytesRead
+      }
+
+      let lineEnd = chunk.length
+      for (;;) {
+        const newline = chunk.lastIndexOf(10, lineEnd - 1)
+        if (newline === -1) break
+        const lineHead = chunk.subarray(newline + 1, lineEnd)
+        const lineChunks = lineHead.length === 0 ? pendingLine : [lineHead, ...pendingLine]
+        const reply = assistantReplyFromChunks(lineChunks, path)
+        if (reply !== undefined) return reply
+        pendingLine = []
+        lineEnd = newline
+      }
+
+      if (lineEnd > 0) pendingLine = [chunk.subarray(0, lineEnd), ...pendingLine]
+      if (position === 0) {
+        const reply = assistantReplyFromChunks(pendingLine, path)
+        if (reply !== undefined) return reply
+      }
+    }
+    throw new Error(`cannot find an assistant reply in ${path}`)
+  } finally {
+    await file.close()
+  }
 }
 
 const readAssistantReply = (path: string) =>
   Effect.tryPromise({
-    try: async () => assistantReply(await readFile(path, "utf8"), path),
+    try: () => assistantReplyFromTranscript(path),
     catch: (cause) => new Error(`cannot read assistant reply from ${path}: ${cause}`),
   })
 

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { open, readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { Cause, Effect } from "effect"
@@ -11,7 +12,11 @@ import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
 import type { LintOptions, Violation } from "../engine/types.ts"
 import { TaggerService } from "../tagger/wink.ts"
-import { consumePendingFeedback, setPendingFeedback } from "./session-state.ts"
+import {
+  consumePendingFeedback,
+  hasProcessedReply,
+  setReplyFeedback,
+} from "./session-state.ts"
 
 interface CommonEvent {
   readonly cwd: string
@@ -210,7 +215,12 @@ const readEditFile = (path: string) =>
     catch: (cause) => new Error(`cannot read edit file ${path}: ${cause}`),
   })
 
-function assistantReply(line: string, path: string): string | undefined {
+interface AssistantReply {
+  readonly identity: string
+  readonly text: string
+}
+
+function assistantReply(line: string, path: string, offset: number): AssistantReply | undefined {
   let value: unknown
   try {
     value = JSON.parse(line) as unknown
@@ -225,7 +235,12 @@ function assistantReply(line: string, path: string): string | undefined {
   if (!Array.isArray(content)) {
     throw new Error(`assistant transcript message in ${path} must contain content blocks`)
   }
-  return content
+  const uuid = entry.uuid
+  const identity =
+    typeof uuid === "string" && uuid.length > 0
+      ? `uuid:${uuid}`
+      : `offset:${offset}:${createHash("sha256").update(line).digest("hex")}`
+  const text = content
     .filter(
       (block): block is { type: "text"; text: string } =>
         typeof block === "object" &&
@@ -235,9 +250,14 @@ function assistantReply(line: string, path: string): string | undefined {
     )
     .map((block) => block.text)
     .join("\n")
+  return { identity, text }
 }
 
-function assistantReplyFromChunks(chunks: readonly Buffer[], path: string): string | undefined {
+function assistantReplyFromChunks(
+  chunks: readonly Buffer[],
+  path: string,
+  offset: number,
+): AssistantReply | undefined {
   const first = chunks[0]
   const line =
     first === undefined
@@ -245,12 +265,12 @@ function assistantReplyFromChunks(chunks: readonly Buffer[], path: string): stri
       : chunks.length === 1
         ? first.toString("utf8")
         : Buffer.concat(chunks).toString("utf8")
-  return assistantReply(line, path)
+  return assistantReply(line, path, offset)
 }
 
 const TRANSCRIPT_CHUNK_SIZE = 64 * 1024
 
-async function assistantReplyFromTranscript(path: string): Promise<string> {
+async function assistantReplyFromTranscript(path: string): Promise<AssistantReply> {
   const file = await open(path, "r")
   try {
     const { size } = await file.stat()
@@ -274,7 +294,7 @@ async function assistantReplyFromTranscript(path: string): Promise<string> {
         if (newline === -1) break
         const lineHead = chunk.subarray(newline + 1, lineEnd)
         const lineChunks = lineHead.length === 0 ? pendingLine : [lineHead, ...pendingLine]
-        const reply = assistantReplyFromChunks(lineChunks, path)
+        const reply = assistantReplyFromChunks(lineChunks, path, position + newline + 1)
         if (reply !== undefined) return reply
         pendingLine = []
         lineEnd = newline
@@ -282,7 +302,7 @@ async function assistantReplyFromTranscript(path: string): Promise<string> {
 
       if (lineEnd > 0) pendingLine = [chunk.subarray(0, lineEnd), ...pendingLine]
       if (position === 0) {
-        const reply = assistantReplyFromChunks(pendingLine, path)
+        const reply = assistantReplyFromChunks(pendingLine, path, 0)
         if (reply !== undefined) return reply
       }
     }
@@ -298,9 +318,19 @@ const readAssistantReply = (path: string) =>
     catch: (cause) => new Error(`cannot read assistant reply from ${path}: ${cause}`),
   })
 
-const updatePendingFeedback = (sessionId: string, feedback: string | undefined) =>
+const replyWasProcessed = (sessionId: string, replyIdentity: string) =>
   Effect.tryPromise({
-    try: () => setPendingFeedback(sessionId, feedback),
+    try: () => hasProcessedReply(sessionId, replyIdentity),
+    catch: (cause) => new Error(`cannot read session state: ${cause}`),
+  })
+
+const updateReplyFeedback = (
+  sessionId: string,
+  replyIdentity: string,
+  feedback: string | undefined,
+) =>
+  Effect.tryPromise({
+    try: () => setReplyFeedback(sessionId, replyIdentity, feedback),
     catch: (cause) => new Error(`cannot update session state: ${cause}`),
   })
 
@@ -355,16 +385,17 @@ function recordReplyFeedback(
   tagger: Tagger,
 ): Effect.Effect<Record<string, never>, Error> {
   return Effect.gen(function* () {
-    const options = yield* loadLintOptions(event.cwd, tagger)
     const reply = yield* readAssistantReply(event.transcriptPath)
-    const hard = lint("prose-file", reply, options).violations.filter(
+    if (yield* replyWasProcessed(event.sessionId, reply.identity)) return {}
+    const options = yield* loadLintOptions(event.cwd, tagger)
+    const hard = lint("prose-file", reply.text, options).violations.filter(
       (violation) => violation.severity === "hard",
     )
     const feedback =
       hard.length === 0
         ? undefined
         : formatViolations("assistant reply", "STE reply feedback for", hard)
-    yield* updatePendingFeedback(event.sessionId, feedback)
+    yield* updateReplyFeedback(event.sessionId, reply.identity, feedback)
     return {}
   })
 }

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -52,6 +52,7 @@ interface BashEvent extends CommonEvent {
 
 interface StopEvent extends CommonEvent {
   readonly hookEventName: "Stop"
+  readonly lastAssistantMessage?: string
 }
 
 interface UserPromptSubmitEvent extends CommonEvent {
@@ -108,7 +109,17 @@ function decodeEvent(raw: string): HookEvent {
     transcriptPath: stringField(event, "transcript_path"),
   }
   if (hookEventName === "SessionStart") return { ...common, hookEventName }
-  if (hookEventName === "Stop") return { ...common, hookEventName }
+  if (hookEventName === "Stop") {
+    const lastAssistantMessage = event.last_assistant_message
+    if (lastAssistantMessage !== undefined && typeof lastAssistantMessage !== "string") {
+      throw new Error("last_assistant_message must be a string")
+    }
+    return {
+      ...common,
+      hookEventName,
+      ...(lastAssistantMessage === undefined ? {} : { lastAssistantMessage }),
+    }
+  }
   if (hookEventName === "UserPromptSubmit") return { ...common, hookEventName }
   if (hookEventName !== "PreToolUse") {
     throw new Error("hook_event_name must be SessionStart, PreToolUse, Stop, or UserPromptSubmit")
@@ -400,6 +411,13 @@ async function assistantReplyFromTranscript(path: string): Promise<AssistantRepl
   }
 }
 
+function assistantReplyFromEvent(text: string): AssistantReply {
+  return {
+    identity: `message:${createHash("sha256").update(text).digest("hex")}`,
+    text,
+  }
+}
+
 const readAssistantReply = (path: string) =>
   Effect.tryPromise({
     try: () => assistantReplyFromTranscript(path),
@@ -473,7 +491,10 @@ function recordReplyFeedback(
   tagger: Tagger,
 ): Effect.Effect<Record<string, never>, Error> {
   return Effect.gen(function* () {
-    const reply = yield* readAssistantReply(event.transcriptPath)
+    const reply =
+      event.lastAssistantMessage === undefined
+        ? yield* readAssistantReply(event.transcriptPath)
+        : assistantReplyFromEvent(event.lastAssistantMessage)
     if (yield* replyWasProcessed(event.sessionId, reply.identity)) return {}
     const options = yield* loadLintOptions(event.cwd, tagger)
     const hard = lint("prose-file", reply.text, options).violations.filter(

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -267,7 +267,7 @@ function assistantReply(line: string, path: string, offset: number): AssistantRe
 const TRANSCRIPT_CHUNK_SIZE = 64 * 1024
 const TRANSCRIPT_ENTRY_HEADER_SIZE = 64 * 1024
 
-type TranscriptEntryKind = "assistant" | "other" | "unknown"
+type TranscriptEntryKind = "assistant" | "user" | "other" | "unknown"
 
 interface JsonFrame {
   readonly kind: "array" | "object"
@@ -308,10 +308,12 @@ function transcriptEntryKind(header: string): TranscriptEntryKind {
           continue
         }
         if (stack.length === 1 && frame.key === "type") {
-          return value === "assistant" ? "assistant" : "other"
+          if (value === "assistant" || value === "user") return value
+          return "other"
         }
         if (frame.message && frame.key === "role") {
-          return value === "assistant" ? "assistant" : "other"
+          if (value === "assistant" || value === "user") return value
+          return "other"
         }
         frame.key = undefined
       }
@@ -376,7 +378,39 @@ async function assistantReplyInRange(
   return assistantReply(line, path, start)
 }
 
-async function assistantReplyFromTranscript(path: string): Promise<AssistantReply> {
+async function turnIdentityInRange(
+  file: Awaited<ReturnType<typeof open>>,
+  path: string,
+  start: number,
+  end: number,
+): Promise<string | undefined> {
+  const length = end - start
+  const headerLength = Math.min(length, TRANSCRIPT_ENTRY_HEADER_SIZE)
+  const header = await readTranscriptRange(file, path, start, headerLength)
+  if (transcriptEntryKind(header.toString("utf8")) !== "user") return undefined
+  if (headerLength === length) {
+    try {
+      const value = JSON.parse(header.toString("utf8")) as unknown
+      if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+        const uuid = (value as Record<string, unknown>).uuid
+        if (typeof uuid === "string" && uuid.length > 0) return `turn-uuid:${uuid}`
+      }
+    } catch {
+      return `turn-offset:${start}:${createHash("sha256").update(header).digest("hex")}`
+    }
+  }
+  return `turn-offset:${start}:${createHash("sha256").update(header).digest("hex")}`
+}
+
+async function latestTranscriptEntry<T>(
+  path: string,
+  readEntry: (
+    file: Awaited<ReturnType<typeof open>>,
+    path: string,
+    start: number,
+    end: number,
+  ) => Promise<T | undefined>,
+): Promise<T | undefined> {
   const file = await open(path, "r")
   try {
     const { size } = await file.stat()
@@ -393,35 +427,42 @@ async function assistantReplyFromTranscript(path: string): Promise<AssistantRepl
         if (newline === -1) break
         const entryStart = position + newline + 1
         if (entryStart < entryEnd) {
-          const reply = await assistantReplyInRange(file, path, entryStart, entryEnd)
-          if (reply !== undefined) return reply
+          const entry = await readEntry(file, path, entryStart, entryEnd)
+          if (entry !== undefined) return entry
         }
         entryEnd = position + newline
         lineEnd = newline
       }
     }
 
-    if (entryEnd > 0) {
-      const reply = await assistantReplyInRange(file, path, 0, entryEnd)
-      if (reply !== undefined) return reply
-    }
-    throw new Error(`cannot find an assistant reply in ${path}`)
+    return entryEnd > 0 ? readEntry(file, path, 0, entryEnd) : undefined
   } finally {
     await file.close()
   }
 }
 
-function assistantReplyFromEvent(text: string): AssistantReply {
-  return {
-    identity: `message:${createHash("sha256").update(text).digest("hex")}`,
-    text,
-  }
+async function assistantReplyFromTranscript(path: string): Promise<AssistantReply> {
+  const reply = await latestTranscriptEntry(path, assistantReplyInRange)
+  if (reply !== undefined) return reply
+  throw new Error(`cannot find an assistant reply in ${path}`)
+}
+
+async function assistantReplyFromEvent(text: string, path: string): Promise<AssistantReply> {
+  const identity = await latestTranscriptEntry(path, turnIdentityInRange)
+  if (identity === undefined) throw new Error(`cannot find a reply turn in ${path}`)
+  return { identity, text }
 }
 
 const readAssistantReply = (path: string) =>
   Effect.tryPromise({
     try: () => assistantReplyFromTranscript(path),
     catch: (cause) => new Error(`cannot read assistant reply from ${path}: ${cause}`),
+  })
+
+const readEventAssistantReply = (text: string, path: string) =>
+  Effect.tryPromise({
+    try: () => assistantReplyFromEvent(text, path),
+    catch: (cause) => new Error(`cannot read assistant reply turn from ${path}: ${cause}`),
   })
 
 const replyWasProcessed = (sessionId: string, replyIdentity: string) =>
@@ -491,10 +532,9 @@ function recordReplyFeedback(
   tagger: Tagger,
 ): Effect.Effect<Record<string, never>, Error> {
   return Effect.gen(function* () {
-    const reply =
-      event.lastAssistantMessage === undefined
-        ? yield* readAssistantReply(event.transcriptPath)
-        : assistantReplyFromEvent(event.lastAssistantMessage)
+    const reply = yield* (event.lastAssistantMessage === undefined
+      ? readAssistantReply(event.transcriptPath)
+      : readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath))
     if (yield* replyWasProcessed(event.sessionId, reply.identity)) return {}
     const options = yield* loadLintOptions(event.cwd, tagger)
     const hard = lint("prose-file", reply.text, options).violations.filter(

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -11,22 +11,26 @@ import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
 import type { LintOptions, Violation } from "../engine/types.ts"
 import { TaggerService } from "../tagger/wink.ts"
+import { consumePendingFeedback, setPendingFeedback } from "./session-state.ts"
 
-interface SessionStartEvent {
+interface CommonEvent {
   readonly cwd: string
+  readonly sessionId: string
+  readonly transcriptPath: string
+}
+
+interface SessionStartEvent extends CommonEvent {
   readonly hookEventName: "SessionStart"
 }
 
-interface WriteEvent {
-  readonly cwd: string
+interface WriteEvent extends CommonEvent {
   readonly hookEventName: "PreToolUse"
   readonly toolName: "Write"
   readonly filePath: string
   readonly content: string
 }
 
-interface EditEvent {
-  readonly cwd: string
+interface EditEvent extends CommonEvent {
   readonly hookEventName: "PreToolUse"
   readonly toolName: "Edit"
   readonly filePath: string
@@ -35,15 +39,22 @@ interface EditEvent {
   readonly replaceAll: boolean
 }
 
-interface BashEvent {
-  readonly cwd: string
+interface BashEvent extends CommonEvent {
   readonly hookEventName: "PreToolUse"
   readonly toolName: "Bash"
   readonly command: string
 }
 
+interface StopEvent extends CommonEvent {
+  readonly hookEventName: "Stop"
+}
+
+interface UserPromptSubmitEvent extends CommonEvent {
+  readonly hookEventName: "UserPromptSubmit"
+}
+
 type PreToolUseEvent = WriteEvent | EditEvent | BashEvent
-type HookEvent = SessionStartEvent | PreToolUseEvent
+type HookEvent = SessionStartEvent | PreToolUseEvent | StopEvent | UserPromptSubmitEvent
 
 interface HookSpecificOutput {
   readonly hookEventName: "PreToolUse"
@@ -56,9 +67,9 @@ interface HookDecision {
   readonly hookSpecificOutput: HookSpecificOutput
 }
 
-interface SessionStartOutput {
+interface ContextOutput {
   readonly hookSpecificOutput: {
-    readonly hookEventName: "SessionStart"
+    readonly hookEventName: "SessionStart" | "UserPromptSubmit"
     readonly additionalContext: string
   }
 }
@@ -68,7 +79,7 @@ interface HookError {
   readonly systemMessage: string
 }
 
-export type HookOutput = HookDecision | SessionStartOutput | HookError
+export type HookOutput = HookDecision | ContextOutput | HookError | Record<string, never>
 
 function record(value: unknown, name: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -86,17 +97,23 @@ function stringField(value: Record<string, unknown>, name: string): string {
 function decodeEvent(raw: string): HookEvent {
   const event = record(JSON.parse(raw) as unknown, "event")
   const hookEventName = stringField(event, "hook_event_name")
-  const cwd = stringField(event, "cwd")
-  if (hookEventName === "SessionStart") return { cwd, hookEventName }
+  const common = {
+    cwd: stringField(event, "cwd"),
+    sessionId: stringField(event, "session_id"),
+    transcriptPath: stringField(event, "transcript_path"),
+  }
+  if (hookEventName === "SessionStart") return { ...common, hookEventName }
+  if (hookEventName === "Stop") return { ...common, hookEventName }
+  if (hookEventName === "UserPromptSubmit") return { ...common, hookEventName }
   if (hookEventName !== "PreToolUse") {
-    throw new Error("hook_event_name must be SessionStart or PreToolUse")
+    throw new Error("hook_event_name must be SessionStart, PreToolUse, Stop, or UserPromptSubmit")
   }
   const toolName = stringField(event, "tool_name")
   const input = record(event.tool_input, "tool_input")
 
   if (toolName === "Write") {
     return {
-      cwd,
+      ...common,
       hookEventName,
       toolName,
       filePath: stringField(input, "file_path"),
@@ -109,7 +126,7 @@ function decodeEvent(raw: string): HookEvent {
       throw new Error("replace_all must be a boolean")
     }
     return {
-      cwd,
+      ...common,
       hookEventName,
       toolName,
       filePath: stringField(input, "file_path"),
@@ -119,7 +136,7 @@ function decodeEvent(raw: string): HookEvent {
     }
   }
   if (toolName === "Bash") {
-    return { cwd, hookEventName, toolName, command: stringField(input, "command") }
+    return { ...common, hookEventName, toolName, command: stringField(input, "command") }
   }
   throw new Error(`unsupported PreToolUse tool: ${toolName}`)
 }
@@ -144,10 +161,13 @@ function deny(reason: string): HookDecision {
   }
 }
 
-function addSessionContext(context: string): SessionStartOutput {
+function addContext(
+  hookEventName: "SessionStart" | "UserPromptSubmit",
+  context: string,
+): ContextOutput {
   return {
     hookSpecificOutput: {
-      hookEventName: "SessionStart",
+      hookEventName,
       additionalContext: context,
     },
   }
@@ -190,6 +210,55 @@ const readEditFile = (path: string) =>
     catch: (cause) => new Error(`cannot read edit file ${path}: ${cause}`),
   })
 
+function assistantReply(raw: string, path: string): string {
+  for (const line of raw.split("\n").reverse()) {
+    if (line.trim() === "") continue
+    let value: unknown
+    try {
+      value = JSON.parse(line) as unknown
+    } catch {
+      continue
+    }
+    if (typeof value !== "object" || value === null || Array.isArray(value)) continue
+    const entry = value as Record<string, unknown>
+    if (entry.type !== "assistant") continue
+    const message = record(entry.message, "assistant transcript message")
+    const content = message.content
+    if (!Array.isArray(content)) {
+      throw new Error(`assistant transcript message in ${path} must contain content blocks`)
+    }
+    return content
+      .filter(
+        (block): block is { type: "text"; text: string } =>
+          typeof block === "object" &&
+          block !== null &&
+          (block as Record<string, unknown>).type === "text" &&
+          typeof (block as Record<string, unknown>).text === "string",
+      )
+      .map((block) => block.text)
+      .join("\n")
+  }
+  throw new Error(`cannot find an assistant reply in ${path}`)
+}
+
+const readAssistantReply = (path: string) =>
+  Effect.tryPromise({
+    try: async () => assistantReply(await readFile(path, "utf8"), path),
+    catch: (cause) => new Error(`cannot read assistant reply from ${path}: ${cause}`),
+  })
+
+const updatePendingFeedback = (sessionId: string, feedback: string | undefined) =>
+  Effect.tryPromise({
+    try: () => setPendingFeedback(sessionId, feedback),
+    catch: (cause) => new Error(`cannot update session state: ${cause}`),
+  })
+
+const takePendingFeedback = (sessionId: string) =>
+  Effect.tryPromise({
+    try: () => consumePendingFeedback(sessionId),
+    catch: (cause) => new Error(`cannot read session state: ${cause}`),
+  })
+
 const loadLintOptions = (cwd: string, tagger: Tagger) => {
   const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
   return Effect.all({
@@ -228,6 +297,25 @@ function textDecision(
     return deny(formatViolations(path, `STE blocked ${operation} for`, hard))
   }
   return allow(soft.length === 0 ? [] : [formatViolations(path, "STE warnings for", soft)])
+}
+
+function recordReplyFeedback(
+  event: StopEvent,
+  tagger: Tagger,
+): Effect.Effect<Record<string, never>, Error> {
+  return Effect.gen(function* () {
+    const options = yield* loadLintOptions(event.cwd, tagger)
+    const reply = yield* readAssistantReply(event.transcriptPath)
+    const hard = lint("prose-file", reply, options).violations.filter(
+      (violation) => violation.severity === "hard",
+    )
+    const feedback =
+      hard.length === 0
+        ? undefined
+        : formatViolations("assistant reply", "STE reply feedback for", hard)
+    yield* updatePendingFeedback(event.sessionId, feedback)
+    return {}
+  })
 }
 
 function evaluateEvent(event: PreToolUseEvent, tagger: Tagger): Effect.Effect<HookDecision, Error> {
@@ -282,8 +370,28 @@ export function runHookMode(raw: string): Effect.Effect<HookOutput, never, Tagge
           return loadConfig(undefined, event.cwd).pipe(
             Effect.match({
               onFailure: (error) => nonBlockingError(error.message),
-              onSuccess: (config) => addSessionContext(ruleSummary(config)),
+              onSuccess: (config) => addContext("SessionStart", ruleSummary(config)),
             }),
+          )
+        }
+        if (event.hookEventName === "UserPromptSubmit") {
+          return takePendingFeedback(event.sessionId).pipe(
+            Effect.match({
+              onFailure: (error) => nonBlockingError(error.message),
+              onSuccess: (feedback) =>
+                feedback === undefined ? {} : addContext("UserPromptSubmit", feedback),
+            }),
+          )
+        }
+        if (event.hookEventName === "Stop") {
+          return Effect.gen(function* () {
+            const tagger = yield* TaggerService
+            return yield* recordReplyFeedback(event, tagger)
+          }).pipe(
+            Effect.catchAll((error) => Effect.succeed(nonBlockingError(error.message))),
+            Effect.catchAllCause((cause) =>
+              Effect.succeed(nonBlockingError(`internal failure: ${Cause.pretty(cause)}`)),
+            ),
           )
         }
         return Effect.gen(function* () {

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -25,7 +25,10 @@ const sessionKey = (sessionId: string): string =>
 const sessionPath = (sessionId: string): string =>
   join(sessionsDirectory(), `${sessionKey(sessionId)}.json`)
 
-function decodeState(text: string, path: string): SessionState | { readonly pendingFeedback: string } {
+function decodeState(
+  text: string,
+  path: string,
+): SessionState | { readonly pendingFeedback: string } {
   const value = JSON.parse(text) as unknown
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`invalid session state in ${path}`)

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -1,0 +1,76 @@
+import { createHash, randomUUID } from "node:crypto"
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { isAbsolute, join } from "node:path"
+
+interface SessionState {
+  readonly version: 1
+  readonly pendingFeedback: string
+}
+
+const isMissingFile = (cause: unknown): boolean =>
+  typeof cause === "object" && cause !== null && (cause as { code?: string }).code === "ENOENT"
+
+const stateRoot = (): string => {
+  const configured = process.env.XDG_STATE_HOME
+  return configured && isAbsolute(configured) ? configured : join(homedir(), ".local", "state")
+}
+
+const sessionsDirectory = (): string => join(stateRoot(), "simple-english", "sessions")
+
+const sessionKey = (sessionId: string): string =>
+  createHash("sha256").update(sessionId).digest("hex")
+
+const sessionPath = (sessionId: string): string =>
+  join(sessionsDirectory(), `${sessionKey(sessionId)}.json`)
+
+function decodeState(text: string, path: string): SessionState {
+  const value = JSON.parse(text) as unknown
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`invalid session state in ${path}`)
+  }
+  const state = value as Record<string, unknown>
+  if (state.version !== 1 || typeof state.pendingFeedback !== "string") {
+    throw new Error(`invalid session state in ${path}`)
+  }
+  return { version: 1, pendingFeedback: state.pendingFeedback }
+}
+
+export async function setPendingFeedback(
+  sessionId: string,
+  pendingFeedback: string | undefined,
+): Promise<void> {
+  const path = sessionPath(sessionId)
+  if (pendingFeedback === undefined) {
+    await rm(path, { force: true })
+    return
+  }
+
+  const directory = sessionsDirectory()
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  const temporaryPath = join(directory, `.${sessionKey(sessionId)}.${randomUUID()}.tmp`)
+  try {
+    const state: SessionState = { version: 1, pendingFeedback }
+    await writeFile(temporaryPath, JSON.stringify(state), { encoding: "utf8", mode: 0o600 })
+    await rename(temporaryPath, path)
+  } finally {
+    await rm(temporaryPath, { force: true })
+  }
+}
+
+export async function consumePendingFeedback(sessionId: string): Promise<string | undefined> {
+  const path = sessionPath(sessionId)
+  const claimedPath = `${path}.${randomUUID()}.claimed`
+  try {
+    await rename(path, claimedPath)
+  } catch (cause) {
+    if (isMissingFile(cause)) return undefined
+    throw cause
+  }
+
+  try {
+    return decodeState(await readFile(claimedPath, "utf8"), claimedPath).pendingFeedback
+  } finally {
+    await rm(claimedPath, { force: true })
+  }
+}

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -4,8 +4,9 @@ import { homedir } from "node:os"
 import { isAbsolute, join } from "node:path"
 
 interface SessionState {
-  readonly version: 1
-  readonly pendingFeedback: string
+  readonly version: 2
+  readonly lastProcessedReply: string
+  readonly pendingFeedback?: string
 }
 
 const isMissingFile = (cause: unknown): boolean =>
@@ -24,38 +25,75 @@ const sessionKey = (sessionId: string): string =>
 const sessionPath = (sessionId: string): string =>
   join(sessionsDirectory(), `${sessionKey(sessionId)}.json`)
 
-function decodeState(text: string, path: string): SessionState {
+function decodeState(text: string, path: string): SessionState | { readonly pendingFeedback: string } {
   const value = JSON.parse(text) as unknown
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`invalid session state in ${path}`)
   }
   const state = value as Record<string, unknown>
-  if (state.version !== 1 || typeof state.pendingFeedback !== "string") {
+  if (state.version === 1 && typeof state.pendingFeedback === "string") {
+    return { pendingFeedback: state.pendingFeedback }
+  }
+  if (
+    state.version !== 2 ||
+    typeof state.lastProcessedReply !== "string" ||
+    state.lastProcessedReply.length === 0 ||
+    (state.pendingFeedback !== undefined && typeof state.pendingFeedback !== "string")
+  ) {
     throw new Error(`invalid session state in ${path}`)
   }
-  return { version: 1, pendingFeedback: state.pendingFeedback }
+  return {
+    version: 2,
+    lastProcessedReply: state.lastProcessedReply,
+    ...(state.pendingFeedback === undefined
+      ? {}
+      : { pendingFeedback: state.pendingFeedback as string }),
+  }
 }
 
-export async function setPendingFeedback(
-  sessionId: string,
-  pendingFeedback: string | undefined,
-): Promise<void> {
+async function readState(sessionId: string): Promise<ReturnType<typeof decodeState> | undefined> {
   const path = sessionPath(sessionId)
-  if (pendingFeedback === undefined) {
-    await rm(path, { force: true })
-    return
+  try {
+    return decodeState(await readFile(path, "utf8"), path)
+  } catch (cause) {
+    if (isMissingFile(cause)) return undefined
+    throw cause
   }
+}
 
+async function writeState(sessionId: string, state: SessionState): Promise<void> {
   const directory = sessionsDirectory()
   await mkdir(directory, { recursive: true, mode: 0o700 })
   const temporaryPath = join(directory, `.${sessionKey(sessionId)}.${randomUUID()}.tmp`)
   try {
-    const state: SessionState = { version: 1, pendingFeedback }
     await writeFile(temporaryPath, JSON.stringify(state), { encoding: "utf8", mode: 0o600 })
-    await rename(temporaryPath, path)
+    await rename(temporaryPath, sessionPath(sessionId))
   } finally {
     await rm(temporaryPath, { force: true })
   }
+}
+
+export async function hasProcessedReply(
+  sessionId: string,
+  replyIdentity: string,
+): Promise<boolean> {
+  const state = await readState(sessionId)
+  return state !== undefined && "lastProcessedReply" in state
+    ? state.lastProcessedReply === replyIdentity
+    : false
+}
+
+export async function setReplyFeedback(
+  sessionId: string,
+  replyIdentity: string,
+  pendingFeedback: string | undefined,
+): Promise<void> {
+  if (await hasProcessedReply(sessionId, replyIdentity)) return
+  await writeState(sessionId, {
+    version: 2,
+    lastProcessedReply: replyIdentity,
+    ...(pendingFeedback === undefined ? {} : { pendingFeedback }),
+  })
 }
 
 export async function consumePendingFeedback(sessionId: string): Promise<string | undefined> {
@@ -69,7 +107,13 @@ export async function consumePendingFeedback(sessionId: string): Promise<string 
   }
 
   try {
-    return decodeState(await readFile(claimedPath, "utf8"), claimedPath).pendingFeedback
+    const state = decodeState(await readFile(claimedPath, "utf8"), claimedPath)
+    if (!("lastProcessedReply" in state)) return state.pendingFeedback
+    await writeState(sessionId, {
+      version: 2,
+      lastProcessedReply: state.lastProcessedReply,
+    })
+    return state.pendingFeedback
   } finally {
     await rm(claimedPath, { force: true })
   }

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, test } from "vitest"
@@ -15,6 +15,10 @@ interface HookOutput {
   readonly continue?: boolean
   readonly systemMessage?: string
   readonly hookSpecificOutput?: HookSpecificOutput
+}
+
+interface SessionState {
+  readonly pendingFeedback: string
 }
 
 const temporaryDirectories: string[] = []
@@ -56,6 +60,47 @@ function sessionStartEvent(cwd: string): string {
   })
 }
 
+function stopEvent(cwd: string, sessionId: string, transcriptPath: string): string {
+  return JSON.stringify({
+    session_id: sessionId,
+    transcript_path: transcriptPath,
+    cwd,
+    permission_mode: "default",
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+  })
+}
+
+function userPromptEvent(cwd: string, sessionId: string): string {
+  return JSON.stringify({
+    session_id: sessionId,
+    transcript_path: join(cwd, `${sessionId}.jsonl`),
+    cwd,
+    permission_mode: "default",
+    hook_event_name: "UserPromptSubmit",
+    prompt: "Continue.",
+  })
+}
+
+async function writeTranscript(path: string, reply: string): Promise<void> {
+  await writeFile(
+    path,
+    `${JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: reply }] },
+    })}\n`,
+  )
+}
+
+async function stateFiles(xdgStateHome: string): Promise<string[]> {
+  try {
+    return await readdir(join(xdgStateHome, "simple-english", "sessions"))
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw error
+  }
+}
+
 async function runHook(
   stdin: string,
   cwd?: string,
@@ -63,16 +108,22 @@ async function runHook(
   xdgConfigHome?: string,
   dictionaryPath?: string,
   agentDir?: string,
+  xdgStateHome?: string,
 ) {
   const result = await runCli(["hook"], {
     stdin,
     cwd,
     preload,
     xdgConfigHome,
+    xdgStateHome,
     dictionaryPath,
     agentDir,
   })
   return { ...result, output: JSON.parse(result.stdout) as HookOutput }
+}
+
+function runReplyHook(stdin: string, cwd: string, xdgStateHome: string) {
+  return runHook(stdin, cwd, undefined, undefined, undefined, undefined, xdgStateHome)
 }
 
 function decision(output: HookOutput): HookSpecificOutput {
@@ -81,6 +132,118 @@ function decision(output: HookOutput): HookSpecificOutput {
 }
 
 describe("simple-english CLI hook mode", () => {
+  test("records hard reply feedback, injects it once, and clears the state", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "session-1.jsonl")
+    await writeTranscript(
+      transcriptPath,
+      "It is important to note that we can't carry out the test; close the valve.",
+    )
+
+    const stopped = await runReplyHook(
+      stopEvent(cwd, "session-1", transcriptPath),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(stopped.code).toBe(0)
+    expect(stopped.output).toEqual({})
+    const files = await stateFiles(xdgStateHome)
+    expect(files).toHaveLength(1)
+    const state = JSON.parse(
+      await readFile(join(xdgStateHome, "simple-english", "sessions", files[0] as string), "utf8"),
+    ) as SessionState
+    expect(state.pendingFeedback).toContain("line 1, column 33 [contraction]")
+    expect(state.pendingFeedback).toContain("[phrasal-verb]")
+    expect(state.pendingFeedback).toContain("[semicolon]")
+    expect(state.pendingFeedback).toContain("Suggested fix:")
+    expect(state.pendingFeedback).not.toContain("[hedging]")
+
+    const submitted = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
+
+    expect(submitted.code).toBe(0)
+    const output = decision(submitted.output)
+    expect(output.hookEventName).toBe("UserPromptSubmit")
+    expect(output.additionalContext).toBe(state.pendingFeedback)
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+
+    const submittedAgain = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
+    expect(submittedAgain.output).toEqual({})
+  })
+
+  test("does not record clean or soft-only reply feedback", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const cleanTranscriptPath = join(cwd, "clean-session.jsonl")
+    await writeTranscript(cleanTranscriptPath, "This isn't permitted.")
+    await runReplyHook(stopEvent(cwd, "clean-session", cleanTranscriptPath), cwd, xdgStateHome)
+    expect(await stateFiles(xdgStateHome)).toHaveLength(1)
+
+    for (const [sessionId, reply] of [
+      ["clean-session", "Close the valve."],
+      ["soft-session", "It is important to note that the valve is open."],
+    ] as const) {
+      const transcriptPath = join(cwd, `${sessionId}.jsonl`)
+      await writeTranscript(transcriptPath, reply)
+      const result = await runReplyHook(
+        stopEvent(cwd, sessionId, transcriptPath),
+        cwd,
+        xdgStateHome,
+      )
+      expect(result.code).toBe(0)
+      expect(result.output).toEqual({})
+    }
+
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+  })
+
+  test("scopes pending reply feedback to one session", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "first-session.jsonl")
+    await writeTranscript(transcriptPath, "This isn't permitted.")
+
+    await runReplyHook(stopEvent(cwd, "first-session", transcriptPath), cwd, xdgStateHome)
+
+    const otherSession = await runReplyHook(
+      userPromptEvent(cwd, "second-session"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(otherSession.output).toEqual({})
+    expect(await stateFiles(xdgStateHome)).toHaveLength(1)
+
+    const firstSession = await runReplyHook(
+      userPromptEvent(cwd, "first-session"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(decision(firstSession.output).additionalContext).toContain("[contraction]")
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+  })
+
+  test("allows Stop when the transcript cannot be read", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const result = await runReplyHook(
+      stopEvent(cwd, "session-1", join(cwd, "missing.jsonl")),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(result.code).toBe(0)
+    expect(result.output.continue).toBe(true)
+    expect(result.output.systemMessage).toContain("STE hook error")
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+  })
+
   test("adds the merged active rule summary to SessionStart context", async () => {
     const cwd = await makeProject({
       maxSentenceWords: 8,

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -108,6 +108,14 @@ function transcriptEntry(reply: string, uuid: string): string {
   })}\n`
 }
 
+function promptEntry(prompt: string, uuid: string): string {
+  return `${JSON.stringify({
+    type: "user",
+    uuid,
+    message: { role: "user", content: prompt },
+  })}\n`
+}
+
 async function writeTranscript(path: string, reply: string, uuid = "reply-1"): Promise<void> {
   await writeFile(path, transcriptEntry(reply, uuid))
 }
@@ -231,12 +239,15 @@ describe("simple-english CLI hook mode", () => {
     expect(decision(secondSubmission.output).additionalContext).toContain("[contraction]")
   })
 
-  test("uses the Stop reply when the transcript lags", async () => {
+  test("uses the Stop reply and distinguishes identical replies by prompt", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
     const transcriptPath = join(cwd, "lagged-session.jsonl")
-    await writeTranscript(transcriptPath, "Close the valve.", "older-reply")
+    await writeFile(
+      transcriptPath,
+      `${transcriptEntry("Close the valve.", "older-reply")}${promptEntry("Check it.", "prompt-1")}`,
+    )
     const firstStop = stopEvent(
       cwd,
       "lagged-session",
@@ -260,11 +271,8 @@ describe("simple-english CLI hook mode", () => {
     )
     expect(duplicateSubmission.output).toEqual({})
 
-    await runReplyHook(
-      stopEvent(cwd, "lagged-session", transcriptPath, "This can't continue."),
-      cwd,
-      xdgStateHome,
-    )
+    await appendFile(transcriptPath, promptEntry("Check it again.", "prompt-2"))
+    await runReplyHook(firstStop, cwd, xdgStateHome)
     const secondSubmission = await runReplyHook(
       userPromptEvent(cwd, "lagged-session"),
       cwd,

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,4 +1,13 @@
-import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import {
+  appendFile,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, describe, expect, test } from "vitest"
@@ -18,7 +27,8 @@ interface HookOutput {
 }
 
 interface SessionState {
-  readonly pendingFeedback: string
+  readonly lastProcessedReply: string
+  readonly pendingFeedback?: string
 }
 
 const temporaryDirectories: string[] = []
@@ -82,14 +92,16 @@ function userPromptEvent(cwd: string, sessionId: string): string {
   })
 }
 
-async function writeTranscript(path: string, reply: string): Promise<void> {
-  await writeFile(
-    path,
-    `${JSON.stringify({
-      type: "assistant",
-      message: { role: "assistant", content: [{ type: "text", text: reply }] },
-    })}\n`,
-  )
+function transcriptEntry(reply: string, uuid: string): string {
+  return `${JSON.stringify({
+    type: "assistant",
+    uuid,
+    message: { role: "assistant", content: [{ type: "text", text: reply }] },
+  })}\n`
+}
+
+async function writeTranscript(path: string, reply: string, uuid = "reply-1"): Promise<void> {
+  await writeFile(path, transcriptEntry(reply, uuid))
 }
 
 async function stateFiles(xdgStateHome: string): Promise<string[]> {
@@ -132,7 +144,7 @@ function decision(output: HookOutput): HookSpecificOutput {
 }
 
 describe("simple-english CLI hook mode", () => {
-  test("records hard reply feedback, injects it once, and clears the state", async () => {
+  test("records hard reply feedback, injects it once, and clears pending feedback", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
@@ -167,10 +179,48 @@ describe("simple-english CLI hook mode", () => {
     const output = decision(submitted.output)
     expect(output.hookEventName).toBe("UserPromptSubmit")
     expect(output.additionalContext).toBe(state.pendingFeedback)
-    expect(await stateFiles(xdgStateHome)).toEqual([])
+    expect(await stateFiles(xdgStateHome)).toEqual(files)
+    const consumedState = JSON.parse(
+      await readFile(join(xdgStateHome, "simple-english", "sessions", files[0] as string), "utf8"),
+    ) as SessionState
+    expect(consumedState.lastProcessedReply).toBe("uuid:reply-1")
+    expect(consumedState.pendingFeedback).toBeUndefined()
 
     const submittedAgain = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
     expect(submittedAgain.output).toEqual({})
+  })
+
+  test("ignores duplicate Stops and records a new reply", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "session-1.jsonl")
+    await writeTranscript(transcriptPath, "This isn't permitted.")
+
+    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
+    const firstSubmission = await runReplyHook(
+      userPromptEvent(cwd, "session-1"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(decision(firstSubmission.output).additionalContext).toContain("[contraction]")
+
+    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
+    const duplicateSubmission = await runReplyHook(
+      userPromptEvent(cwd, "session-1"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(duplicateSubmission.output).toEqual({})
+
+    await appendFile(transcriptPath, transcriptEntry("This can't continue.", "reply-2"))
+    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
+    const secondSubmission = await runReplyHook(
+      userPromptEvent(cwd, "session-1"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(decision(secondSubmission.output).additionalContext).toContain("[contraction]")
   })
 
   test("does not record clean or soft-only reply feedback", async () => {
@@ -188,7 +238,7 @@ describe("simple-english CLI hook mode", () => {
       ["soft-session", "It is important to note that the valve is open."],
     ] as const) {
       const transcriptPath = join(cwd, `${sessionId}.jsonl`)
-      await writeTranscript(transcriptPath, reply)
+      await writeTranscript(transcriptPath, reply, `${sessionId}-clean-reply`)
       const result = await runReplyHook(
         stopEvent(cwd, sessionId, transcriptPath),
         cwd,
@@ -198,7 +248,16 @@ describe("simple-english CLI hook mode", () => {
       expect(result.output).toEqual({})
     }
 
-    expect(await stateFiles(xdgStateHome)).toEqual([])
+    const files = await stateFiles(xdgStateHome)
+    expect(files).toHaveLength(2)
+    const states = await Promise.all(
+      files.map(async (file) =>
+        JSON.parse(
+          await readFile(join(xdgStateHome, "simple-english", "sessions", file), "utf8"),
+        ) as SessionState,
+      ),
+    )
+    expect(states.every((state) => state.pendingFeedback === undefined)).toBe(true)
   })
 
   test("reads a large transcript from the end", async () => {
@@ -243,7 +302,7 @@ describe("simple-english CLI hook mode", () => {
     expect(stopped.code).toBe(0)
     expect(stopped.output).toEqual({})
     expect(decision(submitted.output).additionalContext).toContain("[contraction]")
-    expect(await stateFiles(xdgStateHome)).toEqual([])
+    expect(await stateFiles(xdgStateHome)).toHaveLength(1)
   })
 
   test("scopes pending reply feedback to one session", async () => {
@@ -269,7 +328,7 @@ describe("simple-english CLI hook mode", () => {
       xdgStateHome,
     )
     expect(decision(firstSession.output).additionalContext).toContain("[contraction]")
-    expect(await stateFiles(xdgStateHome)).toEqual([])
+    expect(await stateFiles(xdgStateHome)).toHaveLength(1)
   })
 
   test("allows Stop when the transcript cannot be read", async () => {

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -201,6 +201,51 @@ describe("simple-english CLI hook mode", () => {
     expect(await stateFiles(xdgStateHome)).toEqual([])
   })
 
+  test("reads a large transcript from the end", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "large-session.jsonl")
+    const toolEntry = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "x".repeat(2 * 1024 * 1024) }],
+      },
+    })
+    const assistantEntry = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "x".repeat(128 * 1024) },
+          { type: "text", text: "This isn't permitted." },
+        ],
+      },
+    })
+    await writeFile(transcriptPath, `${toolEntry}\n${assistantEntry}\n`)
+
+    const stopped = await runHook(
+      stopEvent(cwd, "large-session", transcriptPath),
+      cwd,
+      join(repoRoot, "test", "fixtures", "failing-large-transcript-read-preload.js"),
+      undefined,
+      undefined,
+      undefined,
+      xdgStateHome,
+    )
+    const submitted = await runReplyHook(
+      userPromptEvent(cwd, "large-session"),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(stopped.code).toBe(0)
+    expect(stopped.output).toEqual({})
+    expect(decision(submitted.output).additionalContext).toContain("[contraction]")
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+  })
+
   test("scopes pending reply feedback to one session", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -83,9 +83,7 @@ function stopEvent(
     permission_mode: "default",
     hook_event_name: "Stop",
     stop_hook_active: false,
-    ...(lastAssistantMessage === undefined
-      ? {}
-      : { last_assistant_message: lastAssistantMessage }),
+    ...(lastAssistantMessage === undefined ? {} : { last_assistant_message: lastAssistantMessage }),
   })
 }
 
@@ -214,11 +212,7 @@ describe("simple-english CLI hook mode", () => {
     await writeTranscript(transcriptPath, "This isn't permitted.")
 
     await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
-    const firstSubmission = await runReplyHook(
-      userPromptEvent(cwd, "session-1"),
-      cwd,
-      xdgStateHome,
-    )
+    const firstSubmission = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
     expect(decision(firstSubmission.output).additionalContext).toContain("[contraction]")
 
     await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
@@ -248,12 +242,7 @@ describe("simple-english CLI hook mode", () => {
       transcriptPath,
       `${transcriptEntry("Close the valve.", "older-reply")}${promptEntry("Check it.", "prompt-1")}`,
     )
-    const firstStop = stopEvent(
-      cwd,
-      "lagged-session",
-      transcriptPath,
-      "This isn't permitted.",
-    )
+    const firstStop = stopEvent(cwd, "lagged-session", transcriptPath, "This isn't permitted.")
 
     await runReplyHook(firstStop, cwd, xdgStateHome)
     const firstSubmission = await runReplyHook(
@@ -309,10 +298,11 @@ describe("simple-english CLI hook mode", () => {
     const files = await stateFiles(xdgStateHome)
     expect(files).toHaveLength(2)
     const states = await Promise.all(
-      files.map(async (file) =>
-        JSON.parse(
-          await readFile(join(xdgStateHome, "simple-english", "sessions", file), "utf8"),
-        ) as SessionState,
+      files.map(
+        async (file) =>
+          JSON.parse(
+            await readFile(join(xdgStateHome, "simple-english", "sessions", file), "utf8"),
+          ) as SessionState,
       ),
     )
     expect(states.every((state) => state.pendingFeedback === undefined)).toBe(true)
@@ -351,11 +341,7 @@ describe("simple-english CLI hook mode", () => {
       undefined,
       xdgStateHome,
     )
-    const submitted = await runReplyHook(
-      userPromptEvent(cwd, "large-session"),
-      cwd,
-      xdgStateHome,
-    )
+    const submitted = await runReplyHook(userPromptEvent(cwd, "large-session"), cwd, xdgStateHome)
 
     expect(stopped.code).toBe(0)
     expect(stopped.output).toEqual({})

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -305,6 +305,41 @@ describe("simple-english CLI hook mode", () => {
     expect(await stateFiles(xdgStateHome)).toHaveLength(1)
   })
 
+  test("skips a large trailing non-assistant transcript entry", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "trailing-tool-session.jsonl")
+    const assistantEntry = transcriptEntry("This isn't permitted.", "reply-before-tool")
+    const toolEntry = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "x".repeat(2 * 1024 * 1024) }],
+      },
+    })
+    await writeFile(transcriptPath, `${assistantEntry}${toolEntry}\n`)
+
+    const stopped = await runHook(
+      stopEvent(cwd, "trailing-tool-session", transcriptPath),
+      cwd,
+      join(repoRoot, "test", "fixtures", "failing-large-transcript-read-preload.js"),
+      undefined,
+      undefined,
+      undefined,
+      xdgStateHome,
+    )
+    const submitted = await runReplyHook(
+      userPromptEvent(cwd, "trailing-tool-session"),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(stopped.code).toBe(0)
+    expect(stopped.output).toEqual({})
+    expect(decision(submitted.output).additionalContext).toContain("[contraction]")
+  })
+
   test("scopes pending reply feedback to one session", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -70,7 +70,12 @@ function sessionStartEvent(cwd: string): string {
   })
 }
 
-function stopEvent(cwd: string, sessionId: string, transcriptPath: string): string {
+function stopEvent(
+  cwd: string,
+  sessionId: string,
+  transcriptPath: string,
+  lastAssistantMessage?: string,
+): string {
   return JSON.stringify({
     session_id: sessionId,
     transcript_path: transcriptPath,
@@ -78,6 +83,9 @@ function stopEvent(cwd: string, sessionId: string, transcriptPath: string): stri
     permission_mode: "default",
     hook_event_name: "Stop",
     stop_hook_active: false,
+    ...(lastAssistantMessage === undefined
+      ? {}
+      : { last_assistant_message: lastAssistantMessage }),
   })
 }
 
@@ -217,6 +225,48 @@ describe("simple-english CLI hook mode", () => {
     await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
     const secondSubmission = await runReplyHook(
       userPromptEvent(cwd, "session-1"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(decision(secondSubmission.output).additionalContext).toContain("[contraction]")
+  })
+
+  test("uses the Stop reply when the transcript lags", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "lagged-session.jsonl")
+    await writeTranscript(transcriptPath, "Close the valve.", "older-reply")
+    const firstStop = stopEvent(
+      cwd,
+      "lagged-session",
+      transcriptPath,
+      "This isn't permitted.",
+    )
+
+    await runReplyHook(firstStop, cwd, xdgStateHome)
+    const firstSubmission = await runReplyHook(
+      userPromptEvent(cwd, "lagged-session"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(decision(firstSubmission.output).additionalContext).toContain("[contraction]")
+
+    await runReplyHook(firstStop, cwd, xdgStateHome)
+    const duplicateSubmission = await runReplyHook(
+      userPromptEvent(cwd, "lagged-session"),
+      cwd,
+      xdgStateHome,
+    )
+    expect(duplicateSubmission.output).toEqual({})
+
+    await runReplyHook(
+      stopEvent(cwd, "lagged-session", transcriptPath, "This can't continue."),
+      cwd,
+      xdgStateHome,
+    )
+    const secondSubmission = await runReplyHook(
+      userPromptEvent(cwd, "lagged-session"),
       cwd,
       xdgStateHome,
     )

--- a/test/cli/run-cli.ts
+++ b/test/cli/run-cli.ts
@@ -18,6 +18,7 @@ export interface CliOptions {
   cwd?: string
   home?: string
   xdgConfigHome?: string
+  xdgStateHome?: string
   agentDir?: string
   preload?: string
   dictionaryPath?: string
@@ -34,6 +35,7 @@ export async function runCli(args: string[], options: CliOptions = {}): Promise<
     ...process.env,
     HOME: home,
     XDG_CONFIG_HOME: options.xdgConfigHome ?? join(home, ".config"),
+    XDG_STATE_HOME: options.xdgStateHome ?? join(home, ".local", "state"),
     PI_CODING_AGENT_DIR: options.agentDir,
     ...(options.dictionaryPath === undefined
       ? {}

--- a/test/extension/claude-plugin.test.ts
+++ b/test/extension/claude-plugin.test.ts
@@ -55,10 +55,15 @@ describe("Claude Code plugin wiring", () => {
     ])
   })
 
-  test("registers only the SessionStart and gated PreToolUse hooks", async () => {
+  test("registers the session, tool gate, and reply feedback hooks", async () => {
     const hookFile = (await readJson(hooksPath)) as HooksFile
 
-    expect(Object.keys(hookFile.hooks).sort()).toEqual(["PreToolUse", "SessionStart"])
+    expect(Object.keys(hookFile.hooks).sort()).toEqual([
+      "PreToolUse",
+      "SessionStart",
+      "Stop",
+      "UserPromptSubmit",
+    ])
     expect(hookFile.hooks.SessionStart).toEqual([
       {
         hooks: [
@@ -80,6 +85,18 @@ describe("Claude Code plugin wiring", () => {
         ],
       },
     ])
+    for (const hookName of ["Stop", "UserPromptSubmit"] as const) {
+      expect(hookFile.hooks[hookName]).toEqual([
+        {
+          hooks: [
+            expect.objectContaining({
+              type: "command",
+              command: expect.stringContaining('src/cli/main.ts" hook'),
+            }),
+          ],
+        },
+      ])
+    }
   })
 
   test("references CLI entry points that exist in the plugin", async () => {
@@ -88,7 +105,7 @@ describe("Claude Code plugin wiring", () => {
       registrations.flatMap((registration) => registration.hooks.map((hook) => hook.command)),
     )
 
-    expect(commands).toHaveLength(2)
+    expect(commands).toHaveLength(4)
     for (const command of commands) {
       const match = command.match(/^cd "\$\{CLAUDE_PLUGIN_ROOT\}" && bun "([^"]+)" hook$/u)
       expect(match).not.toBeNull()

--- a/test/fixtures/failing-large-transcript-read-preload.js
+++ b/test/fixtures/failing-large-transcript-read-preload.js
@@ -2,6 +2,13 @@ import { mock } from "bun:test"
 import * as fs from "node:fs/promises"
 
 const originalReadFile = fs.readFile
+const originalBufferConcat = Buffer.concat
+
+Buffer.concat = (list, totalLength) => {
+  const length = totalLength ?? list.reduce((total, buffer) => total + buffer.length, 0)
+  if (length > 1024 * 1024) throw new Error("forced large buffer concatenation failure")
+  return originalBufferConcat(list, totalLength)
+}
 
 mock.module("node:fs/promises", () => ({
   ...fs,

--- a/test/fixtures/failing-large-transcript-read-preload.js
+++ b/test/fixtures/failing-large-transcript-read-preload.js
@@ -1,0 +1,19 @@
+import { mock } from "bun:test"
+import * as fs from "node:fs/promises"
+
+const originalReadFile = fs.readFile
+
+mock.module("node:fs/promises", () => ({
+  ...fs,
+  readFile: async (...args) => {
+    const path = args[0]
+    if (
+      typeof path === "string" &&
+      path.endsWith(".jsonl") &&
+      (await fs.stat(path)).size > 1024 * 1024
+    ) {
+      throw new Error("forced complete transcript read failure")
+    }
+    return originalReadFile(...args)
+  },
+}))


### PR DESCRIPTION
## Intent

Implement Linear ticket HUF-152 for the Claude Code Adapter reply correction loop. The Stop hook must check each finished assistant reply and save only hard violations as pending feedback for that session. UserPromptSubmit must add the pending feedback to the next model context and clear it. Feedback must include line, column, rule ID, and suggested fix. Clean and soft-only replies must leave no pending feedback. Concurrent sessions in one project must not share feedback. Use spawned CLI tests for the complete state file lifecycle and do not run Claude Code in tests. Keep default Stop behavior non-blocking. Do not add strict mode, Stop blocking, or commands because HUF-153 owns them. Internal failures must allow the host event with a warning. Document the reply feedback behavior and record the increased Claude Code enforcement ceiling in an ADR.

## What Changed

- Add Stop and UserPromptSubmit hooks that record hard reply violations, add them to the next model context, and clear them after use.
- Use separate session files for pending feedback and processed turn identities, with atomic state changes and bounded transcript reads.
- Allow events after internal failures, and document and test the Claude Code reply feedback lifecycle and enforcement ceiling.

## Risk Assessment

✅ Low: The change is well bounded and satisfies the reply feedback lifecycle requirements without a source-verifiable defect.

## Testing

No prior baseline command was supplied, and targeted spawned CLI tests plus an evidence log verified the complete reply feedback lifecycle without failures.

<details>
<summary>Evidence: Claude Code Adapter reply feedback lifecycle</summary>

```text
Claude Code Adapter reply feedback lifecycle

1. Concurrent Stop hooks return non-blocking empty results.
session-alpha Stop: {}
session-beta Stop:  {}

2. Session state remains separate. An unrelated session gets no feedback.
session-other UserPromptSubmit: {}
session-alpha state after Stop: {"version":2,"lastProcessedReply":"uuid:reply-alpha","pendingFeedback":"STE reply feedback for assistant reply:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}
session-beta state after Stop:  {"version":2,"lastProcessedReply":"uuid:reply-beta","pendingFeedback":"STE reply feedback for assistant reply:\n- line 1, column 1 [phrasal-verb]: Do not use a phrasal verb. Use \"do\", not \"carry out\". Suggested fix: Use \"do\".\n- line 1, column 19 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences."}

3. The next prompt gets hard feedback with location, rule ID, and suggested fix.
session-alpha UserPromptSubmit: {"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"STE reply feedback for assistant reply:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}
session-alpha state after submit: {"version":2,"lastProcessedReply":"uuid:reply-alpha"}
session-alpha second submit: {}
session-beta UserPromptSubmit:  {"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"STE reply feedback for assistant reply:\n- line 1, column 1 [phrasal-verb]: Do not use a phrasal verb. Use \"do\", not \"carry out\". Suggested fix: Use \"do\".\n- line 1, column 19 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences."}}
session-beta state after submit: {"version":2,"lastProcessedReply":"uuid:reply-beta"}

4. Soft-only and clean replies save no pending feedback.
soft Stop: {}
soft state: {"version":2,"lastProcessedReply":"uuid:reply-soft"}
soft next submit: {}
clean Stop: {}
clean state: {"version":2,"lastProcessedReply":"uuid:reply-clean"}
clean next submit: {}

5. An internal read failure allows Stop and supplies a warning.
missing transcript Stop: {"continue":true,"systemMessage":"STE hook error: cannot read assistant reply from /tmp/no-mistakes-evidence/01KYXQDHFJC62TW2TZ6WW5GX8C/cli-lifecycle/project/missing.jsonl: Error: ENOENT: no such file or directory, open '/tmp/no-mistakes-evidence/01KYXQDHFJC62TW2TZ6WW5GX8C/cli-lifecycle/project/missing.jsonl'. The event is allowed."}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (5) ✅</summary>

- ⚠️ `src/cli/hook.ts:246` - `readFile` loads the complete transcript on every Stop, and `split` creates another complete representation before it selects one entry. Transcript size increases throughout a session, so large tool outputs can exhaust memory or reach the 120-second limit. Read file chunks from the end until the latest assistant entry is complete.

🔧 Fix: fix: Read large transcripts in bounded chunks
1 error still open:
- 🚨 `src/cli/hook.ts:359` - `recordReplyFeedback` reads the latest assistant entry for every Stop event. Claude Code also sends Stop events during clear, resume, and compact operations. After UserPromptSubmit consumes feedback, such an event saves the same report again. This conflicts with the required &#34;Stop hook must check each finished assistant reply&#34; behavior and clear-on-submit lifecycle. Save the last processed assistant entry identity or transcript offset in session state, then ignore duplicate entries.

🔧 Fix: Prevent duplicate reply feedback after consumption
1 warning still open:
- ⚠️ `src/cli/hook.ts:303` - When a large non-assistant record follows the latest assistant entry, the reader collects and parses that complete record first. A large trailing tool result can still exhaust memory or reach the Stop timeout, so the durable NM-001 fix remains incomplete. Inspect each record type from bounded data, skip non-assistant payloads, and assemble only the latest assistant entry.

🔧 Fix: Skip large trailing transcript records with bounded memory
1 error still open:
- 🚨 `src/cli/hook.ts:476` - Claude Code can send the completed reply before `transcript_path` contains it. This code can lint an older reply instead. This violates: &#34;The Stop hook must check each finished assistant reply.&#34; Decode `last_assistant_message` at the Stop event boundary and use a per-prompt identity.

🔧 Fix: Use Stop event reply as lint source
1 error still open:
- 🚨 `src/cli/hook.ts:416` - `assistantReplyFromEvent` hashes only reply text, so separate prompts with the same response receive one identity. After feedback consumption, `hasProcessedReply` skips the second Stop. This contradicts &#34;The Stop hook must check each finished assistant reply&#34; and the requested per-prompt identity. Derive identity from a stable prompt or turn record while using `last_assistant_message` as text.

🔧 Fix: Use reply turn identities for Stop event checks
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/cli/hook.test.ts test/extension/claude-plugin.test.ts -t 'records hard reply feedback|ignores duplicate Stops|uses the Stop reply|does not record clean or soft-only reply feedback|reads a large transcript from the end|skips a large trailing non-assistant transcript entry|scopes pending reply feedback|allows Stop when the transcript cannot be read|registers the session, tool gate, and reply feedback hooks|references CLI entry points'`
- <code>`bun src/cli/main.ts hook` processed concurrent Stop and UserPromptSubmit events with isolated `XDG_STATE_HOME` data.</code>
- <code>`bun src/cli/main.ts hook` processed clean, soft-only, duplicate prompt, unrelated-session, and missing-transcript cases for the evidence log.</code>
- <code>`git status --short` verified that testing left no worktree files.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
