### PR TITLE
docs: use consistent agent-simple-english project name

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,4 +1,4 @@
-# Simple English (STE) Toolkit
+# agent-simple-english
 
 A lint engine for ASD-STE100 Simplified Technical English, enforced inside coding agents.
 One agent-agnostic engine; one adapter per host.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,7 +1,8 @@
 # agent-simple-english
 
-A lint engine for ASD-STE100 Simplified Technical English, enforced inside coding agents.
-One agent-agnostic engine; one adapter per host.
+Coding agents use this lint engine to enforce ASD-STE100 Simplified Technical English.
+One agent-agnostic engine.
+One adapter per host.
 
 ## Language
 
@@ -10,7 +11,7 @@ The pure, synchronous lint core that turns text into a report of violations.
 _Avoid_: linter core, checker
 
 **Host**:
-A coding agent runtime the engine is enforced in.
+A coding agent runtime that enforces STE with the Engine.
 Current hosts: pi and Claude Code.
 _Avoid_: platform, agent (ambiguous with the LLM itself), IDE
 
@@ -20,18 +21,20 @@ _Avoid_: plugin (that is the Claude Code artifact name, not the concept), integr
 
 **Enforcement ceiling**:
 The strongest set of STE behaviors a host's extension surface allows.
-Adapters implement up to their host's ceiling; parity across hosts is not required.
+Each Adapter implements STE behaviors up to its Host's ceiling.
+Adapters do not need parity across Hosts.
 
 **Hook mode**:
 The CLI mode that speaks a host's hook protocol: hook event JSON on stdin, hook decision JSON on stdout.
-Hosts whose adapters are hook-based (Claude Code) enforce STE by spawning the CLI in this mode.
+Hosts with hook-based Adapters enforce STE when they start the CLI in this mode.
 
 **Gate**:
 A check that blocks an action (write, edit, commit, reply) when the text has hard violations.
 _Avoid_: guard, filter
 
 **Hard / soft severity**:
-A hard violation blocks the gated action; a soft violation only produces a warning.
+A hard violation blocks the gated action.
+A soft violation only produces a warning.
 
 **Strict mode**:
 The mode that applies the host's strongest available reply gate to hard violations.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# simple-english
+# agent-simple-english
 
-`simple-english` checks ASD-STE100 Simplified Technical English (STE).
+`agent-simple-english` checks ASD-STE100 Simplified Technical English (STE).
 It supplies one Engine, one CLI, a pi Adapter, and a Claude Code Adapter.
 The Claude Code plugin uses CLI Hook mode to enforce the same rules.
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A `SessionStart` event returns the active rule summary as added context.
 A `PreToolUse` event applies the write, edit, and commit gates that the plugin registers.
 A `Stop` event records hard reply feedback in enabled non-strict mode.
 In strict mode, it blocks a reply that has hard violations.
+
 A `UserPromptSubmit` event adds pending feedback to context and clears that feedback.
 Every hook reads the current session mode before it applies a gate.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
@@ -258,6 +259,7 @@ The project fallback is `.pi/simple-english.json`.
 The global fallback is `simple-english.json` in the pi agent config directory.
 The default pi agent config directory is `~/.pi/agent`.
 `PI_CODING_AGENT_DIR` can change that directory.
+
 The loader resolves a relative value from the working directory that requested the config.
 The loader reads a fallback file only when the new file at the same level is absent.
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,6 +1,7 @@
 # Release verification
 
 This record captures the HUF-142 release checks from 2026-07-31.
+The captured commands and output predate the npm package rename to `simple-english`.
 The checks used Bun 1.3.14, npm 11.6.2, Node.js 24.12.0, and pi 0.83.0.
 
 ## Isolated pi package installation


### PR DESCRIPTION
## Intent

Make the project name consistent across repository documentation after the GitHub repository rename from jyooi/ste to jyooi/agent-simple-english on 2026-08-01. Present the project and repository as agent-simple-english. Change the README title to # agent-simple-english and use agent-simple-english in README prose that names the project as a whole. Apply the same rule across docs/, including docs/adr/ and docs/agents/, plus CONTEXT.md, AGENTS.md, CLAUDE.md, and THIRD_PARTY_NOTICES.md. Keep all code-level identifiers unchanged. The npm package name, CLI binary, command examples, and sentences that name the package or command remain simple-english. Keep the plugin id simple-english@agent-simple-english. Keep .simple-english.json, .pi/simple-english.json, $XDG_STATE_HOME/simple-english/sessions, and $XDG_CONFIG_HOME/simple-english/config.json unchanged. In docs/release-verification.md, update only procedure prose to current names. Do not invent or edit captured commands or output from the real pre-rename run that used pi-simple-english. Add one short note that the captured output predates the package rename. Search repository documentation for pi-simple-english and project-name prose that still reads simple-english. Confirm that each remaining match is an intentional identifier or historical captured record. Use repository ASD-STE100 prose style. Do not use contractions or semicolons. Keep sentences to 25 words or fewer and use active voice.

## What Changed

- Rename the documented project to `agent-simple-english` in the README and context glossary.
- Correct context glossary prose for clear, consistent STE terms.
- Note that captured release commands and output predate the npm package rename.

## Risk Assessment

✅ Low: The change is limited to documentation and meets the project naming and historical record requirements.

## Testing

Baseline and target README checks produced identical pre-existing paragraph reports. Focused tests, audits, prose checks, and rendered evidence confirmed the rename.

- Evidence: Rendered README showing the new project title and opening prose (local file: <code>/tmp/no-mistakes-evidence/01KYYP7RWAZBJ5P4QAW9B7NNDX/README-name.png</code>)
<details>
<summary>Evidence: Rendered README HTML</summary>

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
<title>agent-simple-english README</title>
<style>
body { color: #1f2328; background: #fff; font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; }
main { box-sizing: border-box; max-width: 1012px; margin: 0 auto; padding: 32px; }
h1, h2, h3 { line-height: 1.25; border-bottom: 1px solid #d0d7de; padding-bottom: .3em; }
code { background: #f6f8fa; border-radius: 6px; padding: .2em .4em; }
pre { background: #f6f8fa; border-radius: 6px; padding: 16px; overflow: auto; }
pre code { padding: 0; }
a { color: #0969da; }
table { border-collapse: collapse; } th, td { border: 1px solid #d0d7de; padding: 6px 13px; }
</style></head><body><main><h1>agent-simple-english</h1>
<p><code>agent-simple-english</code> checks ASD-STE100 Simplified Technical English (STE).
It supplies one Engine, one CLI, a pi Adapter, and a Claude Code Adapter.
The Claude Code plugin uses CLI Hook mode to enforce the same rules.</p>
<p>This package reports deterministic writing problems.
It does not rewrite text because an automatic rewrite can change its meaning.</p>
<h2>What the pi Adapter does</h2>
<p>The pi Adapter adds its active STE rules to the model prompt before each agent turn.
It then applies the rules at three layers.</p>
<ol>
<li><p><strong>Write and edit gate.</strong>
The extension checks prose before the <code>write</code> or <code>edit</code> tool changes a file.
A hard violation blocks the tool.
A soft violation gives the model a warning but lets the tool change the file.
An edit reports only new violations, so an old violation does not block an unrelated edit.</p>
</li>
<li><p><strong>Commit-message gate.</strong>
The extension checks static messages in detected <code>git commit -m</code> and <code>git commit --message</code> commands.
A hard violation blocks the command before the shell starts.
Conventional Commit prefixes and final trailer lines do not form part of the check.
A detected commit without an available static message fails closed.</p>
</li>
<li><p><strong>Reply check.</strong>
Normal mode checks each final assistant reply and shows the hard and soft counts in a widget.
The model receives hard violation details before its next call.
Normal mode does not hide or change the reply.
Strict mode makes the model send each reply through the <code>say</code> tool.
A strict reply stays hidden until it has no hard violations.</p>
</li>
</ol>
<p>The pi Adapter checks Markdown prose and source comments according to the <a href="#content-kinds">content kinds</a>.
It gives the line, column, rule ID, and suggested correction for a blocked tool call.
A config or dictionary load error makes enabled write, edit, and commit gates fail closed.</p>
<h2>Install the Claude Code Adapter</h2>
<p>Install <a href="https://docs.anthropic.com/en/docs/claude-code">Claude Code</a> and <a href="https://bun.sh">Bun</a> first.
Then use the standard local plugin flow:</p>
<pre><code class="language-sh">claude plugin marketplace add jyooi/agent-simple-english
claude plugin install simple-english@agent-simple-english
</code></pre>
<p>Start a new Claude Code session after installation.
Bun installs the plugin dependencies when the first hook starts.
You do not need a global <code>simple-english</code> package or manual hook settings.
The repository supplies the local marketplace manifest.
Marketplace publication is outside this package release.</p>
<p>At <code>SessionStart</code>, the Adapter loads the merged config for an enabled session.
It reads the config from the session working directory and adds the active STE rule summary to context.
The summary honors <code>hard</code>, <code>soft</code>, and <code>off</code> rule settings plus <code>maxSentenceWords</code>.</p>
<p>The <code>PreToolUse</code> gate checks <code>Write</code>, <code>Edit</code>, and <code>Bash</code> events.
A hard write or edit violation blocks the tool and returns its location, rule ID, and suggested correction.
The Adapter checks only new edit violations, so old prose does not block an unrelated edit.
Correct the text and retry the tool.
A clean retry succeeds.</p>
<p>For <code>Bash</code>, the gate checks static messages in detected <code>git commit</code> commands.
It blocks a hard violation before Git starts.
It also blocks a detected commit without a static <code>-m</code> or <code>--message</code> argument.
A compliant static message passes.
Soft violations allow the event and add warning text.</p>
<h3>Session controls</h3>
<p>The <code>/ste</code> command controls the current Claude Code session.
New sessions start in enabled mode without a strict reply gate.
A change in one session does not change a parallel session.</p>
<table>
<thead>
<tr>
<th>Command</th>
<th>Result</th>
</tr>
</thead>
<tbody><tr>
<td><code>/ste on</code></td>
<td>Enable write, edit, commit, and reply checks.</td>
</tr>
<tr>
<td><code>/ste off</code></td>
<td>Disable all checks and leave strict mode.</td>
</tr>
<tr>
<td><code>/ste status</code></td>
<td>Show the mode, rule counts, and dictionary state.</td>
</tr>
<tr>
<td><code>/ste strict</code></td>
<td>Enable the strict reply gate and all other checks.</td>
</tr>
<tr>
<td><code>/ste strict off</code></td>
<td>Disable the strict reply gate and use reply feedback.</td>
</tr>
</tbody></table>
<p>Strict mode blocks a <code>Stop</code> event when the reply has a hard violation.
Claude Code then uses the violation details to write the reply again.
The <code>stop_hook_active</code> check stops a second block in the same rewrite loop.</p>
<p>Claude Code shows streamed reply text before the <code>Stop</code> hook runs.
Thus, strict mode can reject the completed reply, but it cannot redact text that Claude Code already showed.
The pi Adapter does not have this gap because its <code>say</code> tool hides strict reply text before approval.</p>
<h3>Reply feedback loop</h3>
<p>In enabled non-strict mode, the <code>Stop</code> hook checks each finished assistant reply after Claude Code shows it.
It records only hard violation details in a state file for that Claude Code session.
The <code>Stop</code> hook does not block or change the reply in this mode.</p>
<p>At the next <code>UserPromptSubmit</code> event, the Adapter adds the pending feedback to the model context.
The feedback gives the line, column, rule ID, and suggested fix for each hard violation.
The Adapter then clears the pending feedback, so it adds each report only one time.
The session state retains the processed reply identity and ignores duplicate <code>Stop</code> events.
Clean and soft-only replies leave no pending feedback.</p>
<p>Each session has a separate state file under <code>$XDG_STATE_HOME/simple-english/sessions</code>.
The default state directory is <code>~/.local/state/simple-english/sessions</code>.
The file stores the session mode, reply identity, and pending feedback.
Concurrent sessions in one project do not read or clear state from another session.</p>
<h2>Install the pi Adapter</h2>
<p>Install <a href="https://pi.dev">pi</a> first.
Then use the pi package mechanism:</p>
<pre><code class="language-sh">pi install npm:simple-english
</code></pre>
<p>Pi records the package in its user settings and loads the extension in each session.
Pi packages run with your user permissions, so inspect third-party package code before installation.</p>
<p>Use the checkout without a persistent installation during development:</p>
<pre><code class="language-sh">git clone https://github.com/jyooi/agent-simple-english.git
cd agent-simple-english
bun install
pi -e .
</code></pre>
<h2>Extension commands</h2>
<p>The mode applies to the current pi session.
The extension starts in enabled mode without strict reply gating.
Type <code>/ste </code> to see autocomplete suggestions for <code>on</code>, <code>off</code>, <code>status</code>, and <code>strict</code>.
The list changes to match the text that you type.</p>
<table>
<thead>
<tr>
<th>Command</th>
<th>Result</th>
</tr>
</thead>
<tbody><tr>
<td><code>/ste</code></td>
<td>Toggle all enforcement.</td>
</tr>
<tr>
<td><code>/ste on</code></td>
<td>

... [5464 bytes truncated] ...

allbacks.
The project fallback is <code>.pi/simple-english.json</code>.
The global fallback is <code>simple-english.json</code> in the pi agent config directory.
The default pi agent config directory is <code>~/.pi/agent</code>.
<code>PI_CODING_AGENT_DIR</code> can change that directory.
The loader resolves a relative value from the working directory that requested the config.
The loader reads a fallback file only when the new file at the same level is absent.</p>
<p>This example contains every config key and every rule:</p>
<pre><code class="language-json">{
  &quot;maxSentenceWords&quot;: 25,
  &quot;rules&quot;: {
    &quot;contraction&quot;: &quot;hard&quot;,
    &quot;dictionary-not-approved-word&quot;: &quot;hard&quot;,
    &quot;hedging&quot;: &quot;soft&quot;,
    &quot;marketing&quot;: &quot;soft&quot;,
    &quot;paragraph-length&quot;: &quot;hard&quot;,
    &quot;phrasal-verb&quot;: &quot;hard&quot;,
    &quot;semicolon&quot;: &quot;hard&quot;,
    &quot;sentence-length&quot;: &quot;hard&quot;,
    &quot;verb-progressive&quot;: &quot;hard&quot;,
    &quot;verb-passive&quot;: &quot;soft&quot;,
    &quot;verb-perfect&quot;: &quot;hard&quot;
  }
}
</code></pre>
<p>Each rule setting accepts <code>hard</code>, <code>soft</code>, or <code>off</code>.
A hard violation fails the CLI and blocks a gated extension action.
A soft violation produces a report or warning but does not block the action.
The <code>off</code> value disables that rule.</p>
<p><code>maxSentenceWords</code> must be a positive integer and has a default value of 25.
Unknown keys, unknown rule IDs, and invalid values cause a config error.</p>
<h2>Rule reference</h2>
<h3><code>contraction</code></h3>
<p>Default: hard.
Reports apostrophe contractions such as forms that end in <code>n&#39;t</code>, <code>&#39;re</code>, <code>&#39;ve</code>, <code>&#39;ll</code>, <code>&#39;d</code>, or <code>&#39;m</code>.
It also reports unambiguous forms that end in <code>&#39;s</code>.</p>
<h3><code>dictionary-not-approved-word</code></h3>
<p>Default: hard.
Reports an unapproved word or phrase from the bundled dictionary and supplies approved alternatives.
Part-of-speech data limits applicable entries when that data exists.
Matching does not depend on letter case.</p>
<h3><code>hedging</code></h3>
<p>Default: soft.
Reports these phrases: <code>it is important to note</code>, <code>it should be noted</code>, <code>it is worth noting</code>, <code>please note that</code>, <code>as mentioned</code>, <code>as noted above</code>.
A phrase match stays on one source line.</p>
<h3><code>marketing</code></h3>
<p>Default: soft.
Reports the first listed term in each token.
Matching does not depend on letter case, and it also examines components of hyphenated tokens.</p>
<ul>
<li><code>seamless</code>.</li>
<li><code>seamlessly</code>.</li>
<li><code>robust</code>.</li>
<li><code>powerful</code>.</li>
<li><code>cutting-edge</code>.</li>
<li><code>effortless</code>.</li>
<li><code>effortlessly</code>.</li>
<li><code>world-class</code>.</li>
<li><code>next-generation</code>.</li>
<li><code>revolutionary</code>.</li>
<li><code>blazing</code>.</li>
<li><code>lightning-fast</code>.</li>
<li><code>elegant</code>.</li>
<li><code>delightful</code>.</li>
<li><code>turnkey</code>.</li>
<li><code>best-in-class</code>.</li>
<li><code>state-of-the-art</code>.</li>
<li><code>game-changing</code>.</li>
<li><code>battle-tested</code>.</li>
<li><code>enterprise-grade</code>.</li>
<li><code>supercharge</code>.</li>
<li><code>unleash</code>.</li>
<li><code>empower</code>.</li>
<li><code>empowers</code>.</li>
</ul>
<h3><code>paragraph-length</code></h3>
<p>Default: hard.
Reports a prose paragraph that has more than six sentences.
Markdown block boundaries and list items start separate paragraphs.</p>
<h3><code>phrasal-verb</code></h3>
<p>Default: hard.
Reports these forms and supplies the listed suggestion:</p>
<table>
<thead>
<tr>
<th>Forms</th>
<th>Suggestion</th>
</tr>
</thead>
<tbody><tr>
<td><code>carry out</code>, <code>carries out</code>, <code>carried out</code>, <code>carrying out</code></td>
<td><code>do</code>.</td>
</tr>
<tr>
<td><code>spin up</code>, <code>spins up</code>, <code>spun up</code>, <code>spinning up</code></td>
<td><code>start</code>.</td>
</tr>
<tr>
<td><code>spin down</code>, <code>spins down</code>, <code>spun down</code>, <code>spinning down</code></td>
<td><code>stop</code>.</td>
</tr>
<tr>
<td><code>tear down</code>, <code>tears down</code>, <code>tore down</code>, <code>torn down</code>, <code>tearing down</code></td>
<td><code>remove</code>.</td>
</tr>
<tr>
<td><code>reach out</code>, <code>reaches out</code>, <code>reached out</code>, <code>reaching out</code></td>
<td><code>ask</code>.</td>
</tr>
<tr>
<td><code>dive into</code>, <code>dives into</code>, <code>dived into</code>, <code>dove into</code>, <code>diving into</code></td>
<td><code>examine</code>.</td>
</tr>
<tr>
<td><code>kick off</code>, <code>kicks off</code>, <code>kicked off</code>, <code>kicking off</code></td>
<td><code>start</code>.</td>
</tr>
<tr>
<td><code>roll out</code>, <code>rolls out</code>, <code>rolled out</code>, <code>rolling out</code></td>
<td><code>release</code>.</td>
</tr>
<tr>
<td><code>ramp up</code>, <code>ramps up</code>, <code>ramped up</code>, <code>ramping up</code></td>
<td><code>increase</code>.</td>
</tr>
<tr>
<td><code>circle back</code>, <code>circles back</code>, <code>circled back</code>, <code>circling back</code></td>
<td><code>return</code>.</td>
</tr>
<tr>
<td><code>drill down</code>, <code>drills down</code>, <code>drilled down</code>, <code>drilling down</code></td>
<td><code>examine</code>.</td>
</tr>
</tbody></table>
<p>Matching does not depend on letter case.
A phrase match stays on one source line.</p>
<h3><code>semicolon</code></h3>
<p>Default: hard.
Reports each semicolon and asks for two sentences.
This rule also checks semicolons inside inline Markdown code.</p>
<h3><code>sentence-length</code></h3>
<p>Default: hard.
Reports a sentence above <code>maxSentenceWords</code>.
The default maximum is 25 words.</p>
<h3><code>verb-progressive</code></h3>
<p>Default: hard.
Reports a form of <code>be</code> followed by an <code>-ing</code> verb, with optional adverbs or <code>not</code> between them.</p>
<h3><code>verb-passive</code></h3>
<p>Default: soft.
Reports a form of <code>be</code> followed by a past participle, with optional adverbs or <code>not</code> between them.</p>
<h3><code>verb-perfect</code></h3>
<p>Default: hard.
Reports auxiliary <code>have</code> followed by a past participle, with optional adverbs or <code>not</code> between them.</p>
<p>The three verb rules and applicable dictionary entries use the bundled English part-of-speech tagger.</p>
<h2>Dictionary and attribution</h2>
<p>The package vendors dictionary data converted from Cameron Moore&#39;s MIT-licensed <a href="https://github.com/ctotheameron/pi-ste"><code>ctotheameron/pi-ste</code></a>.
<a href="THIRD_PARTY_NOTICES.md"><code>THIRD_PARTY_NOTICES.md</code></a> records the pinned source, conversion scope, and license details.</p>
<p>ASD owns ASD-STE100 and limits redistribution of the official specification and dictionary.
This package does not include the official specification or the complete ASD dictionary.
Get the current official specification from the <a href="https://www.asd-ste100.org/">ASD-STE100 site</a>.
This project has no affiliation with or endorsement from ASD.</p>
<p>The package dictionary format and match rules are in <a href="src/dictionary/README.md"><code>src/dictionary/README.md</code></a>.
Set <code>SIMPLE_ENGLISH_DICTIONARY</code> to a replacement dictionary file if necessary.
Hook mode resolves a relative replacement path from the session working directory.
A lint command reports a replacement dictionary load error and continues with all other rules.
The enabled pi Adapter fails closed after that error.</p>
<h2>Development</h2>
<pre><code class="language-sh">bun install
bun run test
bun run lint
bun run typecheck
npm publish --dry-run
</code></pre>
<p>Actual npm publishing is a separate release action.</p>
<h2>License</h2>
<p><a href="LICENSE">MIT</a></p>
</main></body></html>
```
</details>
<details>
<summary>Evidence: Documentation name and preserved identifier audit</summary>

```text
Documentation name verification: PASS
- README title and project prose use agent-simple-english.
- CONTEXT.md uses agent-simple-english as its title.
- Repository and marketplace names use agent-simple-english.
- npm package, CLI binary, plugin id, config paths, and state paths retain required identifiers.
- No code-level or manifest identity file differs from the base commit.
- Every release-verification fenced block matches the base commit byte for byte.
- The release record contains one pre-rename note.
- No repository Markdown file contains jyooi/ste.

Classified documentation matches:
AGENTS.md:8: simple-english - required CLI command
CLAUDE.md:8: simple-english - required CLI command
CONTEXT.md:1: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:1: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:3: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:44: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:45: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:45: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:50: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:104: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:105: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:115: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:124: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:125: agent-simple-english - current project, repository, marketplace, or plugin-id repository name
README.md:153: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:175: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:176: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:182: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:188: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:194: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:202: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:247: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:248: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:249: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:257: simple-english - required npm package, CLI command, plugin id, config path, or state path
README.md:258: simple-english - required npm package, CLI command, plugin id, config path, or state path
docs/adr/0002-claude-code-reply-feedback.md:24: simple-english - required session-state path
docs/release-verification.md:4: simple-english - required npm package, CLI command, plugin id, config path, or state path
docs/release-verification.md:18: pi-simple-english - historical captured command or output
docs/release-verification.md:20: pi-simple-english - historical captured command or output
docs/release-verification.md:29: pi-simple-english - historical captured command or output
docs/release-verification.md:33: pi-simple-english - historical captured command or output
docs/release-verification.md:36: pi-simple-english - historical captured command or output
docs/release-verification.md:37: pi-simple-english - historical captured command or output
docs/release-verification.md:41: simple-english - required npm package, CLI command, plugin id, config path, or state path
docs/release-verification.md:77: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:79: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:81: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:83: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:85: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:93: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:95: simple-english - current CLI command, or text inside the preserved historical record
docs/release-verification.md:110: pi-simple-english - historical captured command or output
docs/release-verification.md:112: pi-simple-english - historical captured command or output
docs/release-verification.md:115: pi-simple-english - historical captured command or output
```
</details>
<details>
<summary>Evidence: STE report for changed prose</summary>

```text
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun x vitest run test/extension/claude-plugin.test.ts` verified package, repository, marketplace, and plugin identities.</code>
- <code>`bun src/cli/main.ts --json README.md` and the base README check produced identical pre-existing paragraph reports.</code>
- <code>`bun src/cli/main.ts --json docs/release-verification.md` checked the release record.</code>
- <code>Piped the changed prose through `bun src/cli/main.ts --json -` to verify its STE style.</code>
- `Ran a focused Python audit for documentation names, preserved identifiers, repository links, and unchanged release-verification code blocks.`
- <code>Rendered `README.md` with `bunx marked`, inspected it in Chrome, and captured a screenshot.</code>
- <code>`bun install --frozen-lockfile` prepared dependencies. Removed `node_modules` and browser data after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
