### PR TITLE
test(engine): expand direct rule accuracy coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,8 @@ Parent spec lives in Linear HUF-130.
 - Pure functional core: `src/engine/` is synchronous, and `src/engine/lint.ts` orchestrates it.
   Effect stays at boundaries such as CLI IO, config loading, and schema validation and loading.
 - New rules must register their id in `src/engine/rules/registry.ts`; the config schema derives valid rule names from it, so unregistered ids are rejected in user config.
-- Three test seams only: pure engine API (~90% of suite, `test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), extension wiring via stubbed ExtensionAPI double. Never run pi itself in tests.
+- Three primary test seams cover product behavior: pure engine API (`test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), and extension wiring via a stubbed ExtensionAPI double. Never run pi itself in tests.
+- Rule-accuracy tests grow first at the pure engine seam. Each lint rule must have direct finding, clean, and boundary cases listed in `test/engine/README.md`.
 - Severity model: violations carry `hard`/`soft`; hard violations drive CLI exit code 1.
 - TDD per rule: failing engine-seam test first, then implement.
 - pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`, `wink-nlp`) must stay in `dependencies`, never `devDependencies`.

--- a/test/engine/README.md
+++ b/test/engine/README.md
@@ -1,0 +1,23 @@
+# Engine rule accuracy audit
+
+The registry in `src/engine/rules/registry.ts` is the source for rule IDs.
+Each rule needs a direct true-positive test, a direct false-positive test, and a boundary test.
+Use the test names below to find each case.
+All cells must stay at Yes.
+
+| Rule ID | True positive | False positive | Boundary |
+| --- | --- | --- | --- |
+| `contraction` | Yes. `flags a contraction as a hard violation with its position`. | Yes. `does not flag plain prose`. | Yes. `does not flag a possessive`. |
+| `dictionary-not-approved-word` | Yes. `flags an unapproved word as hard and suggests its approved alternative`. | Yes. `does not flag approved alternatives`. | Yes. `uses POS metadata to allow a noun and reject the same word as a verb`. |
+| `hedging` | Yes. `flags a hedge phrase as a soft violation`. | Yes. `does not flag plain prose that mentions notes`. | Yes. `does not match within a token`. |
+| `marketing` | Yes. `flags a marketing word as a soft violation with its position`. | Yes. `does not flag words that merely contain a listed word`. | Yes. `flags complete hyphenated marketing compounds`. |
+| `paragraph-length` | Yes. `flags a paragraph over 6 sentences as a hard violation`. | Yes. `a blank line ends a paragraph`. | Yes. `does not flag a paragraph of exactly 6 sentences`. |
+| `phrasal-verb` | Yes. `flags a phrasal verb as a hard violation with the approved alternative`. | Yes. `does not flag the bare verb without its particle`. | Yes. `does not match within a token`. |
+| `semicolon` | Yes. `flags a semicolon as a hard violation at its column`. | Yes. `does not flag text without semicolons`. | Yes. `flags semicolons inside inline code`. |
+| `sentence-length` | Yes. `flags a sentence over 25 words as a hard violation`. | Yes. `does not flag short sentences`. | Yes. `does not flag a sentence of exactly 25 words`. |
+| `verb-progressive` | Yes. `flags progressive tense as a hard violation`. | Yes. `does not flag simple present as progressive`. | Yes. `does not flag an adjective that ends in ing as progressive`. |
+| `verb-passive` | Yes. `flags passive voice as a soft violation with a rewrite hint`. | Yes. `does not flag active voice`. | Yes. `detects passive across an intervening adverb`. |
+| `verb-perfect` | Yes. `flags perfect tense as a hard violation`. | Yes. `does not flag simple past as perfect`. | Yes. `does not flag main-verb have`. |
+
+Diff-only behavior has a separate engine seam in `diff-match.test.ts`.
+Tests at that seam call `newFindings` directly.

--- a/test/engine/diff-match.test.ts
+++ b/test/engine/diff-match.test.ts
@@ -5,6 +5,7 @@ import {
   newFindings,
 } from "../../src/engine/diff-match.ts"
 import type { RetainedRange } from "../../src/engine/diff.ts"
+import type { RuleId } from "../../src/engine/rules/registry.ts"
 
 const scope = (startOffset: number, endOffset: number, identity = "scope"): ViolationScope => ({
   kind: "sentence",
@@ -16,12 +17,13 @@ const scope = (startOffset: number, endOffset: number, identity = "scope"): Viol
 const finding = (
   findingScope: ViolationScope,
   options: {
+    readonly ruleId?: RuleId
     readonly sentenceIdentity?: string
     readonly occurrenceOffset?: number
   } = {},
 ): ScopedViolation => ({
   violation: {
-    ruleId: "sentence-length",
+    ruleId: options.ruleId ?? "sentence-length",
     severity: "hard",
     message: "Test violation.",
     line: 1,
@@ -114,5 +116,34 @@ describe("diff finding matcher", () => {
         ],
       ),
     ).toEqual([])
+  })
+
+  test("reports a new rule occurrence in a retained sentence", () => {
+    const previous = finding(scope(0, 10), {
+      ruleId: "semicolon",
+      sentenceIdentity: "same sentence",
+      occurrenceOffset: 4,
+    })
+    const retained = finding(scope(0, 11), {
+      ruleId: "semicolon",
+      sentenceIdentity: "same sentence",
+      occurrenceOffset: 4,
+    })
+    const added = finding(scope(0, 11), {
+      ruleId: "semicolon",
+      sentenceIdentity: "same sentence",
+      occurrenceOffset: 5,
+    })
+
+    expect(
+      match(
+        [previous],
+        [retained, added],
+        [
+          { previousStart: 0, currentStart: 0, length: 5 },
+          { previousStart: 5, currentStart: 6, length: 5 },
+        ],
+      ),
+    ).toEqual([added])
   })
 })

--- a/test/engine/verb-form.test.ts
+++ b/test/engine/verb-form.test.ts
@@ -94,6 +94,40 @@ describe("lint prose-file: verb-form rules (stub tagger)", () => {
     expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
   })
 
+  test("does not flag simple present as progressive", () => {
+    const text = "The pump runs."
+    const tagger = stubTagger({
+      [text]: "The/DET/the pump/NOUN/pump runs/VERB/run ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).not.toContainEqual(
+      expect.objectContaining({ ruleId: "verb-progressive" }),
+    )
+  })
+
+  test("does not flag an adjective that ends in ing as progressive", () => {
+    const text = "The manual is interesting."
+    const tagger = stubTagger({
+      [text]: "The/DET/the manual/NOUN/manual is/AUX/be interesting/ADJ/interesting ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).not.toContainEqual(
+      expect.objectContaining({ ruleId: "verb-progressive" }),
+    )
+  })
+
+  test("does not flag simple past as perfect", () => {
+    const text = "The team completed the test."
+    const tagger = stubTagger({
+      [text]:
+        "The/DET/the team/NOUN/team completed/VERB/complete the/DET/the test/NOUN/test ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).not.toContainEqual(
+      expect.objectContaining({ ruleId: "verb-perfect" }),
+    )
+  })
+
   test("detects passive across an intervening adverb", () => {
     const text = "The valve was quickly closed."
     const tagger = stubTagger({


### PR DESCRIPTION
## Intent

Implement Linear HUF-159 for simple-english: rebalance tests toward engine rule accuracy and correct the CLAUDE.md test-policy claim. Build on the current default branch after HUF-157 extracted the diff matcher into its own module with a direct test seam. Correct the false claim that the engine seam holds about 90 percent of the suite by stating a true measurable policy or dropping the ratio and stating that rule-accuracy tests grow first. Audit every lint rule and list whether direct engine-level true-positive and false-positive tests exist. Add direct engine-level rule-accuracy tests where coverage is thin so every lint rule has a clear violation case, a clean sentence case, and one boundary case. Use the diff matcher direct test seam where relevant. Do not delete adapter tests, and grow the engine side instead. The final policy must match reality, every lint rule must have direct engine-level accuracy tests rather than only CLI E2E coverage, and the full test suite, Biome, and tsc must stay clean.

## What Changed

- Document direct violation, clean, and boundary coverage for every registered lint rule.
- Add engine tests for progressive and perfect verb-form false positives and boundaries.
- Cover new rule occurrences in retained sentences through the direct diff matcher seam and correct the engine test-policy guidance.

## Risk Assessment

✅ Low: The change is limited to accurate test-policy documentation and direct engine tests that cover the stated rule-audit gaps without altering production behavior.

## Testing

After installing locked dependencies to resolve the initial missing `effect` setup, I ran the targeted engine rule-accuracy and diff-matcher tests, verified all 11 registry rules against the documented audit, checked the corrected CLAUDE.md policy and adapter-test preservation, and exercised progressive true-positive, clean, and boundary inputs through the CLI. All reruns passed and evidence was captured. The full suite, Biome, and tsc were not run because this phase requires targeted testing only.

<details>
<summary>Evidence: CLI verb accuracy transcript</summary>

```text
$ printf "The pump is running.\\n" | bun src/cli/main.ts --json
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "verb-progressive",
      "severity": "hard",
      "message": "Use a simple tense. Do not use the progressive. Found: \"is running\".",
      "line": 1,
      "column": 10
    }
  ],
  "summary": {
    "total": 1,
    "hard": 1
  }
}
exit code: 1

$ printf "The pump runs.\\n" | bun src/cli/main.ts --json
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit code: 0

$ printf "The manual is interesting.\\n" | bun src/cli/main.ts --json
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit code: 0
```
</details>
<details>
<summary>Evidence: Targeted engine rule-accuracy test output</summary>

```text

 RUN  v3.2.7 /home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KYZW3AHYA03QJ4AAZWZ8MK50

 ✓ test/engine/diff-match.test.ts > diff finding matcher > retains a scope after an unrelated edit 2ms
 ✓ test/engine/diff-match.test.ts > diff finding matcher > retains a scope that an edit changes 0ms
 ✓ test/engine/diff-match.test.ts > diff finding matcher > skips a removed scope and matches the retained scope 0ms
 ✓ test/engine/diff-match.test.ts > diff finding matcher > reports scopes that split 0ms
 ✓ test/engine/diff-match.test.ts > diff finding matcher > reports scopes that merge 0ms
 ✓ test/engine/diff-match.test.ts > diff finding matcher > maps scope and finding position drift 0ms
 ✓ test/engine/diff-match.test.ts > diff finding matcher > reports a new rule occurrence in a retained sentence 0ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > flags a contraction as a hard violation with its position 7ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > flags an apostrophe-s contraction 2ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > does not flag a possessive 1ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > flags every unambiguous contraction form 3ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > flags a typographic apostrophe 2ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > does not flag plain prose 1ms
 ✓ test/engine/contraction.test.ts > lint prose-file: contraction rule > ignores contractions inside inline code 1ms
 ✓ test/engine/semicolon.test.ts > lint prose-file: semicolon rule > flags a semicolon as a hard violation at its column 7ms
 ✓ test/engine/semicolon.test.ts > lint prose-file: semicolon rule > flags each semicolon separately 4ms
 ✓ test/engine/semicolon.test.ts > lint prose-file: semicolon rule > does not flag text without semicolons 1ms
 ✓ test/engine/semicolon.test.ts > lint prose-file: semicolon rule > flags semicolons inside inline code 1ms
 ✓ test/engine/semicolon.test.ts > lint prose-file: semicolon rule > ignores semicolons inside fenced code blocks 2ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > flags an unapproved word as hard and suggests its approved alternative 8ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > does not flag approved alternatives 2ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > uses POS metadata to allow a noun and reject the same word as a verb 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > falls back to word-level matching when POS metadata is absent 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > matches phrases across Markdown soft line breaks at the source position 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > matches phrases across continued Markdown block quotes 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > matches phrases across lazy Markdown block quote continuations 0ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > does not match phrases across Markdown block boundaries 2ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > preserves Markdown phrase boundaries in extracted comments 2ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > does not match phrases across Markdown indented code boundaries 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > ignores unapproved forms inside Markdown indented code 0ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > ignores indented code in Markdown list containers 0ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > checks prose in Markdown list items 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > keeps fenced code open until a matching delimiter closes it 1ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > ignores fenced code in Markdown containers 0ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > checks indented CommonMark paragraph continuations 0ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > matches hyphenated forms as one exact token 0ms
 ✓ test/engine/dictionary.test.ts > lint prose-file: dictionary rule > skips POS-aware entries when no tagger is available 0ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > flags a hedge phrase as a soft violation 8ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > flags listed hedge phrases regardless of case 5ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > soft hedging violations do not count as hard in the summary 1ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > does not match within a token in The text says as mentioned-above. 1ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > does not match within a token in Do not use as mentioned's wording. 1ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > does not match within a token in Do not use as mentioned’s wording. 2ms
 ✓ test/engine/hedging.test.ts > lint prose-file: hedging rule > does not flag plain prose that mentions notes 1ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > flags a phrasal verb as a hard violation with the approved alternative 8ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > flags conjugated forms 5ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > suggests the single-verb alternative for each listed phrasal verb 4ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > reports the column where the phrasal verb starts 1ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > does not match within a token in The channel carries out-of-band data. 1ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > does not match within a token in Do not confuse carry out's spelling. 1ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > does not match within a token in Do not confuse carry out’s spelling. 2ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > does not flag the bare verb without its particle 4ms
 ✓ test/engine/phrasal-verb.test.ts > lint prose-file: phrasal-verb rule > does not flag unrelated words that contain a listed verb 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > flags passive voice as a soft violation with a rewrite hint 10ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > flags progressive tense as a hard violation 2ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > flags perfect tense as a hard violation 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag active voice 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag simple present as progressive 2ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag an adjective that ends in ing as progressive 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag simple past as perfect 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > detects passive across an intervening adverb 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > detects passive across a negation 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag an infinitive after a linking verb 2ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag main-verb 

... [49 bytes truncated] ...

t prose-file: verb-form rules (stub tagger) > flags 'has been sent' as passive only, mirroring the pi-ste reference 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > skips verb-form rules when no tagger is provided 1ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > reports the line of the violation and ignores fenced code blocks 4ms
 ✓ test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > flags each occurrence on a line 2ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > flags a marketing word as a soft violation with its position 8ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > flags complete hyphenated marketing compounds 3ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > flags listed words within larger hyphenated tokens 1ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > flags only the first listed part of the hyphenated token robust-powerful 1ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > flags only the first listed part of the hyphenated token robust--powerful 2ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > preserves terminal hyphens in the token state-of-the-art-- 1ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > preserves terminal hyphens in the token --state-of-the-art 2ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > preserves apostrophes in the token Turnkey's interface. 1ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > preserves apostrophes in the token Turnkey’s interface. 2ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > soft marketing violations do not count as hard in the summary 1ms
 ✓ test/engine/marketing.test.ts > lint prose-file: marketing rule > does not flag words that merely contain a listed word 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a paragraph over 6 sentences as a hard violation 8ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > does not flag a paragraph of exactly 6 sentences 2ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a paragraph of quoted sentences 2ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags sentences before closing Markdown delimiters 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > ignores punctuation inside inline code spans 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags sentences in Markdown links and references 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags sentences with post-terminator Markdown references 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a blank line ends a paragraph 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a bullet list is not one long paragraph 2ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a numbered list is not one long paragraph 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > blockquoted list items are separate paragraphs 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a long blockquoted list item across continuation lines 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > does not count an ordered-list marker as a sentence 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a long list item across continuation lines 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a long list item across continuation lines 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a long list item across continuation lines 3ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > flags a long blockquote paragraph 2ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a blockquote starts a paragraph after preceding content 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a blockquote ends a list item paragraph 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > ignores punctuation in Markdown link destinations and titles 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > ignores punctuation in Markdown link destinations and titles 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > ignores punctuation in Markdown link destinations and titles 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > scans malformed Markdown suffixes in linear time 41ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > scans malformed Markdown suffixes in linear time 13ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a table is not a paragraph 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > a heading ends a paragraph 0ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > still flags a long prose paragraph that spans hard-wrapped lines 1ms
 ✓ test/engine/paragraph-length.test.ts > lint prose-file: paragraph-length rule > reports the line where the paragraph starts 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > flags a sentence over 25 words as a hard violation 9ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > does not flag a sentence of exactly 25 words 4ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > does not flag short sentences 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > returns no violations for empty input 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > word cap is configurable via options 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > reports the line and column where the long sentence starts 11ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > does not rescan punctuation inside a Markdown sentence suffix 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > ignores inline code for all rules except semicolons 4ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > does not pair inline code delimiters across paragraph boundaries 2ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > counts a sentence that spans multiple lines once, at its start 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > ignores fenced code blocks 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > still flags prose after a fenced code block, with correct position 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > per-rule override to soft downgrades the violation and the hard count 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > per-rule override to off suppresses the rule entirely 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > per-rule override to hard keeps the violation hard 1ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > engine types are keyed by registry-derived rule IDs 0ms
 ✓ test/engine/lint.test.ts > lint prose-file: sentence-length rule > summary counts total and hard violations 1ms

 Test Files  10 passed (10)
      Tests  124 passed (124)
   Start at  08:01:03
   Duration  910ms (transform 690ms, setup 0ms, collect 2.52s, tests 302ms, environment 2ms, prepare 925ms)
```
</details>
<details>
<summary>Evidence: Registry-to-audit verification</summary>

```text
Engine rule accuracy audit verification
Registry and audit agree on 11 rule IDs.

Rule ID | true-positive test | false-positive test | boundary test
--- | --- | --- | ---
contraction | flags a contraction as a hard violation with its position (contraction.test.ts) | does not flag plain prose (contraction.test.ts) | does not flag a possessive (contraction.test.ts)
dictionary-not-approved-word | flags an unapproved word as hard and suggests its approved alternative (dictionary.test.ts) | does not flag approved alternatives (dictionary.test.ts) | uses POS metadata to allow a noun and reject the same word as a verb (dictionary.test.ts)
hedging | flags a hedge phrase as a soft violation (hedging.test.ts) | does not flag plain prose that mentions notes (hedging.test.ts) | does not match within a token (hedging.test.ts)
marketing | flags a marketing word as a soft violation with its position (marketing.test.ts) | does not flag words that merely contain a listed word (marketing.test.ts) | flags complete hyphenated marketing compounds (marketing.test.ts)
paragraph-length | flags a paragraph over 6 sentences as a hard violation (paragraph-length.test.ts) | a blank line ends a paragraph (paragraph-length.test.ts) | does not flag a paragraph of exactly 6 sentences (paragraph-length.test.ts)
phrasal-verb | flags a phrasal verb as a hard violation with the approved alternative (phrasal-verb.test.ts) | does not flag the bare verb without its particle (phrasal-verb.test.ts) | does not match within a token (phrasal-verb.test.ts)
semicolon | flags a semicolon as a hard violation at its column (semicolon.test.ts) | does not flag text without semicolons (semicolon.test.ts) | flags semicolons inside inline code (semicolon.test.ts)
sentence-length | flags a sentence over 25 words as a hard violation (lint.test.ts) | does not flag short sentences (lint.test.ts) | does not flag a sentence of exactly 25 words (lint.test.ts)
verb-progressive | flags progressive tense as a hard violation (verb-form.test.ts) | does not flag simple present as progressive (verb-form.test.ts) | does not flag an adjective that ends in ing as progressive (verb-form.test.ts)
verb-passive | flags passive voice as a soft violation with a rewrite hint (verb-form.test.ts) | does not flag active voice (verb-form.test.ts) | detects passive across an intervening adverb (verb-form.test.ts)
verb-perfect | flags perfect tense as a hard violation (verb-form.test.ts) | does not flag simple past as perfect (verb-form.test.ts) | does not flag main-verb have (verb-form.test.ts)

PASS: every registered rule has documented direct finding, clean, and boundary tests, and every documented test title exists under test/engine/.
```
</details>
<details>
<summary>Evidence: Contributor policy and adapter-test verification</summary>

```text
Contributor policy surface
lrwxrwxrwx 1 jyooi jyooi 9 Aug  2 07:56 CLAUDE.md -> AGENTS.md

Current test policy as read through CLAUDE.md:
17:- Three primary test seams cover product behavior: pure engine API (`test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), and extension wiring via a stubbed ExtensionAPI double. Never run pi itself in tests.
18:- Rule-accuracy tests grow first at the pure engine seam. Each lint rule must have direct finding, clean, and boundary cases listed in `test/engine/README.md`.

Prohibited ratio claim search (no matches expected):
PASS: no 90-percent test-suite ratio remains in CLAUDE.md.

Extension adapter test deletion check for the requested commit range:
PASS: no test/extension adapter test was deleted.
```
</details>
<details>
<summary>Evidence: Reproducible engine audit verifier</summary>

```text
import { readFileSync } from "node:fs"
import { join } from "node:path"

const root = process.cwd()
const registry = readFileSync(join(root, "src/engine/rules/registry.ts"), "utf8")
const registryBlock = registry.match(/ruleIds = \[([\s\S]*?)\] as const/)?.[1]
if (!registryBlock) throw new Error("Could not parse rule registry")
const ruleIds = [...registryBlock.matchAll(/"([^"]+)"/g)].map((match) => match[1])

const readme = readFileSync(join(root, "test/engine/README.md"), "utf8")
const rows = readme
  .split("\n")
  .filter((line) => /^\| `[^`]+` \|/.test(line))
  .map((line) => {
    const cells = line.split("|").slice(1, -1).map((cell) => cell.trim())
    return { id: cells[0].slice(1, -1), cases: cells.slice(1) }
  })

const auditIds = rows.map((row) => row.id)
if (JSON.stringify(auditIds) !== JSON.stringify(ruleIds)) {
  throw new Error(`Audit IDs do not exactly match registry IDs\nregistry=${ruleIds}\naudit=${auditIds}`)
}

const testFileForRule = {
  contraction: "contraction.test.ts",
  "dictionary-not-approved-word": "dictionary.test.ts",
  hedging: "hedging.test.ts",
  marketing: "marketing.test.ts",
  "paragraph-length": "paragraph-length.test.ts",
  "phrasal-verb": "phrasal-verb.test.ts",
  semicolon: "semicolon.test.ts",
  "sentence-length": "lint.test.ts",
  "verb-progressive": "verb-form.test.ts",
  "verb-passive": "verb-form.test.ts",
  "verb-perfect": "verb-form.test.ts",
}

console.log("Engine rule accuracy audit verification")
console.log(`Registry and audit agree on ${ruleIds.length} rule IDs.`)
console.log("")
console.log("Rule ID | true-positive test | false-positive test | boundary test")
console.log("--- | --- | --- | ---")
for (const row of rows) {
  const fileName = testFileForRule[row.id]
  if (!fileName) throw new Error(`${row.id}: no direct engine test file is mapped`)
  const testText = readFileSync(join(root, "test/engine", fileName), "utf8")
  const verified = row.cases.map((cell) => {
    if (!cell.startsWith("Yes.")) throw new Error(`${row.id}: cell is not marked Yes: ${cell}`)
    const title = cell.match(/`([^`]+)`/)?.[1]
    if (!title) throw new Error(`${row.id}: missing test title in ${cell}`)
    if (!testText.includes(title)) {
      throw new Error(`${row.id}: documented test title was not found in ${fileName}: ${title}`)
    }
    return `${title} (${fileName})`
  })
  console.log(`${row.id} | ${verified.join(" | ")}`)
}
console.log("")
console.log("PASS: every registered rule has documented direct finding, clean, and boundary tests, and every documented test title exists under test/engine/.")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bun install --frozen-lockfile`
- `bun run test -- test/engine/contraction.test.ts test/engine/dictionary.test.ts test/engine/hedging.test.ts test/engine/marketing.test.ts test/engine/paragraph-length.test.ts test/engine/phrasal-verb.test.ts test/engine/semicolon.test.ts test/engine/lint.test.ts test/engine/verb-form.test.ts test/engine/diff-match.test.ts --reporter=verbose`
- `bun /tmp/no-mistakes-evidence/01KYZW3AHYA03QJ4AAZWZ8MK50/verify-engine-audit.mjs`
- <code>CLI stdin checks for progressive tense, simple present, and an `-ing` adjective using `bun src/cli/main.ts --json`</code>
- <code>Verified the CLAUDE.md symlink exposes the corrected policy, contains no 90-percent claim, and the commit range deletes no `test/extension` files</code>
- <code>`git status --short &amp;&amp; git diff --check` and transient-artifact inspection</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
