### PR TITLE
chore: rename npm package to agent-simple-english

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Install [pi](https://pi.dev) first.
 Then use the pi package mechanism:
 
 ```sh
-pi install npm:simple-english
+pi install npm:agent-simple-english
 ```
 
 Pi records the package in its user settings and loads the extension in each session.
@@ -147,10 +147,11 @@ The list changes to match the text that you type.
 ## Install and use the CLI
 
 The standalone command needs [Bun](https://bun.sh).
-Install it from the same npm package:
+Install it from the same npm package.
+The package is `agent-simple-english` and the command it installs is `simple-english`:
 
 ```sh
-bun add --global simple-english
+bun add --global agent-simple-english
 ```
 
 ### Claude Code Hook mode

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -1,7 +1,8 @@
 # Release verification
 
 This record captures the HUF-142 release checks from 2026-07-31.
-The captured commands and output predate the npm package rename to `simple-english`.
+The captured commands and output predate the npm package renames to `simple-english` and then to `agent-simple-english`.
+The `simple-english` command name did not change.
 The checks used Bun 1.3.14, npm 11.6.2, Node.js 24.12.0, and pi 0.83.0.
 
 ## Isolated pi package installation

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "simple-english",
+  "name": "agent-simple-english",
   "version": "0.1.0",
   "description": "ASD-STE100 Simplified Technical English lint engine, CLI, and host adapters",
   "license": "MIT",

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -368,7 +368,7 @@ describe.sequential("pi extension wiring", () => {
   test("declares a production pi extension package", async () => {
     const manifest = JSON.parse(await readFile(join(process.cwd(), "package.json"), "utf8"))
 
-    expect(manifest.name).toBe("simple-english")
+    expect(manifest.name).toBe("agent-simple-english")
     expect(manifest.pi.extensions).toEqual(["./src/extension/index.ts"])
     expect(manifest.bin).toEqual({ "simple-english": "src/cli/main.ts" })
     expect(manifest.dependencies).toMatchObject({


### PR DESCRIPTION
Renames the npm package from `simple-english` to `agent-simple-english`, to match the repository name.
The name is free in the public registry.

## Scope

The rename covers installation only.

Changed:

- `package.json` `name`.
- The two README install commands, `pi install npm:agent-simple-english` and `bun add --global agent-simple-english`.
- The manifest assertion in `test/extension/extension.test.ts`, which pinned the old name.
- The historical note in `docs/release-verification.md`.

Unchanged, on purpose:

- The `bin` command stays `simple-english`, which the extension test also pins. All documented CLI examples stay correct.
- The config and state paths stay `.simple-english.json`, `$XDG_CONFIG_HOME/simple-english/`, and `$XDG_STATE_HOME/simple-english/sessions`. A change there would break existing installations.
- The Claude Code plugin name stays `simple-english`, so `claude plugin install simple-english@agent-simple-english` still works.
- The hooks call `src/cli/main.ts` by path, so no hook changes are needed.

The README now states the package name and the command name together, because they differ.

## Verification

Gates on this branch:

- `bun run test`: 402 tests pass across 19 files.
- `bun run lint`: Biome clean, 64 files checked.
- `bun run typecheck`: clean.

The extension test caught the rename before this branch updated it, which confirms the manifest guard works.

Consumer install, from `npm pack` output into a scratch project:

- The tarball resolves as `agent-simple-english` and installs the `simple-english` binary.
- 7 packages installed, with neither optional peer dependency present.

```
sample.md:1:12 [hard] dictionary-not-approved-word Use "use", not "utilizes".
sample.md:1:43 [soft] verb-passive Use the active voice, unless the actor is unknown.
sample.md:1:46 [hard] dictionary-not-approved-word Use "stop", not "terminated".
EXIT=1
```
