### PR TITLE
fix(cli): validate flags and add help and version options

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ Soft violations can appear with exit code 0.
 
 - `--version` writes the package version.
 
+- The command rejects an unknown flag as an argument error.
+
 - A path of `-` reads standard input.
   With no paths, the command also reads standard input.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ Soft violations can appear with exit code 0.
   Valid values are `prose-file`, `slash-source`, `hash-source`, and `commit-message`.
   The form `--kind=<kind>` also works.
 
+- `--help` writes the command usage.
+
+- `--version` writes the package version.
+
 - A path of `-` reads standard input.
   With no paths, the command also reads standard input.
 

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -75,6 +75,13 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
     return { json, configPath, kind, kindMissingValue, help, version, paths }
   })
 
+const rejectUnknownFlags = (args: readonly string[]): Effect.Effect<void, Error> => {
+  const flag = args.find((arg) => arg.startsWith("--"))
+  return flag === undefined
+    ? Effect.void
+    : Effect.fail(new Error(`unknown flag "${flag}"`))
+}
+
 const isLintKind = (value: string): value is LintKind =>
   (KINDS as readonly string[]).includes(value)
 
@@ -210,9 +217,9 @@ const lintProgram = Effect.gen(function* () {
 
 const program: Effect.Effect<number, Error> =
   args[0] === "hook"
-    ? hookProgram
+    ? rejectUnknownFlags(args.slice(1)).pipe(Effect.andThen(hookProgram))
     : args[0] === "session"
-      ? sessionProgram
+      ? rejectUnknownFlags(args.slice(1)).pipe(Effect.andThen(sessionProgram))
       : lintProgram.pipe(Effect.provide(WinkTaggerLive))
 
 const handled = program.pipe(

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -77,9 +77,7 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
 
 const rejectUnknownFlags = (args: readonly string[]): Effect.Effect<void, Error> => {
   const flag = args.find((arg) => arg.startsWith("--"))
-  return flag === undefined
-    ? Effect.void
-    : Effect.fail(new Error(`unknown flag "${flag}"`))
+  return flag === undefined ? Effect.void : Effect.fail(new Error(`unknown flag "${flag}"`))
 }
 
 const isLintKind = (value: string): value is LintKind =>

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises"
 import { Effect, Either } from "effect"
+import packageManifest from "../../package.json" with { type: "json" }
 import { loadConfig } from "../config/load.ts"
 import { loadDictionary } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
@@ -12,11 +13,22 @@ import { runSessionCommand } from "./session-command.ts"
 
 const KINDS: readonly LintKind[] = ["prose-file", "slash-source", "hash-source", "commit-message"]
 
+const USAGE = `Usage: simple-english [options] [paths...]
+
+Options:
+  --json           Write a JSON report.
+  --config <path>  Use one config file.
+  --kind <kind>    Use one content kind.
+  --help           Print this help.
+  --version        Print the package version.`
+
 interface CliArgs {
   readonly json: boolean
   readonly configPath: string | undefined
   readonly kind: string | undefined
   readonly kindMissingValue: boolean
+  readonly help: boolean
+  readonly version: boolean
   readonly paths: readonly string[]
 }
 
@@ -26,16 +38,20 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
     let configPath: string | undefined
     let kind: string | undefined
     let kindMissingValue = false
+    let help = false
+    let version = false
     const paths: string[] = []
     for (let i = 0; i < args.length; i++) {
       const arg = args[i] as string
       if (arg === "--json") {
         json = true
       } else if (arg === "--config") {
-        configPath = args[++i]
-        if (configPath === undefined) {
+        const value = args[i + 1]
+        if (value === undefined || value.startsWith("--")) {
           yield* Effect.fail(new Error("--config requires a file path"))
         }
+        configPath = value
+        i++
       } else if (arg === "--kind") {
         const value = args[i + 1]
         if (value === undefined || value.startsWith("--")) {
@@ -46,11 +62,17 @@ const parseArgs = (args: readonly string[]): Effect.Effect<CliArgs, Error> =>
         }
       } else if (arg.startsWith("--kind=")) {
         kind = arg.slice("--kind=".length)
+      } else if (arg === "--help") {
+        help = true
+      } else if (arg === "--version") {
+        version = true
+      } else if (arg.startsWith("--")) {
+        yield* Effect.fail(new Error(`unknown flag "${arg}"`))
       } else {
         paths.push(arg)
       }
     }
-    return { json, configPath, kind, kindMissingValue, paths }
+    return { json, configPath, kind, kindMissingValue, help, version, paths }
   })
 
 const isLintKind = (value: string): value is LintKind =>
@@ -132,7 +154,15 @@ const sessionProgram = Effect.gen(function* () {
 
 const lintProgram = Effect.gen(function* () {
   const tagger = yield* TaggerService
-  const { json, configPath, kind, kindMissingValue, paths } = yield* parseArgs(args)
+  const { json, configPath, kind, kindMissingValue, help, version, paths } = yield* parseArgs(args)
+  if (help) {
+    console.log(USAGE)
+    return 0
+  }
+  if (version) {
+    console.log(packageManifest.version)
+    return 0
+  }
   if (kindMissingValue) {
     return yield* Effect.fail(
       new Error(`--kind requires a value; expected one of: ${KINDS.join(", ")}`),

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -1,6 +1,8 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
-import { type CliOptions, runCli as runCliBase } from "./run-cli.ts"
+import { type CliOptions, repoRoot, runCli as runCliBase } from "./run-cli.ts"
 
 const fixturesPath = fileURLToPath(new URL("../fixtures", import.meta.url))
 
@@ -88,6 +90,34 @@ describe("simple-english CLI", () => {
       violations: [],
       summary: { total: 0, hard: 0 },
     })
+  })
+
+  test("rejects an unknown flag with exit code 2", async () => {
+    const result = await runCli(["--unknown"])
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain('unknown flag "--unknown"')
+    expect(result.stderr).not.toContain("cannot read --unknown")
+  })
+
+  test("--help prints usage and exits 0", async () => {
+    const result = await runCli(["--help"])
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain("Usage: simple-english")
+    expect(result.stdout).toContain("--config <path>")
+    expect(result.stderr).toBe("")
+  })
+
+  test("--version prints the package version and exits 0", async () => {
+    const packageManifest = JSON.parse(await readFile(join(repoRoot, "package.json"), "utf8")) as {
+      version: string
+    }
+    const result = await runCli(["--version"])
+
+    expect(result.code).toBe(0)
+    expect(result.stdout.trim()).toBe(packageManifest.version)
+    expect(result.stderr).toBe("")
   })
 
   test("exits 1 on progressive tense, a hard violation", async () => {

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -100,6 +100,22 @@ describe("simple-english CLI", () => {
     expect(result.stderr).not.toContain("cannot read --unknown")
   })
 
+  test("rejects an unknown flag in hook mode", async () => {
+    const result = await runCli(["hook", "--unknown"])
+
+    expect(result.code).toBe(2)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toContain('unknown flag "--unknown"')
+  })
+
+  test("rejects an unknown flag in session mode", async () => {
+    const result = await runCli(["session", "--unknown", repoRoot, "status"])
+
+    expect(result.code).toBe(2)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toContain('unknown flag "--unknown"')
+  })
+
   test("--help prints usage and exits 0", async () => {
     const result = await runCli(["--help"])
 

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -170,6 +170,14 @@ describe("simple-english CLI config", () => {
     expect(result.stderr).toContain("--config")
   })
 
+  test("rejects an option token as a --config path", async () => {
+    const result = await runCli(["--config", "--json", "/tmp/t"])
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("--config requires a file path")
+    expect(result.stderr).not.toContain("config file --json")
+  })
+
   test("defaults apply when no config files exist", async () => {
     const cwd = await makeProject()
     const result = await runCli([], { cwd, stdin: tenWords })


### PR DESCRIPTION
## Intent

Implement Linear HUF-154 for simple-english and fix the CLI argument parser. Before code changes, reproduce both failures end to end with the CLI. The command simple-english --config --json /tmp/t must not read --json as the config path. Guard the --config value in the same way that --kind guards its value. Reject every unknown --flag with a clear error and a nonzero exit. Do not treat an unknown flag as a file path. Add --help with usage text and exit 0. Add --version with the package version and exit 0. Add regression tests that fail before the fix and pass after it. Cover a missing --config value, unknown flag rejection, --help, and --version. Both original failure commands must produce correct behavior. Keep all existing tests, Biome, and TypeScript checks clean. Do not change behavior for valid existing invocations.

## What Changed

- Reject unknown flags across lint, hook, and session modes, and prevent `--config` from consuming another option as its path.
- Add `--help` usage output and `--version` package version output.
- Document the new behavior and add CLI regression coverage.

## Risk Assessment

✅ Low: The bounded parser change meets the required CLI behavior and includes focused regression tests.

## Testing

The first test command could not find Vitest, so locked dependency setup restored it. Focused CLI and hook tests passed. The transcript shows the required errors, help, version, and valid JSON behavior.

<details>
<summary>Evidence: CLI acceptance transcript</summary>

`The config and unknown-flag commands exit 2 with clear errors. Help, version, and a valid JSON invocation exit 0.`

```text
CASE: config option token is not a path
COMMAND: bun src/cli/main.ts --config --json /tmp/t
EXIT: 2
STDOUT:
<empty>
STDERR:
--config requires a file path

CASE: unknown flag is not a file path
COMMAND: bun src/cli/main.ts --unknown
EXIT: 2
STDOUT:
<empty>
STDERR:
unknown flag "--unknown"

CASE: missing config path
COMMAND: bun src/cli/main.ts --config
EXIT: 2
STDOUT:
<empty>
STDERR:
--config requires a file path

CASE: help
COMMAND: bun src/cli/main.ts --help
EXIT: 0
STDOUT:
Usage: simple-english [options] [paths...]

Options:
  --json           Write a JSON report.
  --config <path>  Use one config file.
  --kind <kind>    Use one content kind.
  --help           Print this help.
  --version        Print the package version.
STDERR:
<empty>

CASE: version
COMMAND: bun src/cli/main.ts --version
EXIT: 0
STDOUT:
0.1.0
STDERR:
<empty>

CASE: valid JSON lint invocation
COMMAND: bun src/cli/main.ts --json test/fixtures/clean.md
EXIT: 0
STDOUT:
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
STDERR:
<empty>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `src/cli/main.ts:212` - The intent requires: &#34;Reject every unknown --flag with a clear error and a nonzero exit.&#34; Lines 212-215 bypass parseArgs for hook and session modes. `simple-english hook --unknown` enters hookProgram and returns 0. `simple-english session --unknown &lt;cwd&gt; status` accepts the flag as a session ID and can return 0. Validate mode arguments before these programs run.

🔧 Fix: Fix CLI flag validation in hook and session modes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun run test -- test/cli/cli.test.ts test/cli/config.test.ts` initially failed because Vitest was unavailable, then passed after dependency setup.</code>
- <code>`bun install --frozen-lockfile` restored locked dependencies.</code>
- <code>`bun run test -- test/cli/hook.test.ts` validated existing hook and session behavior.</code>
- `bun src/cli/main.ts --config --json /tmp/t`
- `bun src/cli/main.ts --unknown`
- `bun src/cli/main.ts --config`
- `bun src/cli/main.ts --help`
- `bun src/cli/main.ts --version`
- `bun src/cli/main.ts --json test/fixtures/clean.md`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
