### PR TITLE
feat(cli): add Claude Code session controls

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,5 +34,5 @@ _Avoid_: guard, filter
 A hard violation blocks the gated action; a soft violation only produces a warning.
 
 **Strict mode**:
-The reply gate mode that checks the assistant's user-facing prose before the user reads it.
+The mode that applies the host's strongest available reply gate to hard violations.
 Host support follows the [per-host enforcement ceilings](docs/adr/0001-per-host-enforcement-ceiling.md).

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ You do not need a global `simple-english` package or manual hook settings.
 The repository supplies the local marketplace manifest.
 Marketplace publication is outside this package release.
 
-At `SessionStart`, the Adapter loads the merged config from the session working directory.
-It adds the active STE rule summary to context.
+At `SessionStart`, the Adapter loads the merged config for an enabled session.
+It reads the config from the session working directory and adds the active STE rule summary to context.
 The summary honors `hard`, `soft`, and `off` rule settings plus `maxSentenceWords`.
 
 The `PreToolUse` gate checks `Write`, `Edit`, and `Bash` events.
@@ -98,7 +98,7 @@ The `Stop` hook does not block or change the reply in this mode.
 At the next `UserPromptSubmit` event, the Adapter adds the pending feedback to the model context.
 The feedback gives the line, column, rule ID, and suggested fix for each hard violation.
 The Adapter then clears the pending feedback, so it adds each report only one time.
-The session state retains the processed reply turn identity and ignores duplicate `Stop` events.
+The session state retains the processed reply identity and ignores duplicate `Stop` events.
 Clean and soft-only replies leave no pending feedback.
 
 Each session has a separate state file under `$XDG_STATE_HOME/simple-english/sessions`.

--- a/README.md
+++ b/README.md
@@ -67,11 +67,33 @@ It also blocks a detected commit without a static `-m` or `--message` argument.
 A compliant static message passes.
 Soft violations allow the event and add warning text.
 
+### Session controls
+
+The `/ste` command controls the current Claude Code session.
+New sessions start in enabled mode without a strict reply gate.
+A change in one session does not change a parallel session.
+
+| Command | Result |
+| --- | --- |
+| `/ste on` | Enable write, edit, commit, and reply checks. |
+| `/ste off` | Disable all checks and leave strict mode. |
+| `/ste status` | Show the mode, rule counts, and dictionary state. |
+| `/ste strict` | Enable the strict reply gate and all other checks. |
+| `/ste strict off` | Disable the strict reply gate and use reply feedback. |
+
+Strict mode blocks a `Stop` event when the reply has a hard violation.
+Claude Code then uses the violation details to write the reply again.
+The `stop_hook_active` check stops a second block in the same rewrite loop.
+
+Claude Code shows streamed reply text before the `Stop` hook runs.
+Thus, strict mode can reject the completed reply, but it cannot redact text that Claude Code already showed.
+The pi Adapter does not have this gap because its `say` tool hides strict reply text before approval.
+
 ### Reply feedback loop
 
-The `Stop` hook checks each finished assistant reply after Claude Code shows it.
+In enabled non-strict mode, the `Stop` hook checks each finished assistant reply after Claude Code shows it.
 It records only hard violation details in a state file for that Claude Code session.
-The `Stop` hook does not block or change the reply.
+The `Stop` hook does not block or change the reply in this mode.
 
 At the next `UserPromptSubmit` event, the Adapter adds the pending feedback to the model context.
 The feedback gives the line, column, rule ID, and suggested fix for each hard violation.
@@ -81,7 +103,8 @@ Clean and soft-only replies leave no pending feedback.
 
 Each session has a separate state file under `$XDG_STATE_HOME/simple-english/sessions`.
 The default state directory is `~/.local/state/simple-english/sessions`.
-Concurrent sessions in one project do not read or clear feedback from another session.
+The file stores the session mode, reply identity, and pending feedback.
+Concurrent sessions in one project do not read or clear state from another session.
 
 ## Install the pi Adapter
 
@@ -136,8 +159,10 @@ The `hook` subcommand reads one Claude Code hook event from standard input.
 It writes one hook result as JSON.
 A `SessionStart` event returns the active rule summary as added context.
 A `PreToolUse` event applies the write, edit, and commit gates that the plugin registers.
-A `Stop` event records hard reply feedback without blocking the reply.
+A `Stop` event records hard reply feedback in enabled non-strict mode.
+In strict mode, it blocks a reply that has hard violations.
 A `UserPromptSubmit` event adds pending feedback to context and clears that feedback.
+Every hook reads the current session mode before it applies a gate.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
 The hook also allows the event when configuration, dictionary, tagger, transcript, state, or file processing fails.
 It adds warning text.

--- a/commands/ste.md
+++ b/commands/ste.md
@@ -1,0 +1,13 @@
+---
+description: Control STE for this Claude Code session
+argument-hint: on|off|status|strict|strict off
+allowed-tools: Bash
+disable-model-invocation: true
+---
+
+Session state:
+
+!`cd "${CLAUDE_PLUGIN_ROOT}" && bun "src/cli/main.ts" session "${CLAUDE_SESSION_ID}" "${CLAUDE_PROJECT_DIR}" "$ARGUMENTS"`
+
+Show the session state exactly.
+Do not add text.

--- a/docs/adr/0001-per-host-enforcement-ceiling.md
+++ b/docs/adr/0001-per-host-enforcement-ceiling.md
@@ -7,8 +7,11 @@ We do not reduce all hosts to one common enforcement level or limit new hosts to
 The host ceilings differ.
 Pi gets prompt rules, write and edit gates, commit gates, reply feedback, and strict reply gates.
 Claude Code gets prompt rules through SessionStart and write, edit, and commit gates through PreToolUse.
-It gets deferred reply feedback through Stop and UserPromptSubmit, but it has no strict reply gate.
-We accept and document the host differences.
+It gets deferred reply feedback through Stop and UserPromptSubmit.
+Its strict mode can block a completed reply at Stop and cause one immediate rewrite.
+Claude Code streams the reply before Stop, so the Adapter cannot redact text that the host already showed.
+The pi Adapter can hide strict reply text until approval through its `say` tool.
+We accept and document this enforcement ceiling difference.
 
 A host ceiling can increase when its extension surface changes.
 [ADR 0002](0002-claude-code-reply-feedback.md) defines the Claude Code reply feedback design.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -3,16 +3,18 @@
 ADR 0001 defines the per-host enforcement ceiling policy.
 The `Stop` and `UserPromptSubmit` hooks increase the Claude Code enforcement ceiling.
 This decision adds deferred reply feedback to that ceiling.
-The later session-controls slice adds a strict Stop gate.
+Session controls add a strict Stop gate.
 ADR 0001 records its redaction limit.
 
 The `Stop` hook reads `last_assistant_message` from the event.
 This event field is authoritative because the transcript can lag behind the completed reply.
-When the field is present, the latest user transcript record gives the reply turn identity.
+When the field is present, the latest user transcript record gives the base turn identity.
+A hash of the event reply identifies each rewrite in that turn.
 When the field is absent, the latest assistant transcript entry gives the reply and its identity.
-It checks the reply and records only hard violation feedback.
-Session state retains the processed reply turn identity and ignores duplicate `Stop` events.
-In non-strict mode, it does not block or change the completed reply.
+It checks the reply.
+In non-strict mode, it records only hard violation feedback.
+It does not block or change the completed reply in this mode.
+Session state retains the processed reply identity and ignores duplicate `Stop` events.
 
 The `UserPromptSubmit` hook adds pending feedback to the next model context.
 It removes the feedback before it returns, so concurrent calls cannot add the same feedback two times.
@@ -22,8 +24,8 @@ Session state uses one file for each Claude Code session.
 Files are under `$XDG_STATE_HOME/simple-english/sessions`, with `~/.local/state` as the default state root.
 A SHA-256 key from the session ID gives safe, fixed-length file names.
 State writes use a temporary file and an atomic rename.
-Feedback reads claim the file with an atomic rename before they clear pending feedback.
+All state access uses one lock directory for each session.
 
 This design keeps feedback separate for concurrent sessions in the same project.
-It also gives later Adapter work one state location for session mode data.
+The same state file stores session mode data.
 State and transcript failures allow the hook event and give a warning.

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -3,7 +3,8 @@
 ADR 0001 defines the per-host enforcement ceiling policy.
 The `Stop` and `UserPromptSubmit` hooks increase the Claude Code enforcement ceiling.
 This decision adds deferred reply feedback to that ceiling.
-Strict reply gates remain outside the current ceiling.
+The later session-controls slice adds a strict Stop gate.
+ADR 0001 records its redaction limit.
 
 The `Stop` hook reads `last_assistant_message` from the event.
 This event field is authoritative because the transcript can lag behind the completed reply.
@@ -11,7 +12,7 @@ When the field is present, the latest user transcript record gives the reply tur
 When the field is absent, the latest assistant transcript entry gives the reply and its identity.
 It checks the reply and records only hard violation feedback.
 Session state retains the processed reply turn identity and ignores duplicate `Stop` events.
-It does not block or change the completed reply.
+In non-strict mode, it does not block or change the completed reply.
 
 The `UserPromptSubmit` hook adds pending feedback to the next model context.
 It removes the feedback before it returns, so concurrent calls cannot add the same feedback two times.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,15 @@
   "pi": {
     "extensions": ["./src/extension/index.ts"]
   },
-  "files": [".claude-plugin", "hooks", "src", "README.md", "LICENSE", "THIRD_PARTY_NOTICES.md"],
+  "files": [
+    ".claude-plugin",
+    "commands",
+    "hooks",
+    "src",
+    "README.md",
+    "LICENSE",
+    "THIRD_PARTY_NOTICES.md"
+  ],
   "bin": {
     "simple-english": "src/cli/main.ts"
   },

--- a/src/adapter/rule-summary.ts
+++ b/src/adapter/rule-summary.ts
@@ -35,6 +35,22 @@ export function resolvedRuleSetting(config: SteConfig, ruleId: RuleId): RuleSett
   return config.rules?.[ruleId] ?? DEFAULT_RULE_SETTINGS[ruleId]
 }
 
+export function formatStatusSummary(
+  config: SteConfig,
+  mode: "disabled" | "enabled" | "strict",
+  dictionary: string,
+): string {
+  const counts: Record<RuleSetting, number> = { hard: 0, soft: 0, off: 0 }
+  for (const ruleId of Object.keys(RULE_SUMMARIES) as RuleId[]) {
+    counts[resolvedRuleSetting(config, ruleId)] += 1
+  }
+  return [
+    `Mode: ${mode}`,
+    `Rules: ${counts.hard} hard, ${counts.soft} soft, ${counts.off} off`,
+    `Dictionary: ${dictionary}`,
+  ].join("\n")
+}
+
 export function ruleSummary(config: SteConfig): string {
   const maxSentenceWords = config.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS
   const rules = (Object.keys(RULE_SUMMARIES) as RuleId[])

--- a/src/adapter/rule-summary.ts
+++ b/src/adapter/rule-summary.ts
@@ -35,6 +35,18 @@ export function resolvedRuleSetting(config: SteConfig, ruleId: RuleId): RuleSett
   return config.rules?.[ruleId] ?? DEFAULT_RULE_SETTINGS[ruleId]
 }
 
+export function formatFailedStatusSummary(
+  mode: "disabled" | "enabled" | "strict",
+  configError: string,
+): string {
+  return [
+    `Mode: ${mode}`,
+    `Config: failed (${configError})`,
+    "Rules: unavailable",
+    "Dictionary: unavailable",
+  ].join("\n")
+}
+
 export function formatStatusSummary(
   config: SteConfig,
   mode: "disabled" | "enabled" | "strict",

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -465,9 +465,10 @@ async function assistantReplyFromTranscript(path: string): Promise<AssistantRepl
 }
 
 async function assistantReplyFromEvent(text: string, path: string): Promise<AssistantReply> {
-  const identity = await latestTranscriptEntry(path, turnIdentityInRange)
-  if (identity === undefined) throw new Error(`cannot find a reply turn in ${path}`)
-  return { identity, text }
+  const turnIdentity = await latestTranscriptEntry(path, turnIdentityInRange)
+  if (turnIdentity === undefined) throw new Error(`cannot find a reply turn in ${path}`)
+  const textHash = createHash("sha256").update(text).digest("hex")
+  return { identity: `${turnIdentity}:reply:${textHash}`, text }
 }
 
 const readAssistantReply = (path: string) =>

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -12,7 +12,12 @@ import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
 import type { LintOptions, Violation } from "../engine/types.ts"
 import { TaggerService } from "../tagger/wink.ts"
-import { consumePendingFeedback, hasProcessedReply, setReplyFeedback } from "./session-state.ts"
+import {
+  consumePendingFeedback,
+  getSessionControl,
+  hasProcessedReply,
+  setReplyFeedback,
+} from "./session-state.ts"
 
 interface CommonEvent {
   readonly cwd: string
@@ -49,6 +54,7 @@ interface BashEvent extends CommonEvent {
 interface StopEvent extends CommonEvent {
   readonly hookEventName: "Stop"
   readonly lastAssistantMessage?: string
+  readonly stopHookActive: boolean
 }
 
 interface UserPromptSubmitEvent extends CommonEvent {
@@ -81,7 +87,17 @@ interface HookError {
   readonly systemMessage: string
 }
 
-export type HookOutput = HookDecision | ContextOutput | HookError | Record<string, never>
+interface StopDecision {
+  readonly decision: "block"
+  readonly reason: string
+}
+
+export type HookOutput =
+  | HookDecision
+  | ContextOutput
+  | HookError
+  | StopDecision
+  | Record<string, never>
 
 function record(value: unknown, name: string): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -110,9 +126,14 @@ function decodeEvent(raw: string): HookEvent {
     if (lastAssistantMessage !== undefined && typeof lastAssistantMessage !== "string") {
       throw new Error("last_assistant_message must be a string")
     }
+    const stopHookActive = event.stop_hook_active
+    if (typeof stopHookActive !== "boolean") {
+      throw new Error("stop_hook_active must be a boolean")
+    }
     return {
       ...common,
       hookEventName,
+      stopHookActive,
       ...(lastAssistantMessage === undefined ? {} : { lastAssistantMessage }),
     }
   }
@@ -483,6 +504,12 @@ const takePendingFeedback = (sessionId: string) =>
     catch: (cause) => new Error(`cannot read session state: ${cause}`),
   })
 
+const readSessionControl = (sessionId: string) =>
+  Effect.tryPromise({
+    try: () => getSessionControl(sessionId),
+    catch: (cause) => new Error(`cannot read session state: ${cause}`),
+  })
+
 const loadLintOptions = (cwd: string, tagger: Tagger) => {
   const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
   return Effect.all({
@@ -523,15 +550,14 @@ function textDecision(
   return allow(soft.length === 0 ? [] : [formatViolations(path, "STE warnings for", soft)])
 }
 
-function recordReplyFeedback(
-  event: StopEvent,
-  tagger: Tagger,
-): Effect.Effect<Record<string, never>, Error> {
+function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutput, Error> {
   return Effect.gen(function* () {
     const reply = yield* event.lastAssistantMessage === undefined
       ? readAssistantReply(event.transcriptPath)
       : readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath)
-    if (yield* replyWasProcessed(event.sessionId, reply.identity)) return {}
+    if (yield* replyWasProcessed(event.sessionId, reply.identity)) {
+      return {} as Record<string, never>
+    }
     const options = yield* loadLintOptions(event.cwd, tagger)
     const hard = lint("prose-file", reply.text, options).violations.filter(
       (violation) => violation.severity === "hard",
@@ -540,8 +566,14 @@ function recordReplyFeedback(
       hard.length === 0
         ? undefined
         : formatViolations("assistant reply", "STE reply feedback for", hard)
-    yield* updateReplyFeedback(event.sessionId, reply.identity, feedback)
-    return {}
+    const currentControl = yield* updateReplyFeedback(event.sessionId, reply.identity, feedback)
+    if (currentControl === undefined || !currentControl.strict || hard.length === 0) {
+      return {} as Record<string, never>
+    }
+    return {
+      decision: "block",
+      reason: formatViolations("assistant reply", "STE blocked reply for", hard),
+    }
   })
 }
 
@@ -592,43 +624,53 @@ export function runHookMode(raw: string): Effect.Effect<HookOutput, never, Tagge
   }).pipe(
     Effect.matchEffect({
       onFailure: (error) => Effect.succeed(nonBlockingError(error.message)),
-      onSuccess: (event) => {
-        if (event.hookEventName === "SessionStart") {
-          return loadConfig(undefined, event.cwd).pipe(
-            Effect.match({
-              onFailure: (error) => nonBlockingError(error.message),
-              onSuccess: (config) => addContext("SessionStart", ruleSummary(config)),
-            }),
-          )
-        }
-        if (event.hookEventName === "UserPromptSubmit") {
-          return takePendingFeedback(event.sessionId).pipe(
-            Effect.match({
-              onFailure: (error) => nonBlockingError(error.message),
-              onSuccess: (feedback) =>
-                feedback === undefined ? {} : addContext("UserPromptSubmit", feedback),
-            }),
-          )
-        }
-        if (event.hookEventName === "Stop") {
-          return Effect.gen(function* () {
-            const tagger = yield* TaggerService
-            return yield* recordReplyFeedback(event, tagger)
-          }).pipe(
-            Effect.catchAll((error) => Effect.succeed(nonBlockingError(error.message))),
-            Effect.catchAllCause((cause) =>
-              Effect.succeed(nonBlockingError(`internal failure: ${Cause.pretty(cause)}`)),
+      onSuccess: (event) =>
+        readSessionControl(event.sessionId).pipe(
+          Effect.flatMap((control): Effect.Effect<HookOutput, Error, TaggerService> => {
+            if (!control.enabled) {
+              return Effect.succeed(
+                event.hookEventName === "PreToolUse" ? allow() : ({} as Record<string, never>),
+              )
+            }
+            if (event.hookEventName === "SessionStart") {
+              return loadConfig(undefined, event.cwd).pipe(
+                Effect.map((config) => addContext("SessionStart", ruleSummary(config))),
+              )
+            }
+            if (event.hookEventName === "UserPromptSubmit") {
+              return takePendingFeedback(event.sessionId).pipe(
+                Effect.map((feedback) =>
+                  feedback === undefined ? {} : addContext("UserPromptSubmit", feedback),
+                ),
+              )
+            }
+            if (event.hookEventName === "Stop") {
+              if (event.stopHookActive) return Effect.succeed({})
+              return Effect.gen(function* () {
+                const tagger = yield* TaggerService
+                return yield* evaluateReply(event, tagger)
+              })
+            }
+            return Effect.gen(function* () {
+              const tagger = yield* TaggerService
+              return yield* evaluateEvent(event, tagger)
+            })
+          }),
+          Effect.catchAll((error) =>
+            Effect.succeed(
+              event.hookEventName === "PreToolUse"
+                ? nonBlockingWarning(error.message)
+                : nonBlockingError(error.message),
             ),
-          )
-        }
-        return Effect.gen(function* () {
-          const tagger = yield* TaggerService
-          return yield* evaluateEvent(event, tagger)
-        }).pipe(
-          Effect.catchAll((error) => Effect.succeed(nonBlockingWarning(error.message))),
-          Effect.catchAllCause((cause) => Effect.succeed(hookInternalFailure(cause))),
-        )
-      },
+          ),
+          Effect.catchAllCause((cause) =>
+            Effect.succeed(
+              event.hookEventName === "PreToolUse"
+                ? hookInternalFailure(cause)
+                : nonBlockingError(`internal failure: ${Cause.pretty(cause)}`),
+            ),
+          ),
+        ),
     }),
   )
 }

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -567,7 +567,12 @@ function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutp
         ? undefined
         : formatViolations("assistant reply", "STE reply feedback for", hard)
     const currentControl = yield* updateReplyFeedback(event.sessionId, reply.identity, feedback)
-    if (currentControl === undefined || !currentControl.strict || hard.length === 0) {
+    if (
+      currentControl === undefined ||
+      !currentControl.strict ||
+      event.stopHookActive ||
+      hard.length === 0
+    ) {
       return {} as Record<string, never>
     }
     return {
@@ -645,7 +650,6 @@ export function runHookMode(raw: string): Effect.Effect<HookOutput, never, Tagge
               )
             }
             if (event.hookEventName === "Stop") {
-              if (event.stopHookActive) return Effect.succeed({})
               return Effect.gen(function* () {
                 const tagger = yield* TaggerService
                 return yield* evaluateReply(event, tagger)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -8,6 +8,7 @@ import { lint } from "../engine/lint.ts"
 import type { LintKind, LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
 import { hookInternalFailure, runHookMode } from "./hook.ts"
+import { runSessionCommand } from "./session-command.ts"
 
 const KINDS: readonly LintKind[] = ["prose-file", "slash-source", "hash-source", "commit-message"]
 
@@ -124,6 +125,11 @@ const hookProgram = Effect.gen(function* () {
   ),
 )
 
+const sessionProgram = Effect.gen(function* () {
+  console.log(yield* runSessionCommand(args.slice(1)))
+  return 0
+})
+
 const lintProgram = Effect.gen(function* () {
   const tagger = yield* TaggerService
   const { json, configPath, kind, kindMissingValue, paths } = yield* parseArgs(args)
@@ -173,7 +179,11 @@ const lintProgram = Effect.gen(function* () {
 })
 
 const program: Effect.Effect<number, Error> =
-  args[0] === "hook" ? hookProgram : lintProgram.pipe(Effect.provide(WinkTaggerLive))
+  args[0] === "hook"
+    ? hookProgram
+    : args[0] === "session"
+      ? sessionProgram
+      : lintProgram.pipe(Effect.provide(WinkTaggerLive))
 
 const handled = program.pipe(
   Effect.catchAll((error) =>

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -1,0 +1,78 @@
+import { resolve } from "node:path"
+import { Effect, Either } from "effect"
+import { formatStatusSummary } from "../adapter/rule-summary.ts"
+import { loadConfig } from "../config/load.ts"
+import { loadDictionary } from "../dictionary/load.ts"
+import {
+  type SessionControl,
+  getSessionControl,
+  setSessionEnabled,
+  setSessionStrict,
+} from "./session-state.ts"
+
+const USAGE = "Usage: /ste [on|off|status|strict|strict off]"
+
+type DictionaryState = "loaded" | "not loaded" | `failed (${string})`
+
+function modeName(control: SessionControl): "disabled" | "enabled" | "strict" {
+  if (!control.enabled) return "disabled"
+  return control.strict ? "strict" : "enabled"
+}
+
+const readControl = (sessionId: string) =>
+  Effect.tryPromise({
+    try: () => getSessionControl(sessionId),
+    catch: (cause) => new Error(`cannot read session state: ${cause}`),
+  })
+
+const updateEnabled = (sessionId: string, enabled: boolean) =>
+  Effect.tryPromise({
+    try: () => setSessionEnabled(sessionId, enabled),
+    catch: (cause) => new Error(`cannot update session state: ${cause}`),
+  })
+
+const updateStrict = (sessionId: string, strict: boolean) =>
+  Effect.tryPromise({
+    try: () => setSessionStrict(sessionId, strict),
+    catch: (cause) => new Error(`cannot update session state: ${cause}`),
+  })
+
+function status(sessionId: string, cwd: string): Effect.Effect<string, Error> {
+  return Effect.gen(function* () {
+    const control = yield* readControl(sessionId)
+    const configResult = yield* Effect.either(loadConfig(undefined, cwd))
+    if (Either.isLeft(configResult)) {
+      return formatStatusSummary({}, modeName(control), "not loaded")
+    }
+    const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
+    const dictionaryResult = yield* Effect.either(
+      loadDictionary(dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath)),
+    )
+    const dictionary: DictionaryState = Either.isRight(dictionaryResult)
+      ? "loaded"
+      : `failed (${dictionaryResult.left.message})`
+    return formatStatusSummary(configResult.right, modeName(control), dictionary)
+  })
+}
+
+export function runSessionCommand(args: readonly string[]): Effect.Effect<string, Error> {
+  const [sessionId, cwd, ...commandParts] = args
+  if (sessionId === undefined || sessionId.length === 0 || cwd === undefined || cwd.length === 0) {
+    return Effect.fail(new Error(USAGE))
+  }
+  const command = commandParts.join(" ").trim().toLowerCase()
+  if (command === "status") return status(sessionId, cwd)
+  if (command === "on") {
+    return updateEnabled(sessionId, true).pipe(Effect.as("STE enforcement enabled."))
+  }
+  if (command === "off") {
+    return updateEnabled(sessionId, false).pipe(Effect.as("STE enforcement disabled."))
+  }
+  if (command === "strict" || command === "strict on") {
+    return updateStrict(sessionId, true).pipe(Effect.as("STE strict mode enabled."))
+  }
+  if (command === "strict off") {
+    return updateStrict(sessionId, false).pipe(Effect.as("STE strict mode disabled."))
+  }
+  return Effect.fail(new Error(USAGE))
+}

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path"
 import { Effect, Either } from "effect"
-import { formatStatusSummary } from "../adapter/rule-summary.ts"
+import { formatFailedStatusSummary, formatStatusSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import { loadDictionary } from "../dictionary/load.ts"
 import {
@@ -42,7 +42,7 @@ function status(sessionId: string, cwd: string): Effect.Effect<string, Error> {
     const control = yield* readControl(sessionId)
     const configResult = yield* Effect.either(loadConfig(undefined, cwd))
     if (Either.isLeft(configResult)) {
-      return formatStatusSummary({}, modeName(control), "not loaded")
+      return formatFailedStatusSummary(modeName(control), configResult.left.message)
     }
     const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
     const dictionaryResult = yield* Effect.either(

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -1,16 +1,26 @@
 import { createHash, randomUUID } from "node:crypto"
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { isAbsolute, join } from "node:path"
 
-interface SessionState {
-  readonly version: 2
-  readonly lastProcessedReply: string
+export interface SessionControl {
+  readonly enabled: boolean
+  readonly strict: boolean
+}
+
+interface SessionState extends SessionControl {
+  readonly version: 3
+  readonly lastProcessedReply?: string
   readonly pendingFeedback?: string
 }
 
-const isMissingFile = (cause: unknown): boolean =>
-  typeof cause === "object" && cause !== null && (cause as { code?: string }).code === "ENOENT"
+const DEFAULT_CONTROL: SessionControl = { enabled: true, strict: false }
+const LOCK_STALE_MILLISECONDS = 10_000
+const LOCK_RETRY_MILLISECONDS = 5
+const LOCK_RETRIES = 200
+
+const isFileError = (cause: unknown, code: string): boolean =>
+  typeof cause === "object" && cause !== null && (cause as { code?: string }).code === code
 
 const stateRoot = (): string => {
   const configured = process.env.XDG_STATE_HOME
@@ -25,41 +35,60 @@ const sessionKey = (sessionId: string): string =>
 const sessionPath = (sessionId: string): string =>
   join(sessionsDirectory(), `${sessionKey(sessionId)}.json`)
 
-function decodeState(
-  text: string,
-  path: string,
-): SessionState | { readonly pendingFeedback: string } {
+const lockPath = (sessionId: string): string =>
+  join(sessionsDirectory(), `.${sessionKey(sessionId)}.lock`)
+
+function optionalString(state: Record<string, unknown>, name: string): string | undefined {
+  const value = state[name]
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`${name} must be a string`)
+  }
+  return value as string | undefined
+}
+
+function decodeState(text: string, path: string): SessionState {
   const value = JSON.parse(text) as unknown
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`invalid session state in ${path}`)
   }
   const state = value as Record<string, unknown>
-  if (state.version === 1 && typeof state.pendingFeedback === "string") {
-    return { pendingFeedback: state.pendingFeedback }
+  const pendingFeedback = optionalString(state, "pendingFeedback")
+  if (state.version === 1 && typeof pendingFeedback === "string") {
+    return { version: 3, ...DEFAULT_CONTROL, pendingFeedback }
+  }
+  const lastProcessedReply = optionalString(state, "lastProcessedReply")
+  if (state.version === 2 && lastProcessedReply !== undefined && lastProcessedReply.length > 0) {
+    return {
+      version: 3,
+      ...DEFAULT_CONTROL,
+      lastProcessedReply,
+      ...(pendingFeedback === undefined ? {} : { pendingFeedback }),
+    }
   }
   if (
-    state.version !== 2 ||
-    typeof state.lastProcessedReply !== "string" ||
-    state.lastProcessedReply.length === 0 ||
-    (state.pendingFeedback !== undefined && typeof state.pendingFeedback !== "string")
+    state.version !== 3 ||
+    typeof state.enabled !== "boolean" ||
+    typeof state.strict !== "boolean" ||
+    (state.strict && !state.enabled) ||
+    lastProcessedReply === ""
   ) {
     throw new Error(`invalid session state in ${path}`)
   }
   return {
-    version: 2,
-    lastProcessedReply: state.lastProcessedReply,
-    ...(state.pendingFeedback === undefined
-      ? {}
-      : { pendingFeedback: state.pendingFeedback as string }),
+    version: 3,
+    enabled: state.enabled,
+    strict: state.strict,
+    ...(lastProcessedReply === undefined ? {} : { lastProcessedReply }),
+    ...(pendingFeedback === undefined ? {} : { pendingFeedback }),
   }
 }
 
-async function readState(sessionId: string): Promise<ReturnType<typeof decodeState> | undefined> {
+async function readState(sessionId: string): Promise<SessionState | undefined> {
   const path = sessionPath(sessionId)
   try {
     return decodeState(await readFile(path, "utf8"), path)
   } catch (cause) {
-    if (isMissingFile(cause)) return undefined
+    if (isFileError(cause, "ENOENT")) return undefined
     throw cause
   }
 }
@@ -76,48 +105,110 @@ async function writeState(sessionId: string, state: SessionState): Promise<void>
   }
 }
 
+const wait = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+async function acquireLock(sessionId: string): Promise<() => Promise<void>> {
+  const directory = sessionsDirectory()
+  const path = lockPath(sessionId)
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  for (let attempt = 0; attempt < LOCK_RETRIES; attempt += 1) {
+    try {
+      await mkdir(path, { mode: 0o700 })
+      return () => rm(path, { recursive: true, force: true })
+    } catch (cause) {
+      if (!isFileError(cause, "EEXIST")) throw cause
+      try {
+        const lockStat = await stat(path)
+        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MILLISECONDS) {
+          await rm(path, { recursive: true, force: true })
+          continue
+        }
+      } catch (statCause) {
+        if (!isFileError(statCause, "ENOENT")) throw statCause
+      }
+      await wait(LOCK_RETRY_MILLISECONDS)
+    }
+  }
+  throw new Error(`timed out while reading session ${sessionId}`)
+}
+
+async function withStateLock<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+  const release = await acquireLock(sessionId)
+  try {
+    return await operation()
+  } finally {
+    await release()
+  }
+}
+
+const currentState = (state: SessionState | undefined): SessionState =>
+  state ?? { version: 3, ...DEFAULT_CONTROL }
+
+export async function getSessionControl(sessionId: string): Promise<SessionControl> {
+  return withStateLock(sessionId, async () => {
+    const { enabled, strict } = currentState(await readState(sessionId))
+    return { enabled, strict }
+  })
+}
+
+export async function setSessionEnabled(sessionId: string, enabled: boolean): Promise<void> {
+  await withStateLock(sessionId, async () => {
+    const state = currentState(await readState(sessionId))
+    await writeState(sessionId, {
+      ...state,
+      enabled,
+      strict: enabled ? state.strict : false,
+      ...(enabled || state.pendingFeedback === undefined ? {} : { pendingFeedback: undefined }),
+    })
+  })
+}
+
+export async function setSessionStrict(sessionId: string, strict: boolean): Promise<void> {
+  await withStateLock(sessionId, async () => {
+    const state = currentState(await readState(sessionId))
+    await writeState(sessionId, {
+      ...state,
+      enabled: strict ? true : state.enabled,
+      strict,
+    })
+  })
+}
+
 export async function hasProcessedReply(
   sessionId: string,
   replyIdentity: string,
 ): Promise<boolean> {
-  const state = await readState(sessionId)
-  return state !== undefined && "lastProcessedReply" in state
-    ? state.lastProcessedReply === replyIdentity
-    : false
+  return withStateLock(sessionId, async () => {
+    const state = await readState(sessionId)
+    return state?.lastProcessedReply === replyIdentity
+  })
 }
 
 export async function setReplyFeedback(
   sessionId: string,
   replyIdentity: string,
   pendingFeedback: string | undefined,
-): Promise<void> {
-  if (await hasProcessedReply(sessionId, replyIdentity)) return
-  await writeState(sessionId, {
-    version: 2,
-    lastProcessedReply: replyIdentity,
-    ...(pendingFeedback === undefined ? {} : { pendingFeedback }),
+): Promise<SessionControl | undefined> {
+  return withStateLock(sessionId, async () => {
+    const state = currentState(await readState(sessionId))
+    if (!state.enabled || state.lastProcessedReply === replyIdentity) return undefined
+    await writeState(sessionId, {
+      ...state,
+      lastProcessedReply: replyIdentity,
+      ...(state.strict || pendingFeedback === undefined
+        ? { pendingFeedback: undefined }
+        : { pendingFeedback }),
+    })
+    return { enabled: state.enabled, strict: state.strict }
   })
 }
 
 export async function consumePendingFeedback(sessionId: string): Promise<string | undefined> {
-  const path = sessionPath(sessionId)
-  const claimedPath = `${path}.${randomUUID()}.claimed`
-  try {
-    await rename(path, claimedPath)
-  } catch (cause) {
-    if (isMissingFile(cause)) return undefined
-    throw cause
-  }
-
-  try {
-    const state = decodeState(await readFile(claimedPath, "utf8"), claimedPath)
-    if (!("lastProcessedReply" in state)) return state.pendingFeedback
-    await writeState(sessionId, {
-      version: 2,
-      lastProcessedReply: state.lastProcessedReply,
-    })
+  return withStateLock(sessionId, async () => {
+    const state = await readState(sessionId)
+    if (state?.pendingFeedback === undefined) return undefined
+    await writeState(sessionId, { ...state, pendingFeedback: undefined })
     return state.pendingFeedback
-  } finally {
-    await rm(claimedPath, { force: true })
-  }
+  })
 }

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -17,16 +17,15 @@ import { Effect } from "effect"
 import { Type } from "typebox"
 import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-message.ts"
 import { formatViolations, violationDetails } from "../adapter/feedback.ts"
-import { RULE_SUMMARIES, resolvedRuleSetting, ruleSummary } from "../adapter/rule-summary.ts"
+import { formatStatusSummary, ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import type { SteConfig } from "../config/schema.ts"
 import { loadDictionary } from "../dictionary/load.ts"
 import type { Dictionary } from "../dictionary/schema.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
-import type { RuleId } from "../engine/rules/registry.ts"
 import type { Tagger } from "../engine/tagger.ts"
-import type { LintReport, RuleSetting, Violation } from "../engine/types.ts"
+import type { LintReport, Violation } from "../engine/types.ts"
 import { makeWinkTagger } from "../tagger/wink.ts"
 
 const STE_COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
@@ -65,10 +64,6 @@ const STRICT_MODE_NOTE = [
 let sharedTagger: Tagger | undefined
 
 function statusSummary(state: SessionState): string {
-  const counts: Record<RuleSetting, number> = { hard: 0, soft: 0, off: 0 }
-  for (const ruleId of Object.keys(RULE_SUMMARIES) as RuleId[]) {
-    counts[resolvedRuleSetting(state.config, ruleId)]++
-  }
   const mode = !state.enabled ? "disabled" : state.strict ? "strict" : "enabled"
   const dictionary =
     state.dictionary !== undefined
@@ -76,11 +71,7 @@ function statusSummary(state: SessionState): string {
       : state.dictionaryError !== undefined
         ? `failed (${state.dictionaryError})`
         : "not loaded"
-  return [
-    `Mode: ${mode}`,
-    `Rules: ${counts.hard} hard, ${counts.soft} soft, ${counts.off} off`,
-    `Dictionary: ${dictionary}`,
-  ].join("\n")
+  return formatStatusSummary(state.config, mode, dictionary)
 }
 
 function formatReplyFeedback(violations: readonly Violation[]): string {

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -289,6 +289,24 @@ describe("simple-english CLI hook mode", () => {
     expect(failedDictionary.stdout).toContain("missing-dictionary.json")
   })
 
+  test("reports unavailable status details when config loading fails", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    await writeFile(join(cwd, ".simple-english.json"), "{")
+    await runSessionCommand("session-1", cwd, "off", xdgStateHome)
+
+    const status = await runSessionCommand("session-1", cwd, "status", xdgStateHome)
+
+    expect(status.code).toBe(0)
+    expect(status.stdout).toContain("Mode: disabled")
+    expect(status.stdout).toContain("Config: failed (invalid JSON in")
+    expect(status.stdout).toContain(join(cwd, ".simple-english.json"))
+    expect(status.stdout).toContain("Rules: unavailable")
+    expect(status.stdout).toContain("Dictionary: unavailable")
+    expect(status.stdout).not.toMatch(/Rules: \d+ hard/)
+  })
+
   test("blocks one strict Stop, then allows the clean rewrite Stop", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -381,6 +381,36 @@ describe("simple-english CLI hook mode", () => {
     expect(decision(submitted.output).additionalContext).toContain("[contraction]")
   })
 
+  test("records rewritten feedback after a clean Stop and strict off", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "strict-off-rewrite-session.jsonl")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    await runSessionCommand("strict-off-rewrite-session", cwd, "strict", xdgStateHome)
+
+    const cleanStop = await runReplyHook(
+      stopEvent(cwd, "strict-off-rewrite-session", transcriptPath, "Close the valve."),
+      cwd,
+      xdgStateHome,
+    )
+    await runSessionCommand("strict-off-rewrite-session", cwd, "strict off", xdgStateHome)
+    const rewrittenStop = await runReplyHook(
+      stopEvent(cwd, "strict-off-rewrite-session", transcriptPath, "This isn't permitted.", true),
+      cwd,
+      xdgStateHome,
+    )
+    const submitted = await runReplyHook(
+      userPromptEvent(cwd, "strict-off-rewrite-session"),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(cleanStop.output).toEqual({})
+    expect(rewrittenStop.output).toEqual({})
+    expect(decision(submitted.output).additionalContext).toContain("[contraction]")
+  })
+
   test("rejects an invalid session command without changing state", async () => {
     const cwd = await makeProject()
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -22,12 +22,17 @@ interface HookSpecificOutput {
 
 interface HookOutput {
   readonly continue?: boolean
+  readonly decision?: "block"
+  readonly reason?: string
   readonly systemMessage?: string
   readonly hookSpecificOutput?: HookSpecificOutput
 }
 
 interface SessionState {
-  readonly lastProcessedReply: string
+  readonly version: number
+  readonly enabled: boolean
+  readonly strict: boolean
+  readonly lastProcessedReply?: string
   readonly pendingFeedback?: string
 }
 
@@ -46,9 +51,14 @@ async function makeProject(config?: object): Promise<string> {
   return cwd
 }
 
-function event(cwd: string, toolName: "Write" | "Edit" | "Bash", toolInput: object): string {
+function event(
+  cwd: string,
+  toolName: "Write" | "Edit" | "Bash",
+  toolInput: object,
+  sessionId = "session-1",
+): string {
   return JSON.stringify({
-    session_id: "session-1",
+    session_id: sessionId,
     transcript_path: join(cwd, "transcript.jsonl"),
     cwd,
     permission_mode: "default",
@@ -75,6 +85,7 @@ function stopEvent(
   sessionId: string,
   transcriptPath: string,
   lastAssistantMessage?: string,
+  stopHookActive = false,
 ): string {
   return JSON.stringify({
     session_id: sessionId,
@@ -82,7 +93,7 @@ function stopEvent(
     cwd,
     permission_mode: "default",
     hook_event_name: "Stop",
-    stop_hook_active: false,
+    stop_hook_active: stopHookActive,
     ...(lastAssistantMessage === undefined ? {} : { last_assistant_message: lastAssistantMessage }),
   })
 }
@@ -152,12 +163,218 @@ function runReplyHook(stdin: string, cwd: string, xdgStateHome: string) {
   return runHook(stdin, cwd, undefined, undefined, undefined, undefined, xdgStateHome)
 }
 
+function runSessionCommand(
+  sessionId: string,
+  cwd: string,
+  command: string,
+  xdgStateHome: string,
+  dictionaryPath?: string,
+) {
+  return runCli(["session", sessionId, cwd, command], {
+    cwd,
+    xdgStateHome,
+    dictionaryPath,
+  })
+}
+
 function decision(output: HookOutput): HookSpecificOutput {
   expect(output.hookSpecificOutput).toBeDefined()
   return output.hookSpecificOutput as HookSpecificOutput
 }
 
 describe("simple-english CLI hook mode", () => {
+  test("disables every hook gate for only the selected session and enables it again", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const violatingWrite = (sessionId: string) =>
+      event(
+        cwd,
+        "Write",
+        {
+          file_path: join(cwd, "notes.md"),
+          content: "This isn't permitted.",
+        },
+        sessionId,
+      )
+
+    const disabled = await runSessionCommand("session-1", cwd, "off", xdgStateHome)
+    const disabledWrite = await runReplyHook(violatingWrite("session-1"), cwd, xdgStateHome)
+    const parallelWrite = await runReplyHook(violatingWrite("session-2"), cwd, xdgStateHome)
+    const disabledStart = await runReplyHook(sessionStartEvent(cwd), cwd, xdgStateHome)
+    const transcriptPath = join(cwd, "disabled-session.jsonl")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    const disabledStop = await runReplyHook(
+      stopEvent(cwd, "session-1", transcriptPath, "This isn't permitted."),
+      cwd,
+      xdgStateHome,
+    )
+    const disabledPrompt = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
+
+    expect(disabled).toMatchObject({ code: 0, stdout: "STE enforcement disabled.\n" })
+    expect(decision(disabledWrite.output).permissionDecision).toBe("allow")
+    expect(decision(parallelWrite.output).permissionDecision).toBe("deny")
+    expect(disabledStart.output).toEqual({})
+    expect(disabledStop.output).toEqual({})
+    expect(disabledPrompt.output).toEqual({})
+    const disabledFiles = await stateFiles(xdgStateHome)
+    expect(disabledFiles).toHaveLength(1)
+    const disabledState = JSON.parse(
+      await readFile(
+        join(xdgStateHome, "simple-english", "sessions", disabledFiles[0] as string),
+        "utf8",
+      ),
+    ) as SessionState
+    expect(disabledState).toMatchObject({ version: 3, enabled: false, strict: false })
+
+    const enabled = await runSessionCommand("session-1", cwd, "on", xdgStateHome)
+    const enabledWrite = await runReplyHook(violatingWrite("session-1"), cwd, xdgStateHome)
+
+    expect(enabled).toMatchObject({ code: 0, stdout: "STE enforcement enabled.\n" })
+    expect(decision(enabledWrite.output).permissionDecision).toBe("deny")
+    const enabledState = JSON.parse(
+      await readFile(
+        join(xdgStateHome, "simple-english", "sessions", disabledFiles[0] as string),
+        "utf8",
+      ),
+    ) as SessionState
+    expect(enabledState).toMatchObject({ version: 3, enabled: true, strict: false })
+  })
+
+  test("starts a new session in enabled non-strict mode", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    await runSessionCommand("old-session", cwd, "strict", xdgStateHome)
+    await runSessionCommand("old-session", cwd, "off", xdgStateHome)
+
+    const result = await runReplyHook(
+      event(
+        cwd,
+        "Write",
+        { file_path: join(cwd, "notes.md"), content: "This isn't permitted." },
+        "new-session",
+      ),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(decision(result.output).permissionDecision).toBe("deny")
+  })
+
+  test("reports session mode, rule counts, and dictionary state", async () => {
+    const cwd = await makeProject({
+      rules: { contraction: "off", semicolon: "soft" },
+    })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    await runSessionCommand("session-1", cwd, "off", xdgStateHome)
+
+    const status = await runSessionCommand("session-1", cwd, "status", xdgStateHome)
+
+    expect(status.code).toBe(0)
+    expect(status.stdout).toContain("Mode: disabled")
+    expect(status.stdout).toContain("Rules: 6 hard, 4 soft, 1 off")
+    expect(status.stdout).toContain("Dictionary: loaded")
+
+    const failedDictionary = await runSessionCommand(
+      "session-1",
+      cwd,
+      "status",
+      xdgStateHome,
+      join(cwd, "missing-dictionary.json"),
+    )
+    expect(failedDictionary.code).toBe(0)
+    expect(failedDictionary.stdout).toContain("Dictionary: failed (")
+    expect(failedDictionary.stdout).toContain("missing-dictionary.json")
+  })
+
+  test("blocks one strict Stop, then allows the clean rewrite Stop", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "strict-session.jsonl")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    await runSessionCommand("strict-session", cwd, "strict", xdgStateHome)
+    const strictFiles = await stateFiles(xdgStateHome)
+    const strictState = JSON.parse(
+      await readFile(
+        join(xdgStateHome, "simple-english", "sessions", strictFiles[0] as string),
+        "utf8",
+      ),
+    ) as SessionState
+    expect(strictState).toMatchObject({ version: 3, enabled: true, strict: true })
+
+    const blocked = await runReplyHook(
+      stopEvent(cwd, "strict-session", transcriptPath, "This isn't permitted."),
+      cwd,
+      xdgStateHome,
+    )
+    const rewritten = await runReplyHook(
+      stopEvent(cwd, "strict-session", transcriptPath, "Close the valve.", true),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(blocked.output.decision).toBe("block")
+    expect(blocked.output.reason).toContain("[contraction]")
+    expect(rewritten.output).toEqual({})
+  })
+
+  test("never blocks an already active Stop hook", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "active-session.jsonl")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    await runSessionCommand("active-session", cwd, "strict", xdgStateHome)
+
+    const result = await runReplyHook(
+      stopEvent(cwd, "active-session", transcriptPath, "This isn't permitted.", true),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(result.output).toEqual({})
+  })
+
+  test("returns strict mode to deferred feedback behavior", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const transcriptPath = join(cwd, "strict-off-session.jsonl")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    await runSessionCommand("strict-off-session", cwd, "strict", xdgStateHome)
+
+    const disabled = await runSessionCommand("strict-off-session", cwd, "strict off", xdgStateHome)
+    const stopped = await runReplyHook(
+      stopEvent(cwd, "strict-off-session", transcriptPath, "This isn't permitted."),
+      cwd,
+      xdgStateHome,
+    )
+    const submitted = await runReplyHook(
+      userPromptEvent(cwd, "strict-off-session"),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(disabled).toMatchObject({ code: 0, stdout: "STE strict mode disabled.\n" })
+    expect(stopped.output).toEqual({})
+    expect(decision(submitted.output).additionalContext).toContain("[contraction]")
+  })
+
+  test("rejects an invalid session command without changing state", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const result = await runSessionCommand("session-1", cwd, "invalid", xdgStateHome)
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("Usage: /ste [on|off|status|strict|strict off]")
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+  })
+
   test("records hard reply feedback, injects it once, and clears pending feedback", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -356,7 +356,7 @@ describe("simple-english CLI hook mode", () => {
     expect(result.output).toEqual({})
   })
 
-  test("returns strict mode to deferred feedback behavior", async () => {
+  test("records deferred feedback from an active Stop after strict mode is off", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
@@ -366,7 +366,7 @@ describe("simple-english CLI hook mode", () => {
 
     const disabled = await runSessionCommand("strict-off-session", cwd, "strict off", xdgStateHome)
     const stopped = await runReplyHook(
-      stopEvent(cwd, "strict-off-session", transcriptPath, "This isn't permitted."),
+      stopEvent(cwd, "strict-off-session", transcriptPath, "This isn't permitted.", true),
       cwd,
       xdgStateHome,
     )

--- a/test/extension/claude-plugin.test.ts
+++ b/test/extension/claude-plugin.test.ts
@@ -20,6 +20,7 @@ const repoRoot = process.cwd()
 const pluginManifestPath = join(repoRoot, ".claude-plugin", "plugin.json")
 const marketplaceManifestPath = join(repoRoot, ".claude-plugin", "marketplace.json")
 const hooksPath = join(repoRoot, "hooks", "hooks.json")
+const steCommandPath = join(repoRoot, "commands", "ste.md")
 
 async function readJson(path: string): Promise<unknown> {
   return JSON.parse(await readFile(path, "utf8")) as unknown
@@ -43,7 +44,7 @@ describe("Claude Code plugin wiring", () => {
       repository: "https://github.com/jyooi/agent-simple-english",
     })
     expect(packageManifest.files).toEqual(
-      expect.arrayContaining([".claude-plugin", "hooks", "src"]),
+      expect.arrayContaining([".claude-plugin", "commands", "hooks", "src"]),
     )
     expect(marketplace.name).toBe("agent-simple-english")
     expect(marketplace.plugins).toEqual([
@@ -53,6 +54,18 @@ describe("Claude Code plugin wiring", () => {
         source: "./",
       }),
     ])
+  })
+
+  test("defines the session STE command", async () => {
+    const command = await readFile(steCommandPath, "utf8")
+
+    expect(command).toContain("description: Control STE for this Claude Code session")
+    expect(command).toContain("argument-hint: on|off|status|strict|strict off")
+    expect(command).toContain("${CLAUDE_PLUGIN_ROOT}")
+    expect(command).toContain("${CLAUDE_SESSION_ID}")
+    expect(command).toContain("${CLAUDE_PROJECT_DIR}")
+    expect(command).toContain("$ARGUMENTS")
+    expect(command).toContain('src/cli/main.ts" session')
   })
 
   test("registers the session, tool gate, and reply feedback hooks", async () => {


### PR DESCRIPTION
## Intent

Implement Linear ticket HUF-153 for the Claude Code Adapter. Add a /ste command with on, off, status, strict, and strict off session controls. Store mode per Claude Code session and make every hook read that state, so parallel and new sessions stay independent. In strict mode, block a Stop with hard STE violations and return the violations for one immediate rewrite. Honor stop_hook_active to prevent a rewrite loop. Keep normal deferred feedback after strict off. Report mode, hard, soft, and off rule counts, plus dictionary state. Pin behavior with spawned CLI tests and validate the command definition without running Claude Code. Document the Claude Code strict-mode limit: Stop runs after streamed text, so this Adapter cannot redact text that the host already showed. Preserve internal-failure allow-with-warning behavior and existing turn identity deduplication. Do not publish npm or modify Linear.

## What Changed

- Add per-session `/ste` controls for enable, disable, status, and strict modes, with rule counts and dictionary state.
- Make every Claude Code hook honor session mode, preserve deferred feedback, and block one strict reply rewrite without loops.
- Add CLI and plugin tests, package the command, and document the streamed-text limit of strict mode.

## Risk Assessment

✅ Low: The change is bounded and preserves session isolation, strict Stop behavior, status reporting, command packaging, and reply deduplication.

## Testing

No baseline test output was supplied. Targeted spawned CLI and command-definition tests passed. Manual hook events confirmed controls, strict blocking, loop prevention, deferred feedback, and session isolation. The worktree stayed clean.

<details>
<summary>Evidence: Claude Code Adapter end-to-end CLI and hook transcript</summary>

```text
Claude Code Adapter end-to-end transcript

$ /ste status  [session: alpha]
Mode: enabled
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded

$ /ste strict  [session: alpha]
STE strict mode enabled.
$ /ste status  [session: alpha]
Mode: strict
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded

$ Claude Code Stop (hard violation, stop_hook_active=false)
{"decision":"block","reason":"STE blocked reply for assistant reply:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}

$ Claude Code Stop rewrite (hard violation, stop_hook_active=true)
{}

$ /ste strict off  [session: alpha]
STE strict mode disabled.
$ Claude Code Stop in normal mode (deferred feedback)
{}
$ Claude Code UserPromptSubmit (feedback delivered)
{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"STE reply feedback for assistant reply:\n- line 1, column 4 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

$ /ste off  [session: alpha]
STE enforcement disabled.
$ /ste status  [session: alpha]
Mode: disabled
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded
$ Claude Code SessionStart while alpha is off
{}
$ Claude Code PreToolUse Write while alpha is off
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}
$ Claude Code Stop while alpha is off
{}
$ Claude Code UserPromptSubmit while alpha is off
{}

$ /ste status  [session: beta]
Mode: enabled
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded
$ Claude Code PreToolUse Write in independent beta session
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STE blocked write for /tmp/no-mistakes-evidence/01KYXVSMN3XWWAR4QHNHQRF56M/project/notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

$ /ste on  [session: alpha]
STE enforcement enabled.
$ /ste status  [session: alpha]
Mode: enabled
Rules: 7 hard, 3 soft, 1 off
Dictionary: loaded
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `src/cli/session-state.ts:123` - A suspended owner can exceed ten seconds. Another process then removes its lock, and the first owner can overwrite newer mode state. Do not steal locks by age alone. Record ownership and verify owner liveness before removal.
- ⚠️ `src/cli/session-command.ts:43` - The intent requires rule counts and dictionary state. A config error instead reports default counts and skips the dictionary check. Ask whether status must fail or report explicit config and dictionary failures.
- ℹ️ `docs/adr/0002-claude-code-reply-feedback.md:25` - The ADR still says feedback reads claim the state file with an atomic rename. The new implementation uses a directory lock and rewrites the file. Update this design description.

🔧 Fix: fix: report invalid config status
1 error still open:
- 🚨 `src/cli/hook.ts:648` - The intent requires &#34;Keep normal deferred feedback after strict off.&#34; Another Stop hook can request a rewrite after `strict off`. The next Stop has `stop_hook_active: true`, so line 648 skips `evaluateReply` and records no feedback. Apply this bypass only when this session is strict.

🔧 Fix: fix: preserve deferred feedback after strict mode
1 error still open:
- 🚨 `src/cli/hook.ts:558` - The requirement says, &#34;Keep normal deferred feedback after strict off.&#34; A clean first Stop saves the turn identity. A violating active Stop shares that identity, so line 558 ignores it and saves no feedback. Form the event identity from both the turn identity and reply text.

🔧 Fix: fix: preserve feedback after reply changes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/cli/hook.test.ts test/extension/claude-plugin.test.ts -t 'disables every hook gate|starts a new session|reports session mode|reports unavailable status|blocks one strict Stop|never blocks an already active Stop hook|records deferred feedback from an active Stop after strict mode is off|records rewritten feedback after a clean Stop and strict off|rejects an invalid session command|records hard reply feedback|uses the Stop reply|scopes pending reply feedback|allows Stop when the transcript cannot be read|Claude Code plugin wiring'`
- `bunx vitest run test/cli/hook.test.ts -t 'ignores duplicate Stops and records a new reply|allows Stop when the transcript cannot be read|allows a valid event with a warning when configuration load fails|allows a valid event with a warning when tagger setup fails|returns a non-blocking JSON error for malformed event JSON'`
- <code>Spawned `bun src/cli/main.ts session` and `bun src/cli/main.ts hook` for all session controls, all hook types, strict rewriting, and parallel sessions.</code>
- `rg -n 'streamed reply text|cannot redact text|stop_hook_active|one immediate rewrite' README.md docs/adr/0001-per-host-enforcement-ceiling.md docs/adr/0002-claude-code-reply-feedback.md commands/ste.md`
- <code>`git status --short --untracked-files=all` after evidence capture and cleanup</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
