### PR TITLE
chore: add npm publish metadata and optional peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,17 @@
   "description": "ASD-STE100 Simplified Technical English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",
+  "author": {
+    "name": "JIA YI"
+  },
+  "homepage": "https://github.com/jyooi/agent-simple-english#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jyooi/agent-simple-english.git"
+  },
+  "bugs": {
+    "url": "https://github.com/jyooi/agent-simple-english/issues"
+  },
   "keywords": ["pi-package", "simplified-technical-english", "linter"],
   "pi": {
     "extensions": ["./src/extension/index.ts"]
@@ -33,6 +44,14 @@
   "peerDependencies": {
     "@earendil-works/pi-coding-agent": "*",
     "typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "typebox": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",


### PR DESCRIPTION
Prepares the package for its first npm publish.

## Changes

**Repository metadata.**
The package had no `repository`, `homepage`, `bugs`, or `author`.
Without them the npmjs.com page shows no link back to the source.
All four are now set.

**Optional peer dependencies.**
`@earendil-works/pi-coding-agent` and `typebox` were declared as non-optional peers.
Package managers auto-install peers, so every CLI user would have pulled the pi runtime tree on install.
Both are used only under `src/extension/`, confirmed by grep across `src/`.
They are now marked optional through `peerDependenciesMeta`.

## Verification

Gates on this branch:

- `bun run test`: 402 tests pass across 19 files.
- `bun run lint`: Biome clean, 64 files checked.
- `bun run typecheck`: clean.

Consumer install, from `npm pack` output into a scratch project:

- 7 packages installed, with neither peer dependency present.
- The installed binary reports correct violations and exits 1 on hard ones.

```
sample.md:1:12 [hard] dictionary-not-approved-word Use "use", not "utilizes".
sample.md:1:43 [soft] verb-passive Use the active voice, unless the actor is unknown.
sample.md:1:46 [hard] dictionary-not-approved-word Use "stop", not "terminated".
EXIT=1
```

Tarball is 47 files and 51.4 kB.
It carries `src`, `commands`, `hooks`, `.claude-plugin`, and the license and notice files.
No tests or fixtures are included.

## Notes

The `bin` entry stays a `.ts` file with a `bun` shebang, which matches the documented Bun requirement.
A global install on a machine without Bun gives a binary that does not run.
This PR does not change that.

The publish itself is not done.
The registry rejected it with a 403 because the account requires a 2FA one-time password.
The name `simple-english` is still unclaimed.
