### PR TITLE
feat(dictionary): support extensible rule data

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "simple-english",
-      "description": "Apply Simplified Technical English rules to writes, edits, and git commit messages.",
+      "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
       "version": "0.1.0",
       "author": {
         "name": "JIA YI"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
   "version": "0.1.0",
-  "description": "Apply Simplified Technical English rules to writes, edits, and git commit messages.",
+  "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",
   "keywords": ["simplified-technical-english", "lint", "hooks"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 ## What this project is
 
-A host-neutral ASD-STE100 Simplified Technical English toolkit in TypeScript and Effect.
+A host-neutral toolkit for rules derived from ASD-STE100 Simplified Technical English and package house style, implemented in TypeScript and Effect.
 It supplies a pure Engine, a standalone `simple-english` CLI (`src/cli/main.ts`), and a pi Adapter.
 Behavioral reference: https://github.com/ctotheameron/pi-ste (Gleam) - this is a reimplementation, not a fork.
 Parent spec lives in Linear HUF-130.
@@ -19,7 +19,7 @@ Parent spec lives in Linear HUF-130.
 - TDD per rule: failing engine-seam test first, then implement.
 - pi installs extension deps with `npm install --omit=dev` from the package.json next to the entry point, so runtime deps (e.g. `effect`, `wink-nlp`) must stay in `dependencies`, never `devDependencies`.
 - POS tagging is an injected boundary: the engine consumes the pure `Tagger` type (`src/engine/tagger.ts`) and silently skips tagger-dependent checks when `LintOptions.tagger` is absent; the wink-nlp implementation and its Effect layer live in `src/tagger/wink.ts`. Tagger-dependent verb verdicts are pinned, right or wrong, in `test/engine/verb-form-fixtures.test.ts`.
-- The package-owned dictionary format and matching semantics are documented in `src/dictionary/README.md`; load and validate dictionary data before passing it into the synchronous engine.
+- The package-owned data format and dictionary matching semantics are documented in `src/dictionary/README.md`; load and validate dictionary and list-backed rule data before passing it into the synchronous engine.
 - Extractors (`src/engine/comments.ts`, `markdown.ts`, `identifiers.ts`) blank non-prose with spaces so violation line/column always map to the original file. `test/fixtures/**` is excluded from Biome because tests pin exact byte positions in fixtures; do not let a formatter touch them.
 
 ## Commands

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # agent-simple-english
 
-Coding agents use this lint engine to enforce ASD-STE100 Simplified Technical English.
+Coding agents use this lint engine to enforce technical and house-style writing rules.
 One agent-agnostic engine.
 One adapter per host.
 
@@ -11,7 +11,7 @@ The pure, synchronous lint core that turns text into a report of violations.
 _Avoid_: linter core, checker
 
 **Host**:
-A coding agent runtime that enforces STE with the Engine.
+A coding agent runtime that enforces writing rules with the Engine.
 Current hosts: pi and Claude Code.
 _Avoid_: platform, agent (ambiguous with the LLM itself), IDE
 
@@ -20,13 +20,13 @@ The per-host integration layer that wires the engine into that host's extension 
 _Avoid_: plugin (that is the Claude Code artifact name, not the concept), integration
 
 **Enforcement ceiling**:
-The strongest set of STE behaviors a host's extension surface allows.
-Each Adapter implements STE behaviors up to its Host's ceiling.
+The strongest set of writing-rule behaviors a host's extension surface allows.
+Each Adapter implements writing-rule behaviors up to its Host's ceiling.
 Adapters do not need parity across Hosts.
 
 **Hook mode**:
 The CLI mode that speaks a host's hook protocol: hook event JSON on stdin, hook decision JSON on stdout.
-Hosts with hook-based Adapters enforce STE when they start the CLI in this mode.
+Hosts with hook-based Adapters enforce writing rules when they start the CLI in this mode.
 
 **Gate**:
 A check that blocks an action (write, edit, commit, reply) when the text has hard violations.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # agent-simple-english
 
-`agent-simple-english` checks ASD-STE100 Simplified Technical English (STE).
+`agent-simple-english` checks rules derived from ASD-STE100 Simplified Technical English (STE) and two enabled house-style rules.
 It supplies one Engine, one CLI, a pi Adapter, and a Claude Code Adapter.
 The Claude Code plugin uses CLI Hook mode to enforce the same rules.
 
@@ -269,6 +269,11 @@ This example contains every config key and every rule:
 ```json
 {
   "maxSentenceWords": 25,
+  "ruleDataExtensions": {
+    "phrasal-verb": ["config/phrasal-verbs.json"],
+    "hedging": ["config/hedging.json"],
+    "marketing": ["config/marketing.json"]
+  },
   "rules": {
     "contraction": "hard",
     "dictionary-not-approved-word": "hard",
@@ -293,65 +298,35 @@ The `off` value disables that rule.
 `maxSentenceWords` must be a positive integer and has a default value of 25.
 Unknown keys, unknown rule IDs, and invalid values cause a config error.
 
+`ruleDataExtensions` maps each list-backed rule to more JSON data files.
+The loader adds entries from these files after the bundled entries.
+The loader resolves relative paths from the current working directory.
+Each file must use the [package dictionary data format](src/dictionary/README.md).
+
 ## Rule reference
 
-### `contraction`
+### Rules derived from ASD-STE100
+
+#### `contraction`
 
 Default: hard.
 Reports apostrophe contractions such as forms that end in `n't`, `'re`, `'ve`, `'ll`, `'d`, or `'m`.
 It also reports unambiguous forms that end in `'s`.
 
-### `dictionary-not-approved-word`
+#### `dictionary-not-approved-word`
 
 Default: hard.
 Reports an unapproved word or phrase from the bundled dictionary and supplies approved alternatives.
 Part-of-speech data limits applicable entries when that data exists.
 Matching does not depend on letter case.
 
-### `hedging`
-
-Default: soft.
-Reports these phrases: `it is important to note`, `it should be noted`, `it is worth noting`, `please note that`, `as mentioned`, `as noted above`.
-A phrase match stays on one source line.
-
-### `marketing`
-
-Default: soft.
-Reports the first listed term in each token.
-Matching does not depend on letter case, and it also examines components of hyphenated tokens.
-
-- `seamless`.
-- `seamlessly`.
-- `robust`.
-- `powerful`.
-- `cutting-edge`.
-- `effortless`.
-- `effortlessly`.
-- `world-class`.
-- `next-generation`.
-- `revolutionary`.
-- `blazing`.
-- `lightning-fast`.
-- `elegant`.
-- `delightful`.
-- `turnkey`.
-- `best-in-class`.
-- `state-of-the-art`.
-- `game-changing`.
-- `battle-tested`.
-- `enterprise-grade`.
-- `supercharge`.
-- `unleash`.
-- `empower`.
-- `empowers`.
-
-### `paragraph-length`
+#### `paragraph-length`
 
 Default: hard.
 Reports a prose paragraph that has more than six sentences.
 Markdown block boundaries and list items start separate paragraphs.
 
-### `phrasal-verb`
+#### `phrasal-verb`
 
 Default: hard.
 Reports these forms and supplies the listed suggestion:
@@ -373,34 +348,52 @@ Reports these forms and supplies the listed suggestion:
 Matching does not depend on letter case.
 A phrase match stays on one source line.
 
-### `semicolon`
+#### `semicolon`
 
 Default: hard.
 Reports each semicolon and asks for two sentences.
 This rule also checks semicolons inside inline Markdown code.
 
-### `sentence-length`
+#### `sentence-length`
 
 Default: hard.
 Reports a sentence above `maxSentenceWords`.
 The default maximum is 25 words.
 
-### `verb-progressive`
+#### `verb-progressive`
 
 Default: hard.
 Reports a form of `be` followed by an `-ing` verb, with optional adverbs or `not` between them.
 
-### `verb-passive`
+#### `verb-passive`
 
 Default: soft.
 Reports a form of `be` followed by a past participle, with optional adverbs or `not` between them.
 
-### `verb-perfect`
+#### `verb-perfect`
 
 Default: hard.
 Reports auxiliary `have` followed by a past participle, with optional adverbs or `not` between them.
 
 The three verb rules and applicable dictionary entries use the bundled English part-of-speech tagger.
+
+### House-style rules
+
+These rules define package house style.
+They do not come from ASD-STE100.
+The default config enables both rules.
+
+#### `hedging`
+
+Default: soft.
+Reports these phrases: `it is important to note`, `it should be noted`, `it is worth noting`, `please note that`, `as mentioned`, `as noted above`.
+A phrase match stays on one source line.
+
+#### `marketing`
+
+Default: soft.
+Reports the first listed term in each token from [`src/dictionary/data/marketing.json`](src/dictionary/data/marketing.json).
+Matching does not depend on letter case, and it also examines components of hyphenated tokens.
 
 ## Dictionary and attribution
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It does not rewrite text because an automatic rewrite can change its meaning.
 
 ## What the pi Adapter does
 
-The pi Adapter adds its active STE rules to the model prompt before each agent turn.
+The pi Adapter adds its active writing rules to the model prompt before each agent turn.
 It then applies the rules at three layers.
 
 1. **Write and edit gate.**
@@ -52,7 +52,7 @@ The repository supplies the local marketplace manifest.
 Marketplace publication is outside this package release.
 
 At `SessionStart`, the Adapter loads the merged config for an enabled session.
-It reads the config from the session working directory and adds the active STE rule summary to context.
+It reads the config from the session working directory and adds the active writing-rule summary to context.
 The summary honors `hard`, `soft`, and `off` rule settings plus `maxSentenceWords`.
 
 The `PreToolUse` gate checks `Write`, `Edit`, and `Bash` events.
@@ -392,8 +392,9 @@ A phrase match stays on one source line.
 #### `marketing`
 
 Default: soft.
-Reports the first listed term in each token from [`src/dictionary/data/marketing.json`](src/dictionary/data/marketing.json).
-Matching does not depend on letter case, and it also examines components of hyphenated tokens.
+Reports complete listed forms from [`src/dictionary/data/marketing.json`](src/dictionary/data/marketing.json).
+A multi-word form stays on one source line.
+Matching does not depend on letter case, and the rule also reports the first listed single-token component of a hyphenated token.
 
 ## Dictionary and attribution
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It then applies the rules at three layers.
 
 The pi Adapter checks Markdown prose and source comments according to the [content kinds](#content-kinds).
 It gives the line, column, rule ID, and suggested correction for a blocked tool call.
-A config or dictionary load error makes enabled write, edit, and commit gates fail closed.
+A config, dictionary, or rule-data load error makes enabled write, edit, and commit gates fail closed.
 
 ## Install the Claude Code Adapter
 
@@ -166,7 +166,7 @@ In strict mode, it blocks a reply that has hard violations.
 A `UserPromptSubmit` event adds pending feedback to context and clears that feedback.
 Every hook reads the current session mode before it applies a gate.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
-The hook also allows the event when configuration, dictionary, tagger, transcript, state, or file processing fails.
+The hook also allows the event when configuration, dictionary, rule-data, tagger, transcript, state, or file processing fails.
 It adds warning text.
 
 ### Lint files and standard input
@@ -302,6 +302,8 @@ Unknown keys, unknown rule IDs, and invalid values cause a config error.
 The loader adds entries from these files after the bundled entries.
 The loader resolves relative paths from the current working directory.
 Each file must use the [package dictionary data format](src/dictionary/README.md).
+A lint command reports an extension load error and continues with the bundled rule data.
+The enabled pi Adapter fails closed after that error, while Claude Code Hook mode allows the event and adds a warning.
 
 ## Rule reference
 
@@ -329,21 +331,8 @@ Markdown block boundaries and list items start separate paragraphs.
 #### `phrasal-verb`
 
 Default: hard.
-Reports these forms and supplies the listed suggestion:
-
-| Forms | Suggestion |
-| --- | --- |
-| `carry out`, `carries out`, `carried out`, `carrying out` | `do`. |
-| `spin up`, `spins up`, `spun up`, `spinning up` | `start`. |
-| `spin down`, `spins down`, `spun down`, `spinning down` | `stop`. |
-| `tear down`, `tears down`, `tore down`, `torn down`, `tearing down` | `remove`. |
-| `reach out`, `reaches out`, `reached out`, `reaching out` | `ask`. |
-| `dive into`, `dives into`, `dived into`, `dove into`, `diving into` | `examine`. |
-| `kick off`, `kicks off`, `kicked off`, `kicking off` | `start`. |
-| `roll out`, `rolls out`, `rolled out`, `rolling out` | `release`. |
-| `ramp up`, `ramps up`, `ramped up`, `ramping up` | `increase`. |
-| `circle back`, `circles back`, `circled back`, `circling back` | `return`. |
-| `drill down`, `drills down`, `drilled down`, `drilling down` | `examine`. |
+Reports listed forms and supplies their suggestion.
+The bundled forms and suggestions are in [`src/dictionary/data/phrasal-verbs.json`](src/dictionary/data/phrasal-verbs.json).
 
 Matching does not depend on letter case.
 A phrase match stays on one source line.
@@ -386,7 +375,7 @@ The default config enables both rules.
 #### `hedging`
 
 Default: soft.
-Reports these phrases: `it is important to note`, `it should be noted`, `it is worth noting`, `please note that`, `as mentioned`, `as noted above`.
+Reports the phrases in [`src/dictionary/data/hedging.json`](src/dictionary/data/hedging.json).
 A phrase match stays on one source line.
 
 #### `marketing`

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "simple-english",
       "dependencies": {
         "effect": "^3.14.0",
+        "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
       },
@@ -21,6 +22,10 @@
         "@earendil-works/pi-coding-agent": "*",
         "typebox": "*",
       },
+      "optionalPeers": [
+        "@earendil-works/pi-coding-agent",
+        "typebox",
+      ],
     },
   },
   "packages": {
@@ -491,6 +496,8 @@
     "undici": ["undici@8.5.0", "", {}, "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg=="],
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unicode-case-folding": ["unicode-case-folding@1.1.1", "", {}, "sha512-ZAYziAnMTBisO2dT5tyGvBFMNsIfonOS/BZTd3UZaKWtXMOZqK8s8HRUCrlKxGCTeCxCuCjS/6HW+4a6G+rbzw=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 

--- a/commands/ste.md
+++ b/commands/ste.md
@@ -1,5 +1,5 @@
 ---
-description: Control STE for this Claude Code session
+description: Control writing-rule enforcement for this Claude Code session
 argument-hint: on|off|status|strict|strict off
 allowed-tools: Bash
 disable-model-invocation: true

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Inject active STE rules, gate changes, and return reply feedback on the next prompt.",
+  "description": "Inject active writing rules, gate changes, and return reply feedback on the next prompt.",
 
   "hooks": {
     "SessionStart": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-simple-english",
   "version": "0.1.0",
-  "description": "ASD-STE100 Simplified Technical English lint engine, CLI, and host adapters",
+  "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",
   "author": {
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "effect": "^3.14.0",
+    "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
   },

--- a/src/adapter/rule-summary.ts
+++ b/src/adapter/rule-summary.ts
@@ -63,9 +63,15 @@ export function formatStatusSummary(
   ].join("\n")
 }
 
-export function ruleSummary(config: SteConfig): string {
-  const maxSentenceWords = config.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS
-  const rules = (Object.keys(RULE_SUMMARIES) as RuleId[])
+const HOUSE_STYLE_RULE_IDS: ReadonlySet<RuleId> = new Set(["hedging", "marketing"])
+
+function formatRuleGroup(
+  heading: string,
+  ruleIds: readonly RuleId[],
+  config: SteConfig,
+  maxSentenceWords: number,
+): string | undefined {
+  const rules = ruleIds
     .filter((ruleId) => resolvedRuleSetting(config, ruleId) !== "off")
     .map((ruleId) => {
       const summary =
@@ -74,6 +80,30 @@ export function ruleSummary(config: SteConfig): string {
           : RULE_SUMMARIES[ruleId]
       return `- [${resolvedRuleSetting(config, ruleId)}] ${summary}`
     })
-    .join("\n")
-  return `## Simplified Technical English\n\nFollow these STE rules in prose that you write or edit:\n${rules}\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
+  if (rules.length === 0) return undefined
+  return `### ${heading}\n\n${rules.join("\n")}`
+}
+
+export function ruleSummary(config: SteConfig): string {
+  const maxSentenceWords = config.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS
+  const ruleIds = Object.keys(RULE_SUMMARIES) as RuleId[]
+  const sections = [
+    formatRuleGroup(
+      "Rules derived from ASD-STE100 Simplified Technical English",
+      ruleIds.filter((ruleId) => !HOUSE_STYLE_RULE_IDS.has(ruleId)),
+      config,
+      maxSentenceWords,
+    ),
+    formatRuleGroup(
+      "House-style rules",
+      ruleIds.filter((ruleId) => HOUSE_STYLE_RULE_IDS.has(ruleId)),
+      config,
+      maxSentenceWords,
+    ),
+  ].filter((section): section is string => section !== undefined)
+  const rules =
+    sections.length === 0
+      ? "No writing rules are enabled."
+      : `Apply these enabled rules to prose that you write or edit:\n\n${sections.join("\n\n")}`
+  return `## Writing rules\n\n${rules}\n\nWrites, edits, and git commit messages reject hard violations. Correct the reported text and retry. Soft violations produce warnings.`
 }

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -6,7 +6,7 @@ import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-me
 import { formatViolations } from "../adapter/feedback.ts"
 import { ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
-import { loadDictionary } from "../dictionary/load.ts"
+import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
@@ -513,12 +513,25 @@ const readSessionControl = (sessionId: string) =>
 
 const loadLintOptions = (cwd: string, tagger: Tagger) => {
   const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
-  return Effect.all({
-    config: loadConfig(undefined, cwd),
-    dictionary: loadDictionary(
-      dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
+  return loadConfig(undefined, cwd).pipe(
+    Effect.flatMap((config) =>
+      Effect.all({
+        dictionary: loadDictionary(
+          dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
+        ),
+        ruleData: loadRuleData(config.ruleDataExtensions, cwd),
+      }).pipe(
+        Effect.map(
+          ({ dictionary, ruleData }): LintOptions => ({
+            ...config,
+            dictionary,
+            ruleData,
+            tagger,
+          }),
+        ),
+      ),
     ),
-  }).pipe(Effect.map(({ config, dictionary }): LintOptions => ({ ...config, dictionary, tagger })))
+  )
 }
 
 function splitViolations(violations: readonly Violation[]): {

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -561,9 +561,7 @@ function textDecision(
   if (hard.length > 0) {
     return deny(formatViolations(path, `Writing rules blocked ${operation} for`, hard))
   }
-  return allow(
-    soft.length === 0 ? [] : [formatViolations(path, "Writing-rule warnings for", soft)],
-  )
+  return allow(soft.length === 0 ? [] : [formatViolations(path, "Writing-rule warnings for", soft)])
 }
 
 function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutput, Error> {

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -209,12 +209,12 @@ function addContext(
 function nonBlockingError(message: string): HookError {
   return {
     continue: true,
-    systemMessage: `STE hook error: ${message}. The event is allowed.`,
+    systemMessage: `Writing-rule hook error: ${message}. The event is allowed.`,
   }
 }
 
 function nonBlockingWarning(message: string): HookDecision {
-  return allow([`STE hook warning: ${message}. The event is allowed.`])
+  return allow([`Writing-rule hook warning: ${message}. The event is allowed.`])
 }
 
 export function hookInternalFailure(cause: Cause.Cause<unknown>): HookOutput {
@@ -559,9 +559,11 @@ function textDecision(
   })
   const { hard, soft } = splitViolations(report.violations)
   if (hard.length > 0) {
-    return deny(formatViolations(path, `STE blocked ${operation} for`, hard))
+    return deny(formatViolations(path, `Writing rules blocked ${operation} for`, hard))
   }
-  return allow(soft.length === 0 ? [] : [formatViolations(path, "STE warnings for", soft)])
+  return allow(
+    soft.length === 0 ? [] : [formatViolations(path, "Writing-rule warnings for", soft)],
+  )
 }
 
 function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutput, Error> {
@@ -579,7 +581,7 @@ function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutp
     const feedback =
       hard.length === 0
         ? undefined
-        : formatViolations("assistant reply", "STE reply feedback for", hard)
+        : formatViolations("assistant reply", "Writing-rule reply feedback for", hard)
     const currentControl = yield* updateReplyFeedback(event.sessionId, reply.identity, feedback)
     if (
       currentControl === undefined ||
@@ -591,7 +593,7 @@ function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutp
     }
     return {
       decision: "block",
-      reason: formatViolations("assistant reply", "STE blocked reply for", hard),
+      reason: formatViolations("assistant reply", "Writing rules blocked reply for", hard),
     }
   })
 }
@@ -603,7 +605,7 @@ function evaluateEvent(event: PreToolUseEvent, tagger: Tagger): Effect.Effect<Ho
     if (invocations.some((invocation) => invocation.requiresExplicitMessage)) {
       return Effect.succeed(
         deny(
-          "STE could not check the git commit message. Use git commit with a static -m or --message argument.",
+          "Writing rules could not check the git commit message. Use git commit with a static -m or --message argument.",
         ),
       )
     }
@@ -616,10 +618,12 @@ function evaluateEvent(event: PreToolUseEvent, tagger: Tagger): Effect.Effect<Ho
       )
       const { hard, soft } = splitViolations(violations)
       if (hard.length > 0) {
-        return deny(formatViolations("commit message", "STE blocked commit for", hard))
+        return deny(formatViolations("commit message", "Writing rules blocked commit for", hard))
       }
       return allow(
-        soft.length === 0 ? [] : [formatViolations("commit message", "STE warnings for", soft)],
+        soft.length === 0
+          ? []
+          : [formatViolations("commit message", "Writing-rule warnings for", soft)],
       )
     })
   }

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,7 +2,7 @@
 import { readFile } from "node:fs/promises"
 import { Effect, Either } from "effect"
 import { loadConfig } from "../config/load.ts"
-import { loadDictionary } from "../dictionary/load.ts"
+import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { LintKind, LintReport } from "../engine/types.ts"
@@ -147,9 +147,14 @@ const lintProgram = Effect.gen(function* () {
   const loadedDictionary = yield* Effect.either(
     loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
   )
+  const loadedRuleData = yield* Effect.either(loadRuleData(config.ruleDataExtensions))
   const dictionary = Either.getOrUndefined(loadedDictionary)
+  const ruleData = Either.getOrUndefined(loadedRuleData)
   if (Either.isLeft(loadedDictionary)) {
     yield* Effect.sync(() => console.error(loadedDictionary.left.message))
+  }
+  if (Either.isLeft(loadedRuleData)) {
+    yield* Effect.sync(() => console.error(loadedRuleData.left.message))
   }
   const inputs =
     paths.length === 0
@@ -164,6 +169,7 @@ const lintProgram = Effect.gen(function* () {
         report: lint(kind ?? classification.kind, text, {
           ...config,
           dictionary,
+          ruleData,
           tagger,
           sourceDialect: classification.sourceDialect,
         }),

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path"
 import { Effect, Either } from "effect"
 import { formatFailedStatusSummary, formatStatusSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
-import { loadDictionary } from "../dictionary/load.ts"
+import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
 import {
   type SessionControl,
   getSessionControl,
@@ -46,7 +46,12 @@ function status(sessionId: string, cwd: string): Effect.Effect<string, Error> {
     }
     const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
     const dictionaryResult = yield* Effect.either(
-      loadDictionary(dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath)),
+      Effect.all({
+        dictionary: loadDictionary(
+          dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
+        ),
+        ruleData: loadRuleData(configResult.right.ruleDataExtensions, cwd),
+      }),
     )
     const dictionary: DictionaryState = Either.isRight(dictionaryResult)
       ? "loaded"

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -68,16 +68,16 @@ export function runSessionCommand(args: readonly string[]): Effect.Effect<string
   const command = commandParts.join(" ").trim().toLowerCase()
   if (command === "status") return status(sessionId, cwd)
   if (command === "on") {
-    return updateEnabled(sessionId, true).pipe(Effect.as("STE enforcement enabled."))
+    return updateEnabled(sessionId, true).pipe(Effect.as("Writing-rule enforcement enabled."))
   }
   if (command === "off") {
-    return updateEnabled(sessionId, false).pipe(Effect.as("STE enforcement disabled."))
+    return updateEnabled(sessionId, false).pipe(Effect.as("Writing-rule enforcement disabled."))
   }
   if (command === "strict" || command === "strict on") {
-    return updateStrict(sessionId, true).pipe(Effect.as("STE strict mode enabled."))
+    return updateStrict(sessionId, true).pipe(Effect.as("Writing-rule strict mode enabled."))
   }
   if (command === "strict off") {
-    return updateStrict(sessionId, false).pipe(Effect.as("STE strict mode disabled."))
+    return updateStrict(sessionId, false).pipe(Effect.as("Writing-rule strict mode disabled."))
   }
   return Effect.fail(new Error(USAGE))
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,10 +1,12 @@
 import { Effect, ParseResult, Schema } from "effect"
+import type { RuleDataExtensions } from "../dictionary/rule-data.ts"
 import { type RuleId, ruleIds } from "../engine/rules/registry.ts"
 import type { RuleSetting } from "../engine/types.ts"
 
 export interface SteConfig {
   readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
   readonly maxSentenceWords?: number
+  readonly ruleDataExtensions?: RuleDataExtensions
 }
 
 const RuleSettingSchema = Schema.Literal("hard", "soft", "off").annotations({
@@ -25,9 +27,18 @@ const MaxSentenceWordsSchema = Schema.Int.pipe(Schema.positive()).annotations({
   }),
 })
 
+const RuleDataExtensionsSchema = Schema.partial(
+  Schema.Struct({
+    "phrasal-verb": Schema.Array(Schema.NonEmptyTrimmedString),
+    hedging: Schema.Array(Schema.NonEmptyTrimmedString),
+    marketing: Schema.Array(Schema.NonEmptyTrimmedString),
+  }),
+)
+
 const SteConfigSchema = Schema.Struct({
   rules: Schema.optional(RulesSchema),
   maxSentenceWords: Schema.optional(MaxSentenceWordsSchema),
+  ruleDataExtensions: Schema.optional(RuleDataExtensionsSchema),
 })
 
 const decodeUnknown = Schema.decodeUnknown(SteConfigSchema, {

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -1,6 +1,7 @@
 # Dictionary data format
 
-`data/pi-ste.json` uses the package-owned format that `schema.ts` defines and Effect Schema validates.
+The JSON files in `data/` use the package-owned format that `schema.ts` defines and Effect Schema validates.
+The CLI and Adapters load all bundled data through `load.ts`.
 
 - `formatVersion` identifies incompatible format changes.
 - `source` records the source name and pins the repository, commit, and path from which the data was converted.
@@ -10,9 +11,11 @@
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
 
 Unknown properties and unsupported form syntax cause dictionary validation to fail.
-Matching is token based, and a hyphenated form matches only that exact hyphenated token.
+For the `dictionary-not-approved-word` rule, matching is token based.
+A hyphenated form matches only that exact hyphenated token.
 A phrase can span horizontal whitespace or a soft line break in the same Markdown paragraph, but it cannot span Markdown block boundaries or hard line breaks.
 Fenced and indented Markdown code is excluded from matching.
 The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags for the form's first token.
 The rule checks an entry without `partsOfSpeech` by word or phrase alone.
-See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the bundled data's exact source, conversion scope, and license details.
+The root [README](../../README.md) documents match details for the three list-backed rules and their config extension paths.
+See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the STE dictionary's exact source, conversion scope, and license details.

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -7,8 +7,10 @@ The CLI and Adapters load all bundled data through `load.ts`.
 - `source` records the source name and pins the repository, commit, and path from which the data was converted.
 - `entries[].unapproved` lists exact case-insensitive word forms or phrases.
   Forms can contain letters, numbers, internal apostrophes, internal hyphens, and horizontal whitespace between words.
-- `entries[].suggestions` lists approved alternatives.
+- `entries[].suggestions` is a required list of rule responses.
+  The dictionary rule reports all values as approved alternatives, the phrasal-verb rule uses the first value, and the hedging and marketing rules ignore this field.
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
+  Only the `dictionary-not-approved-word` rule uses this field.
 
 Unknown properties and unsupported form syntax cause dictionary validation to fail.
 For the `dictionary-not-approved-word` rule, matching is token based.

--- a/src/dictionary/bundled-rule-data.ts
+++ b/src/dictionary/bundled-rule-data.ts
@@ -1,0 +1,11 @@
+import hedging from "./data/hedging.json" with { type: "json" }
+import marketing from "./data/marketing.json" with { type: "json" }
+import phrasalVerbs from "./data/phrasal-verbs.json" with { type: "json" }
+import type { RuleData } from "./rule-data.ts"
+import type { Dictionary } from "./schema.ts"
+
+export const BUNDLED_RULE_DATA: RuleData = {
+  "phrasal-verb": phrasalVerbs as unknown as Dictionary,
+  hedging: hedging as unknown as Dictionary,
+  marketing: marketing as unknown as Dictionary,
+}

--- a/src/dictionary/bundled-rule-data.ts
+++ b/src/dictionary/bundled-rule-data.ts
@@ -2,10 +2,10 @@ import hedging from "./data/hedging.json" with { type: "json" }
 import marketing from "./data/marketing.json" with { type: "json" }
 import phrasalVerbs from "./data/phrasal-verbs.json" with { type: "json" }
 import type { RuleData } from "./rule-data.ts"
-import type { Dictionary } from "./schema.ts"
+import { decodeDictionaryData } from "./schema.ts"
 
 export const BUNDLED_RULE_DATA: RuleData = {
-  "phrasal-verb": phrasalVerbs as unknown as Dictionary,
-  hedging: hedging as unknown as Dictionary,
-  marketing: marketing as unknown as Dictionary,
+  "phrasal-verb": decodeDictionaryData(phrasalVerbs),
+  hedging: decodeDictionaryData(hedging),
+  marketing: decodeDictionaryData(marketing),
 }

--- a/src/dictionary/data/hedging.json
+++ b/src/dictionary/data/hedging.json
@@ -1,0 +1,22 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "agent-simple-english hedging list",
+    "repository": "https://github.com/jyooi/agent-simple-english",
+    "commit": "20a8ea5f3881c37620f9ab7808e2c930320ef0ef",
+    "path": "src/engine/rules/hedging.ts"
+  },
+  "entries": [
+    {
+      "unapproved": [
+        "it is important to note",
+        "it should be noted",
+        "it is worth noting",
+        "please note that",
+        "as mentioned",
+        "as noted above"
+      ],
+      "suggestions": ["delete"]
+    }
+  ]
+}

--- a/src/dictionary/data/marketing.json
+++ b/src/dictionary/data/marketing.json
@@ -1,0 +1,40 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "agent-simple-english marketing list",
+    "repository": "https://github.com/jyooi/agent-simple-english",
+    "commit": "20a8ea5f3881c37620f9ab7808e2c930320ef0ef",
+    "path": "src/engine/rules/marketing.ts"
+  },
+  "entries": [
+    {
+      "unapproved": [
+        "seamless",
+        "seamlessly",
+        "robust",
+        "powerful",
+        "cutting-edge",
+        "effortless",
+        "effortlessly",
+        "world-class",
+        "next-generation",
+        "revolutionary",
+        "blazing",
+        "lightning-fast",
+        "elegant",
+        "delightful",
+        "turnkey",
+        "best-in-class",
+        "state-of-the-art",
+        "game-changing",
+        "battle-tested",
+        "enterprise-grade",
+        "supercharge",
+        "unleash",
+        "empower",
+        "empowers"
+      ],
+      "suggestions": ["delete"]
+    }
+  ]
+}

--- a/src/dictionary/data/phrasal-verbs.json
+++ b/src/dictionary/data/phrasal-verbs.json
@@ -1,0 +1,55 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "agent-simple-english phrasal verb list",
+    "repository": "https://github.com/jyooi/agent-simple-english",
+    "commit": "20a8ea5f3881c37620f9ab7808e2c930320ef0ef",
+    "path": "src/engine/rules/phrasal-verb.ts"
+  },
+  "entries": [
+    {
+      "unapproved": ["carry out", "carries out", "carried out", "carrying out"],
+      "suggestions": ["do"]
+    },
+    {
+      "unapproved": ["spin up", "spins up", "spun up", "spinning up"],
+      "suggestions": ["start"]
+    },
+    {
+      "unapproved": ["spin down", "spins down", "spun down", "spinning down"],
+      "suggestions": ["stop"]
+    },
+    {
+      "unapproved": ["tear down", "tears down", "tore down", "torn down", "tearing down"],
+      "suggestions": ["remove"]
+    },
+    {
+      "unapproved": ["reach out", "reaches out", "reached out", "reaching out"],
+      "suggestions": ["ask"]
+    },
+    {
+      "unapproved": ["dive into", "dives into", "dived into", "dove into", "diving into"],
+      "suggestions": ["examine"]
+    },
+    {
+      "unapproved": ["kick off", "kicks off", "kicked off", "kicking off"],
+      "suggestions": ["start"]
+    },
+    {
+      "unapproved": ["roll out", "rolls out", "rolled out", "rolling out"],
+      "suggestions": ["release"]
+    },
+    {
+      "unapproved": ["ramp up", "ramps up", "ramped up", "ramping up"],
+      "suggestions": ["increase"]
+    },
+    {
+      "unapproved": ["circle back", "circles back", "circled back", "circling back"],
+      "suggestions": ["return"]
+    },
+    {
+      "unapproved": ["drill down", "drills down", "drilled down", "drilling down"],
+      "suggestions": ["examine"]
+    }
+  ]
+}

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -13,12 +13,15 @@ export const BUNDLED_RULE_DATA_PATHS: Readonly<Record<RuleDataId, string>> = {
   marketing: fileURLToPath(new URL("./data/marketing.json", import.meta.url)),
 }
 
+type DictionaryLoadLabel = "STE dictionary" | "rule data"
+
 export class DictionaryLoadError extends Error {
   constructor(
     readonly path: string,
     readonly reason: string,
+    label: DictionaryLoadLabel = "STE dictionary",
   ) {
-    super(`Cannot load STE dictionary from ${path}: ${reason}`)
+    super(`Cannot load ${label} from ${path}: ${reason}`)
     this.name = "DictionaryLoadError"
   }
 }
@@ -42,8 +45,9 @@ const decodeDictionary = Schema.decode(Schema.parseJson(DictionarySchema), {
   errors: "all",
 })
 
-export const loadDictionary = (
-  path = BUNDLED_DICTIONARY_PATH,
+const loadDictionaryData = (
+  path: string,
+  label: DictionaryLoadLabel,
 ): Effect.Effect<Dictionary, DictionaryLoadError> =>
   Effect.tryPromise({
     try: () => readFile(path, "utf8"),
@@ -51,15 +55,20 @@ export const loadDictionary = (
       new DictionaryLoadError(
         path,
         `cannot read file: ${cause instanceof Error ? cause.message : String(cause)}`,
+        label,
       ),
   }).pipe(
     Effect.flatMap(decodeDictionary),
     Effect.mapError((cause) =>
       cause instanceof DictionaryLoadError
         ? cause
-        : new DictionaryLoadError(path, formatParseError(cause)),
+        : new DictionaryLoadError(path, formatParseError(cause), label),
     ),
   )
+
+export const loadDictionary = (
+  path = BUNDLED_DICTIONARY_PATH,
+): Effect.Effect<Dictionary, DictionaryLoadError> => loadDictionaryData(path, "STE dictionary")
 
 const loadExtendedRuleData = (
   id: RuleDataId,
@@ -67,8 +76,8 @@ const loadExtendedRuleData = (
   cwd: string,
 ): Effect.Effect<Dictionary, DictionaryLoadError> =>
   Effect.all([
-    loadDictionary(BUNDLED_RULE_DATA_PATHS[id]),
-    ...extensionPaths.map((path) => loadDictionary(resolve(cwd, path))),
+    loadDictionaryData(BUNDLED_RULE_DATA_PATHS[id], "rule data"),
+    ...extensionPaths.map((path) => loadDictionaryData(resolve(cwd, path), "rule data")),
   ]).pipe(
     Effect.map(([bundled, ...extensions]) => ({
       ...bundled,

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -1,9 +1,17 @@
 import { readFile } from "node:fs/promises"
+import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Effect, ParseResult, Schema } from "effect"
+import type { RuleData, RuleDataExtensions, RuleDataId } from "./rule-data.ts"
 import { type Dictionary, DictionarySchema } from "./schema.ts"
 
 export const BUNDLED_DICTIONARY_PATH = fileURLToPath(new URL("./data/pi-ste.json", import.meta.url))
+
+export const BUNDLED_RULE_DATA_PATHS: Readonly<Record<RuleDataId, string>> = {
+  "phrasal-verb": fileURLToPath(new URL("./data/phrasal-verbs.json", import.meta.url)),
+  hedging: fileURLToPath(new URL("./data/hedging.json", import.meta.url)),
+  marketing: fileURLToPath(new URL("./data/marketing.json", import.meta.url)),
+}
 
 export class DictionaryLoadError extends Error {
   constructor(
@@ -52,3 +60,28 @@ export const loadDictionary = (
         : new DictionaryLoadError(path, formatParseError(cause)),
     ),
   )
+
+const loadExtendedRuleData = (
+  id: RuleDataId,
+  extensionPaths: readonly string[],
+  cwd: string,
+): Effect.Effect<Dictionary, DictionaryLoadError> =>
+  Effect.all([
+    loadDictionary(BUNDLED_RULE_DATA_PATHS[id]),
+    ...extensionPaths.map((path) => loadDictionary(resolve(cwd, path))),
+  ]).pipe(
+    Effect.map(([bundled, ...extensions]) => ({
+      ...bundled,
+      entries: [bundled, ...extensions].flatMap((dictionary) => dictionary.entries),
+    })),
+  )
+
+export const loadRuleData = (
+  extensions: RuleDataExtensions = {},
+  cwd = process.cwd(),
+): Effect.Effect<RuleData, DictionaryLoadError> =>
+  Effect.all({
+    "phrasal-verb": loadExtendedRuleData("phrasal-verb", extensions["phrasal-verb"] ?? [], cwd),
+    hedging: loadExtendedRuleData("hedging", extensions.hedging ?? [], cwd),
+    marketing: loadExtendedRuleData("marketing", extensions.marketing ?? [], cwd),
+  })

--- a/src/dictionary/rule-data.ts
+++ b/src/dictionary/rule-data.ts
@@ -1,0 +1,7 @@
+import type { Dictionary } from "./schema.ts"
+
+export const ruleDataIds = ["phrasal-verb", "hedging", "marketing"] as const
+
+export type RuleDataId = (typeof ruleDataIds)[number]
+export type RuleData = Readonly<Partial<Record<RuleDataId, Dictionary>>>
+export type RuleDataExtensions = Readonly<Partial<Record<RuleDataId, readonly string[]>>>

--- a/src/dictionary/schema.ts
+++ b/src/dictionary/schema.ts
@@ -24,5 +24,10 @@ export const DictionarySchema = Schema.Struct({
   entries: Schema.Array(DictionaryEntrySchema),
 })
 
+export const decodeDictionaryData = Schema.decodeUnknownSync(DictionarySchema, {
+  onExcessProperty: "error",
+  errors: "all",
+})
+
 export type Dictionary = typeof DictionarySchema.Type
 export type DictionaryEntry = typeof DictionaryEntrySchema.Type

--- a/src/engine/case-fold.ts
+++ b/src/engine/case-fold.ts
@@ -1,0 +1,17 @@
+import { caseFold } from "unicode-case-folding"
+import { TOKEN_RUN_PATTERN } from "./tokens.ts"
+
+export interface CaseFoldedToken {
+  readonly text: string
+  readonly key: string
+  readonly offset: number
+}
+
+export const caseFoldKey = (text: string): string => caseFold(text)
+
+export const tokenizeCaseFolded = (line: string): readonly CaseFoldedToken[] =>
+  Array.from(line.matchAll(TOKEN_RUN_PATTERN), (match) => ({
+    text: match[0],
+    key: caseFoldKey(match[0]),
+    offset: match.index,
+  }))

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,3 +1,5 @@
+import { BUNDLED_RULE_DATA } from "../dictionary/bundled-rule-data.ts"
+import type { RuleData } from "../dictionary/rule-data.ts"
 import type { Dictionary } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
 import { type ScopedViolation, type ViolationScope, newFindings } from "./diff-match.ts"
@@ -23,6 +25,7 @@ export const DEFAULT_MAX_SENTENCE_WORDS = 25
 interface ResolvedOptions {
   readonly maxSentenceWords: number
   readonly dictionary?: Dictionary
+  readonly ruleData?: RuleData
   readonly tagger?: Tagger
 }
 
@@ -262,9 +265,15 @@ const lintProse = (
     ),
     ...sentenceFindings(contraction(prepared.lines)),
     ...sentenceFindings(semicolon(prepared.mechanicalLines)),
-    ...sentenceFindings(phrasalVerb(prepared.lines)),
-    ...sentenceFindings(hedging(prepared.lines)),
-    ...sentenceFindings(marketing(prepared.lines)),
+    ...(options.ruleData?.["phrasal-verb"] === undefined
+      ? []
+      : sentenceFindings(phrasalVerb(prepared.lines, options.ruleData["phrasal-verb"]))),
+    ...(options.ruleData?.hedging === undefined
+      ? []
+      : sentenceFindings(hedging(prepared.lines, options.ruleData.hedging))),
+    ...(options.ruleData?.marketing === undefined
+      ? []
+      : sentenceFindings(marketing(prepared.lines, options.ruleData.marketing))),
     ...(options.dictionary === undefined
       ? []
       : sentenceFindings(
@@ -298,6 +307,7 @@ function evaluate(kind: LintKind, text: string, options: LintOptions): ScopedVio
   const resolved: ResolvedOptions = {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
     dictionary: options.dictionary,
+    ruleData: options.ruleData ?? BUNDLED_RULE_DATA,
     tagger: options.tagger,
   }
   return splitProseRuns(extract(kind, text, options))

--- a/src/engine/phrase-matcher.ts
+++ b/src/engine/phrase-matcher.ts
@@ -9,6 +9,8 @@ export interface CaseFoldedPhrase {
   readonly words: readonly string[]
 }
 
+const SAME_LINE_WHITESPACE_PATTERN = /^[^\S\r\n\u2028\u2029]+$/u
+
 export const compileCaseFoldedPhrase = (form: string): CaseFoldedPhrase => ({
   words: form.split(/[\t ]+/u).map(caseFoldKey),
 })
@@ -26,7 +28,9 @@ const matchesPhrase = (
 
     const previous = tokens[start + wordIndex - 1]
     if (previous === undefined) return false
-    return /^[\t ]+$/u.test(line.slice(previous.offset + previous.text.length, token.offset))
+    return SAME_LINE_WHITESPACE_PATTERN.test(
+      line.slice(previous.offset + previous.text.length, token.offset),
+    )
   })
 
 export function scanCaseFoldedPhrases(

--- a/src/engine/phrase-matcher.ts
+++ b/src/engine/phrase-matcher.ts
@@ -1,0 +1,64 @@
+import {
+  caseFoldKey,
+  type CaseFoldedToken,
+  tokenizeCaseFolded,
+} from "./case-fold.ts"
+import type { LineMatch } from "./scan.ts"
+
+export interface CaseFoldedPhrase {
+  readonly words: readonly string[]
+}
+
+export const compileCaseFoldedPhrase = (form: string): CaseFoldedPhrase => ({
+  words: form.split(/[\t ]+/u).map(caseFoldKey),
+})
+
+const matchesPhrase = (
+  line: string,
+  tokens: readonly CaseFoldedToken[],
+  start: number,
+  phrase: CaseFoldedPhrase,
+): boolean =>
+  phrase.words.every((word, wordIndex) => {
+    const token = tokens[start + wordIndex]
+    if (token === undefined || token.key !== word) return false
+    if (wordIndex === 0) return true
+
+    const previous = tokens[start + wordIndex - 1]
+    if (previous === undefined) return false
+    return /^[\t ]+$/u.test(line.slice(previous.offset + previous.text.length, token.offset))
+  })
+
+export function scanCaseFoldedPhrases(
+  lines: readonly string[],
+  phrases: readonly CaseFoldedPhrase[],
+): LineMatch[] {
+  const matches: LineMatch[] = []
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex]
+    if (line === undefined) continue
+
+    const tokens = tokenizeCaseFolded(line)
+    for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+      const first = tokens[tokenIndex]
+      if (first === undefined) continue
+
+      const phrase = phrases.find((candidate) =>
+        matchesPhrase(line, tokens, tokenIndex, candidate),
+      )
+      if (phrase === undefined) continue
+
+      const last = tokens[tokenIndex + phrase.words.length - 1]
+      if (last === undefined) continue
+      matches.push({
+        found: line.slice(first.offset, last.offset + last.text.length),
+        line: lineIndex + 1,
+        column: first.offset + 1,
+      })
+      tokenIndex += phrase.words.length - 1
+    }
+  }
+
+  return matches
+}

--- a/src/engine/phrase-matcher.ts
+++ b/src/engine/phrase-matcher.ts
@@ -1,8 +1,4 @@
-import {
-  caseFoldKey,
-  type CaseFoldedToken,
-  tokenizeCaseFolded,
-} from "./case-fold.ts"
+import { type CaseFoldedToken, caseFoldKey, tokenizeCaseFolded } from "./case-fold.ts"
 import type { LineMatch } from "./scan.ts"
 
 export interface CaseFoldedPhrase {
@@ -48,9 +44,7 @@ export function scanCaseFoldedPhrases(
       const first = tokens[tokenIndex]
       if (first === undefined) continue
 
-      const phrase = phrases.find((candidate) =>
-        matchesPhrase(line, tokens, tokenIndex, candidate),
-      )
+      const phrase = phrases.find((candidate) => matchesPhrase(line, tokens, tokenIndex, candidate))
       if (phrase === undefined) continue
 
       const last = tokens[tokenIndex + phrase.words.length - 1]

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -3,17 +3,19 @@ import { scanLines } from "../scan.ts"
 import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
-const compilePattern = (dictionary: Dictionary): RegExp =>
+const compilePattern = (forms: readonly string[]): RegExp =>
   new RegExp(
-    `(?<!${TOKEN_CHARACTER_PATTERN})(?:${dictionary.entries
-      .flatMap((entry) => entry.unapproved)
+    `(?<!${TOKEN_CHARACTER_PATTERN})(?:${forms
       .map((phrase) => phrase.replace(/[\t ]+/g, "\\s+"))
       .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-    "gi",
+    "giu",
   )
 
 export function hedging(lines: readonly string[], dictionary: Dictionary): Violation[] {
-  return scanLines(lines, compilePattern(dictionary)).map((match) => ({
+  const forms = dictionary.entries.flatMap((entry) => entry.unapproved)
+  if (forms.length === 0) return []
+
+  return scanLines(lines, compilePattern(forms)).map((match) => ({
     ruleId: "hedging",
     severity: "soft" as const,
     message: `Do not hedge. Delete "${match.found.toLowerCase()}".`,

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -3,19 +3,40 @@ import { scanLines } from "../scan.ts"
 import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
-const compilePattern = (forms: readonly string[]): RegExp =>
-  new RegExp(
-    `(?<!${TOKEN_CHARACTER_PATTERN})(?:${forms
-      .map((phrase) => phrase.replace(/[\t ]+/g, "\\s+"))
-      .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-    "giu",
-  )
+interface CompiledHedgingData {
+  readonly pattern?: RegExp
+}
+
+const compiledDataByDictionary = new WeakMap<Dictionary, CompiledHedgingData>()
+
+const compileHedgingData = (dictionary: Dictionary): CompiledHedgingData => {
+  const forms = dictionary.entries.flatMap((entry) => entry.unapproved)
+  if (forms.length === 0) return {}
+
+  return {
+    pattern: new RegExp(
+      `(?<!${TOKEN_CHARACTER_PATTERN})(?:${forms
+        .map((phrase) => phrase.replace(/[\t ]+/g, "\\s+"))
+        .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
+      "giu",
+    ),
+  }
+}
+
+const hedgingDataFor = (dictionary: Dictionary): CompiledHedgingData => {
+  const cached = compiledDataByDictionary.get(dictionary)
+  if (cached !== undefined) return cached
+
+  const compiled = compileHedgingData(dictionary)
+  compiledDataByDictionary.set(dictionary, compiled)
+  return compiled
+}
 
 export function hedging(lines: readonly string[], dictionary: Dictionary): Violation[] {
-  const forms = dictionary.entries.flatMap((entry) => entry.unapproved)
-  if (forms.length === 0) return []
+  const { pattern } = hedgingDataFor(dictionary)
+  if (pattern === undefined) return []
 
-  return scanLines(lines, compilePattern(forms)).map((match) => ({
+  return scanLines(lines, pattern).map((match) => ({
     ruleId: "hedging",
     severity: "soft" as const,
     message: `Do not hedge. Delete "${match.found.toLowerCase()}".`,

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -1,42 +1,26 @@
 import type { Dictionary } from "../../dictionary/schema.ts"
-import { scanLines } from "../scan.ts"
-import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
+import {
+  compileCaseFoldedPhrase,
+  type CaseFoldedPhrase,
+  scanCaseFoldedPhrases,
+} from "../phrase-matcher.ts"
 import type { Violation } from "../types.ts"
 
-interface CompiledHedgingData {
-  readonly pattern?: RegExp
-}
+const phrasesByDictionary = new WeakMap<Dictionary, readonly CaseFoldedPhrase[]>()
 
-const compiledDataByDictionary = new WeakMap<Dictionary, CompiledHedgingData>()
-
-const compileHedgingData = (dictionary: Dictionary): CompiledHedgingData => {
-  const forms = dictionary.entries.flatMap((entry) => entry.unapproved)
-  if (forms.length === 0) return {}
-
-  return {
-    pattern: new RegExp(
-      `(?<!${TOKEN_CHARACTER_PATTERN})(?:${forms
-        .map((phrase) => phrase.replace(/[\t ]+/g, "\\s+"))
-        .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-      "giu",
-    ),
-  }
-}
-
-const hedgingDataFor = (dictionary: Dictionary): CompiledHedgingData => {
-  const cached = compiledDataByDictionary.get(dictionary)
+const phrasesFor = (dictionary: Dictionary): readonly CaseFoldedPhrase[] => {
+  const cached = phrasesByDictionary.get(dictionary)
   if (cached !== undefined) return cached
 
-  const compiled = compileHedgingData(dictionary)
-  compiledDataByDictionary.set(dictionary, compiled)
+  const compiled = dictionary.entries.flatMap((entry) =>
+    entry.unapproved.map(compileCaseFoldedPhrase),
+  )
+  phrasesByDictionary.set(dictionary, compiled)
   return compiled
 }
 
 export function hedging(lines: readonly string[], dictionary: Dictionary): Violation[] {
-  const { pattern } = hedgingDataFor(dictionary)
-  if (pattern === undefined) return []
-
-  return scanLines(lines, pattern).map((match) => ({
+  return scanCaseFoldedPhrases(lines, phrasesFor(dictionary)).map((match) => ({
     ruleId: "hedging",
     severity: "soft" as const,
     message: `Do not hedge. Delete "${match.found.toLowerCase()}".`,

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -1,7 +1,7 @@
 import type { Dictionary } from "../../dictionary/schema.ts"
 import {
-  compileCaseFoldedPhrase,
   type CaseFoldedPhrase,
+  compileCaseFoldedPhrase,
   scanCaseFoldedPhrases,
 } from "../phrase-matcher.ts"
 import type { Violation } from "../types.ts"

--- a/src/engine/rules/hedging.ts
+++ b/src/engine/rules/hedging.ts
@@ -1,23 +1,19 @@
+import type { Dictionary } from "../../dictionary/schema.ts"
 import { scanLines } from "../scan.ts"
 import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
-const HEDGES = [
-  "it is important to note",
-  "it should be noted",
-  "it is worth noting",
-  "please note that",
-  "as mentioned",
-  "as noted above",
-]
+const compilePattern = (dictionary: Dictionary): RegExp =>
+  new RegExp(
+    `(?<!${TOKEN_CHARACTER_PATTERN})(?:${dictionary.entries
+      .flatMap((entry) => entry.unapproved)
+      .map((phrase) => phrase.replace(/[\t ]+/g, "\\s+"))
+      .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
+    "gi",
+  )
 
-const HEDGE_PATTERN = new RegExp(
-  `(?<!${TOKEN_CHARACTER_PATTERN})(?:${HEDGES.map((phrase) => phrase.replace(/ /g, "\\s+")).join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-  "gi",
-)
-
-export function hedging(lines: readonly string[]): Violation[] {
-  return scanLines(lines, HEDGE_PATTERN).map((match) => ({
+export function hedging(lines: readonly string[], dictionary: Dictionary): Violation[] {
+  return scanLines(lines, compilePattern(dictionary)).map((match) => ({
     ruleId: "hedging",
     severity: "soft" as const,
     message: `Do not hedge. Delete "${match.found.toLowerCase()}".`,

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,59 +1,37 @@
+import type { Dictionary } from "../../dictionary/schema.ts"
 import { TOKEN_RUN_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
-
-const MARKETING_WORDS = [
-  "seamless",
-  "seamlessly",
-  "robust",
-  "powerful",
-  "cutting-edge",
-  "effortless",
-  "effortlessly",
-  "world-class",
-  "next-generation",
-  "revolutionary",
-  "blazing",
-  "lightning-fast",
-  "elegant",
-  "delightful",
-  "turnkey",
-  "best-in-class",
-  "state-of-the-art",
-  "game-changing",
-  "battle-tested",
-  "enterprise-grade",
-  "supercharge",
-  "unleash",
-  "empower",
-  "empowers",
-]
-
-const MARKETING_SET = new Set(MARKETING_WORDS)
 
 interface MarketingMatch {
   readonly found: string
   readonly offset: number
 }
 
-function findMarketingLanguage(token: string): MarketingMatch | undefined {
+function findMarketingLanguage(
+  token: string,
+  marketingWords: ReadonlySet<string>,
+): MarketingMatch | undefined {
   const normalized = token.toLowerCase()
-  if (MARKETING_SET.has(normalized)) {
+  if (marketingWords.has(normalized)) {
     return { found: normalized, offset: 0 }
   }
 
   let offset = 0
   for (const part of normalized.split("-")) {
-    if (MARKETING_SET.has(part)) {
+    if (marketingWords.has(part)) {
       return { found: part, offset }
     }
     offset += part.length + 1
   }
 }
 
-export function marketing(lines: readonly string[]): Violation[] {
+export function marketing(lines: readonly string[], dictionary: Dictionary): Violation[] {
+  const marketingWords = new Set(
+    dictionary.entries.flatMap((entry) => entry.unapproved.map((word) => word.toLowerCase())),
+  )
   return lines.flatMap((line, lineIndex) =>
     Array.from(line.matchAll(TOKEN_RUN_PATTERN)).flatMap((tokenMatch) => {
-      const match = findMarketingLanguage(tokenMatch[0])
+      const match = findMarketingLanguage(tokenMatch[0], marketingWords)
       if (!match) {
         return []
       }

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,13 +1,10 @@
-import { caseFold } from "unicode-case-folding"
 import type { Dictionary } from "../../dictionary/schema.ts"
-import { TOKEN_RUN_PATTERN } from "../tokens.ts"
+import {
+  caseFoldKey,
+  type CaseFoldedToken,
+  tokenizeCaseFolded,
+} from "../case-fold.ts"
 import type { Violation } from "../types.ts"
-
-interface MarketingToken {
-  readonly text: string
-  readonly key: string
-  readonly offset: number
-}
 
 interface MarketingForm {
   readonly words: readonly string[]
@@ -25,15 +22,6 @@ interface MarketingMatch {
 }
 
 const compiledDataByDictionary = new WeakMap<Dictionary, CompiledMarketingData>()
-
-const caseFoldKey = (text: string): string => caseFold(text)
-
-const tokenize = (line: string): readonly MarketingToken[] =>
-  Array.from(line.matchAll(TOKEN_RUN_PATTERN), (match) => ({
-    text: match[0],
-    key: caseFoldKey(match[0]),
-    offset: match.index,
-  }))
 
 const compileMarketingData = (dictionary: Dictionary): CompiledMarketingData => {
   const forms = dictionary.entries
@@ -70,7 +58,7 @@ const marketingDataFor = (dictionary: Dictionary): CompiledMarketingData => {
 
 function matchesForm(
   line: string,
-  tokens: readonly MarketingToken[],
+  tokens: readonly CaseFoldedToken[],
   start: number,
   form: MarketingForm,
 ): boolean {
@@ -87,7 +75,7 @@ function matchesForm(
 
 function findCompleteForm(
   line: string,
-  tokens: readonly MarketingToken[],
+  tokens: readonly CaseFoldedToken[],
   start: number,
   data: CompiledMarketingData,
 ): MarketingMatch | undefined {
@@ -108,7 +96,7 @@ function findCompleteForm(
 }
 
 function findMarketingComponent(
-  token: MarketingToken,
+  token: CaseFoldedToken,
   componentWords: ReadonlySet<string>,
 ): MarketingMatch | undefined {
   let partOffset = 0
@@ -128,7 +116,7 @@ export function marketing(lines: readonly string[], dictionary: Dictionary): Vio
     const line = lines[lineIndex]
     if (line === undefined) continue
 
-    const tokens = tokenize(line)
+    const tokens = tokenizeCaseFolded(line)
     for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
       const token = tokens[tokenIndex]
       if (token === undefined) continue

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -4,7 +4,7 @@ import type { Violation } from "../types.ts"
 
 interface MarketingToken {
   readonly text: string
-  readonly lower: string
+  readonly key: string
   readonly offset: number
 }
 
@@ -25,17 +25,20 @@ interface MarketingMatch {
 
 const compiledDataByDictionary = new WeakMap<Dictionary, CompiledMarketingData>()
 
+const caseFoldKey = (text: string): string =>
+  text.toLowerCase().toUpperCase().toLowerCase()
+
 const tokenize = (line: string): readonly MarketingToken[] =>
   Array.from(line.matchAll(TOKEN_RUN_PATTERN), (match) => ({
     text: match[0],
-    lower: match[0].toLowerCase(),
+    key: caseFoldKey(match[0]),
     offset: match.index,
   }))
 
 const compileMarketingData = (dictionary: Dictionary): CompiledMarketingData => {
   const forms = dictionary.entries
     .flatMap((entry) => entry.unapproved)
-    .map((form) => ({ words: form.toLowerCase().split(/[\t ]+/u) }))
+    .map((form) => ({ words: form.split(/[\t ]+/u).map(caseFoldKey) }))
     .sort((left, right) => right.words.length - left.words.length)
   const formsByFirstWord = new Map<string, MarketingForm[]>()
   const componentWords = new Set<string>()
@@ -73,7 +76,7 @@ function matchesForm(
 ): boolean {
   return form.words.every((word, wordIndex) => {
     const token = tokens[start + wordIndex]
-    if (token === undefined || token.lower !== word) return false
+    if (token === undefined || token.key !== word) return false
     if (wordIndex === 0) return true
 
     const previous = tokens[start + wordIndex - 1]
@@ -91,7 +94,7 @@ function findCompleteForm(
   const first = tokens[start]
   if (first === undefined) return undefined
 
-  for (const form of data.formsByFirstWord.get(first.lower) ?? []) {
+  for (const form of data.formsByFirstWord.get(first.key) ?? []) {
     if (!matchesForm(line, tokens, start, form)) continue
 
     const last = tokens[start + form.words.length - 1]
@@ -110,9 +113,8 @@ function findMarketingComponent(
 ): MarketingMatch | undefined {
   let partOffset = 0
   for (const part of token.text.split(/[-‐‑]/u)) {
-    const lower = part.toLowerCase()
-    if (componentWords.has(lower)) {
-      return { found: lower, offset: token.offset + partOffset, tokenCount: 1 }
+    if (componentWords.has(caseFoldKey(part))) {
+      return { found: part.toLowerCase(), offset: token.offset + partOffset, tokenCount: 1 }
     }
     partOffset += part.length + 1
   }

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,9 +1,5 @@
 import type { Dictionary } from "../../dictionary/schema.ts"
-import {
-  caseFoldKey,
-  type CaseFoldedToken,
-  tokenizeCaseFolded,
-} from "../case-fold.ts"
+import { type CaseFoldedToken, caseFoldKey, tokenizeCaseFolded } from "../case-fold.ts"
 import type { Violation } from "../types.ts"
 
 interface MarketingForm {

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -2,48 +2,150 @@ import type { Dictionary } from "../../dictionary/schema.ts"
 import { TOKEN_RUN_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
-interface MarketingMatch {
-  readonly found: string
+interface MarketingToken {
+  readonly text: string
+  readonly lower: string
   readonly offset: number
 }
 
-function findMarketingLanguage(
-  token: string,
-  marketingWords: ReadonlySet<string>,
-): MarketingMatch | undefined {
-  const normalized = token.toLowerCase()
-  if (marketingWords.has(normalized)) {
-    return { found: normalized, offset: 0 }
+interface MarketingForm {
+  readonly words: readonly string[]
+}
+
+interface CompiledMarketingData {
+  readonly formsByFirstWord: ReadonlyMap<string, readonly MarketingForm[]>
+  readonly componentWords: ReadonlySet<string>
+}
+
+interface MarketingMatch {
+  readonly found: string
+  readonly offset: number
+  readonly tokenCount: number
+}
+
+const compiledDataByDictionary = new WeakMap<Dictionary, CompiledMarketingData>()
+
+const tokenize = (line: string): readonly MarketingToken[] =>
+  Array.from(line.matchAll(TOKEN_RUN_PATTERN), (match) => ({
+    text: match[0],
+    lower: match[0].toLowerCase(),
+    offset: match.index,
+  }))
+
+const compileMarketingData = (dictionary: Dictionary): CompiledMarketingData => {
+  const forms = dictionary.entries
+    .flatMap((entry) => entry.unapproved)
+    .map((form) => ({ words: form.toLowerCase().split(/[\t ]+/u) }))
+    .sort((left, right) => right.words.length - left.words.length)
+  const formsByFirstWord = new Map<string, MarketingForm[]>()
+  const componentWords = new Set<string>()
+
+  for (const form of forms) {
+    const firstWord = form.words[0]
+    if (firstWord === undefined) continue
+
+    const candidates = formsByFirstWord.get(firstWord)
+    if (candidates === undefined) {
+      formsByFirstWord.set(firstWord, [form])
+    } else {
+      candidates.push(form)
+    }
+    if (form.words.length === 1) componentWords.add(firstWord)
   }
 
-  let offset = 0
-  for (const part of normalized.split(/[-‐‑]/u)) {
-    if (marketingWords.has(part)) {
-      return { found: part, offset }
+  return { formsByFirstWord, componentWords }
+}
+
+const marketingDataFor = (dictionary: Dictionary): CompiledMarketingData => {
+  const cached = compiledDataByDictionary.get(dictionary)
+  if (cached !== undefined) return cached
+
+  const compiled = compileMarketingData(dictionary)
+  compiledDataByDictionary.set(dictionary, compiled)
+  return compiled
+}
+
+function matchesForm(
+  line: string,
+  tokens: readonly MarketingToken[],
+  start: number,
+  form: MarketingForm,
+): boolean {
+  return form.words.every((word, wordIndex) => {
+    const token = tokens[start + wordIndex]
+    if (token === undefined || token.lower !== word) return false
+    if (wordIndex === 0) return true
+
+    const previous = tokens[start + wordIndex - 1]
+    if (previous === undefined) return false
+    return /^[\t ]+$/u.test(line.slice(previous.offset + previous.text.length, token.offset))
+  })
+}
+
+function findCompleteForm(
+  line: string,
+  tokens: readonly MarketingToken[],
+  start: number,
+  data: CompiledMarketingData,
+): MarketingMatch | undefined {
+  const first = tokens[start]
+  if (first === undefined) return undefined
+
+  for (const form of data.formsByFirstWord.get(first.lower) ?? []) {
+    if (!matchesForm(line, tokens, start, form)) continue
+
+    const last = tokens[start + form.words.length - 1]
+    if (last === undefined) continue
+    return {
+      found: line.slice(first.offset, last.offset + last.text.length).toLowerCase(),
+      offset: first.offset,
+      tokenCount: form.words.length,
     }
-    offset += part.length + 1
+  }
+}
+
+function findMarketingComponent(
+  token: MarketingToken,
+  componentWords: ReadonlySet<string>,
+): MarketingMatch | undefined {
+  let partOffset = 0
+  for (const part of token.text.split(/[-‐‑]/u)) {
+    const lower = part.toLowerCase()
+    if (componentWords.has(lower)) {
+      return { found: lower, offset: token.offset + partOffset, tokenCount: 1 }
+    }
+    partOffset += part.length + 1
   }
 }
 
 export function marketing(lines: readonly string[], dictionary: Dictionary): Violation[] {
-  const marketingWords = new Set(
-    dictionary.entries.flatMap((entry) => entry.unapproved.map((word) => word.toLowerCase())),
-  )
-  return lines.flatMap((line, lineIndex) =>
-    Array.from(line.matchAll(TOKEN_RUN_PATTERN)).flatMap((tokenMatch) => {
-      const match = findMarketingLanguage(tokenMatch[0], marketingWords)
-      if (!match) {
-        return []
-      }
-      return [
-        {
-          ruleId: "marketing",
-          severity: "soft" as const,
-          message: `Do not use marketing language. Delete "${match.found}".`,
-          line: lineIndex + 1,
-          column: tokenMatch.index + match.offset + 1,
-        },
-      ]
-    }),
-  )
+  const data = marketingDataFor(dictionary)
+  const violations: Violation[] = []
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex]
+    if (line === undefined) continue
+
+    const tokens = tokenize(line)
+    for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+      const token = tokens[tokenIndex]
+      if (token === undefined) continue
+
+      const match =
+        findCompleteForm(line, tokens, tokenIndex, data) ??
+        findMarketingComponent(token, data.componentWords)
+      if (match === undefined) continue
+
+      violations.push({
+        ruleId: "marketing",
+        severity: "soft",
+        message: `Do not use marketing language. Delete "${match.found}".`,
+        line: lineIndex + 1,
+        column: match.offset + 1,
+      })
+      tokenIndex += match.tokenCount - 1
+    }
+  }
+
+  return violations
 }

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -17,7 +17,7 @@ function findMarketingLanguage(
   }
 
   let offset = 0
-  for (const part of normalized.split("-")) {
+  for (const part of normalized.split(/[-‐‑]/u)) {
     if (marketingWords.has(part)) {
       return { found: part, offset }
     }

--- a/src/engine/rules/marketing.ts
+++ b/src/engine/rules/marketing.ts
@@ -1,3 +1,4 @@
+import { caseFold } from "unicode-case-folding"
 import type { Dictionary } from "../../dictionary/schema.ts"
 import { TOKEN_RUN_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
@@ -25,8 +26,7 @@ interface MarketingMatch {
 
 const compiledDataByDictionary = new WeakMap<Dictionary, CompiledMarketingData>()
 
-const caseFoldKey = (text: string): string =>
-  text.toLowerCase().toUpperCase().toLowerCase()
+const caseFoldKey = (text: string): string => caseFold(text)
 
 const tokenize = (line: string): readonly MarketingToken[] =>
   Array.from(line.matchAll(TOKEN_RUN_PATTERN), (match) => ({

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -1,49 +1,31 @@
 import type { Dictionary } from "../../dictionary/schema.ts"
-import { scanLines } from "../scan.ts"
-import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
+import {
+  compileCaseFoldedPhrase,
+  type CaseFoldedPhrase,
+  scanCaseFoldedPhrases,
+} from "../phrase-matcher.ts"
 import type { Violation } from "../types.ts"
 
 interface PhrasalVerbPattern {
   readonly suggestion: string
-  readonly pattern: RegExp
+  readonly phrases: readonly CaseFoldedPhrase[]
 }
 
 const patternsByDictionary = new WeakMap<Dictionary, readonly PhrasalVerbPattern[]>()
 
-const normalizeWhitespace = (form: string): string => form.replace(/[\t ]+/gu, " ")
-
 const compilePatterns = (dictionary: Dictionary): readonly PhrasalVerbPattern[] => {
-  const canonicalForms: Array<{ readonly form: string; readonly pattern: RegExp }> = []
   const seenPairs = new Set<string>()
   return dictionary.entries.flatMap((entry) => {
     const suggestion = entry.suggestions[0]
-    const forms = entry.unapproved.filter((form) => {
-      const normalized = normalizeWhitespace(form)
-      const pattern = new RegExp(`^(?:${normalized})$`, "iu")
-      const equivalent = canonicalForms.find(
-        (candidate) => candidate.pattern.test(normalized) && pattern.test(candidate.form),
-      )
-      const canonical = equivalent?.form ?? normalized
-      if (equivalent === undefined) canonicalForms.push({ form: canonical, pattern })
+    const phrases = entry.unapproved.flatMap((form) => {
+      const phrase = compileCaseFoldedPhrase(form)
+      const pair = JSON.stringify([phrase.words, suggestion])
+      if (seenPairs.has(pair)) return []
 
-      const pair = JSON.stringify([canonical, suggestion])
-      if (seenPairs.has(pair)) return false
       seenPairs.add(pair)
-      return true
+      return [phrase]
     })
-    if (forms.length === 0) return []
-
-    return [
-      {
-        suggestion,
-        pattern: new RegExp(
-          `(?<!${TOKEN_CHARACTER_PATTERN})(?:${forms
-            .map((form) => form.replace(/[\t ]+/g, "\\s+"))
-            .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-          "giu",
-        ),
-      },
-    ]
+    return phrases.length === 0 ? [] : [{ suggestion, phrases }]
   })
 }
 
@@ -57,8 +39,8 @@ const patternsFor = (dictionary: Dictionary): readonly PhrasalVerbPattern[] => {
 }
 
 export function phrasalVerb(lines: readonly string[], dictionary: Dictionary): Violation[] {
-  return patternsFor(dictionary).flatMap(({ pattern, suggestion }) =>
-    scanLines(lines, pattern).map((match) => ({
+  return patternsFor(dictionary).flatMap(({ phrases, suggestion }) =>
+    scanCaseFoldedPhrases(lines, phrases).map((match) => ({
       ruleId: "phrasal-verb",
       severity: "hard" as const,
       message: `Do not use a phrasal verb. Use "${suggestion}", not "${match.found.toLowerCase()}".`,

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -10,12 +10,23 @@ interface PhrasalVerbPattern {
 
 const patternsByDictionary = new WeakMap<Dictionary, readonly PhrasalVerbPattern[]>()
 
+const normalizeWhitespace = (form: string): string => form.replace(/[\t ]+/gu, " ")
+
 const compilePatterns = (dictionary: Dictionary): readonly PhrasalVerbPattern[] => {
+  const canonicalForms: Array<{ readonly form: string; readonly pattern: RegExp }> = []
   const seenPairs = new Set<string>()
   return dictionary.entries.flatMap((entry) => {
     const suggestion = entry.suggestions[0]
     const forms = entry.unapproved.filter((form) => {
-      const pair = JSON.stringify([form, suggestion])
+      const normalized = normalizeWhitespace(form)
+      const pattern = new RegExp(`^(?:${normalized})$`, "iu")
+      const equivalent = canonicalForms.find(
+        (candidate) => candidate.pattern.test(normalized) && pattern.test(candidate.form),
+      )
+      const canonical = equivalent?.form ?? normalized
+      if (equivalent === undefined) canonicalForms.push({ form: canonical, pattern })
+
+      const pair = JSON.stringify([canonical, suggestion])
       if (seenPairs.has(pair)) return false
       seenPairs.add(pair)
       return true

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -10,7 +10,7 @@ const compilePatterns = (dictionary: Dictionary) =>
       `(?<!${TOKEN_CHARACTER_PATTERN})(?:${entry.unapproved
         .map((form) => form.replace(/[\t ]+/g, "\\s+"))
         .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-      "gi",
+      "giu",
     ),
   }))
 

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -1,7 +1,7 @@
 import type { Dictionary } from "../../dictionary/schema.ts"
 import {
-  compileCaseFoldedPhrase,
   type CaseFoldedPhrase,
+  compileCaseFoldedPhrase,
   scanCaseFoldedPhrases,
 } from "../phrase-matcher.ts"
 import type { Violation } from "../types.ts"

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -1,50 +1,21 @@
+import type { Dictionary } from "../../dictionary/schema.ts"
 import { scanLines } from "../scan.ts"
 import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
-interface PhrasalVerbEntry {
-  readonly forms: readonly string[]
-  readonly suggestion: string
-}
+const compilePatterns = (dictionary: Dictionary) =>
+  dictionary.entries.map((entry) => ({
+    suggestion: entry.suggestions[0],
+    pattern: new RegExp(
+      `(?<!${TOKEN_CHARACTER_PATTERN})(?:${entry.unapproved
+        .map((form) => form.replace(/[\t ]+/g, "\\s+"))
+        .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
+      "gi",
+    ),
+  }))
 
-// List and suggestions follow the pi-ste reference implementation, extended
-// with conjugated forms and "carry out" from the HUF-132 spec.
-const PHRASAL_VERBS: readonly PhrasalVerbEntry[] = [
-  { forms: ["carry out", "carries out", "carried out", "carrying out"], suggestion: "do" },
-  { forms: ["spin up", "spins up", "spun up", "spinning up"], suggestion: "start" },
-  { forms: ["spin down", "spins down", "spun down", "spinning down"], suggestion: "stop" },
-  {
-    forms: ["tear down", "tears down", "tore down", "torn down", "tearing down"],
-    suggestion: "remove",
-  },
-  { forms: ["reach out", "reaches out", "reached out", "reaching out"], suggestion: "ask" },
-  {
-    forms: ["dive into", "dives into", "dived into", "dove into", "diving into"],
-    suggestion: "examine",
-  },
-  { forms: ["kick off", "kicks off", "kicked off", "kicking off"], suggestion: "start" },
-  { forms: ["roll out", "rolls out", "rolled out", "rolling out"], suggestion: "release" },
-  { forms: ["ramp up", "ramps up", "ramped up", "ramping up"], suggestion: "increase" },
-  {
-    forms: ["circle back", "circles back", "circled back", "circling back"],
-    suggestion: "return",
-  },
-  {
-    forms: ["drill down", "drills down", "drilled down", "drilling down"],
-    suggestion: "examine",
-  },
-]
-
-const patterns = PHRASAL_VERBS.map((entry) => ({
-  suggestion: entry.suggestion,
-  pattern: new RegExp(
-    `(?<!${TOKEN_CHARACTER_PATTERN})(?:${entry.forms.map((form) => form.replace(/ /g, "\\s+")).join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-    "gi",
-  ),
-}))
-
-export function phrasalVerb(lines: readonly string[]): Violation[] {
-  return patterns.flatMap(({ pattern, suggestion }) =>
+export function phrasalVerb(lines: readonly string[], dictionary: Dictionary): Violation[] {
+  return compilePatterns(dictionary).flatMap(({ pattern, suggestion }) =>
     scanLines(lines, pattern).map((match) => ({
       ruleId: "phrasal-verb",
       severity: "hard" as const,

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -10,16 +10,31 @@ interface PhrasalVerbPattern {
 
 const patternsByDictionary = new WeakMap<Dictionary, readonly PhrasalVerbPattern[]>()
 
-const compilePatterns = (dictionary: Dictionary): readonly PhrasalVerbPattern[] =>
-  dictionary.entries.map((entry) => ({
-    suggestion: entry.suggestions[0],
-    pattern: new RegExp(
-      `(?<!${TOKEN_CHARACTER_PATTERN})(?:${entry.unapproved
-        .map((form) => form.replace(/[\t ]+/g, "\\s+"))
-        .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
-      "giu",
-    ),
-  }))
+const compilePatterns = (dictionary: Dictionary): readonly PhrasalVerbPattern[] => {
+  const seenPairs = new Set<string>()
+  return dictionary.entries.flatMap((entry) => {
+    const suggestion = entry.suggestions[0]
+    const forms = entry.unapproved.filter((form) => {
+      const pair = JSON.stringify([form, suggestion])
+      if (seenPairs.has(pair)) return false
+      seenPairs.add(pair)
+      return true
+    })
+    if (forms.length === 0) return []
+
+    return [
+      {
+        suggestion,
+        pattern: new RegExp(
+          `(?<!${TOKEN_CHARACTER_PATTERN})(?:${forms
+            .map((form) => form.replace(/[\t ]+/g, "\\s+"))
+            .join("|")})(?!${TOKEN_CHARACTER_PATTERN})`,
+          "giu",
+        ),
+      },
+    ]
+  })
+}
 
 const patternsFor = (dictionary: Dictionary): readonly PhrasalVerbPattern[] => {
   const cached = patternsByDictionary.get(dictionary)

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -3,7 +3,14 @@ import { scanLines } from "../scan.ts"
 import { TOKEN_CHARACTER_PATTERN } from "../tokens.ts"
 import type { Violation } from "../types.ts"
 
-const compilePatterns = (dictionary: Dictionary) =>
+interface PhrasalVerbPattern {
+  readonly suggestion: string
+  readonly pattern: RegExp
+}
+
+const patternsByDictionary = new WeakMap<Dictionary, readonly PhrasalVerbPattern[]>()
+
+const compilePatterns = (dictionary: Dictionary): readonly PhrasalVerbPattern[] =>
   dictionary.entries.map((entry) => ({
     suggestion: entry.suggestions[0],
     pattern: new RegExp(
@@ -14,8 +21,17 @@ const compilePatterns = (dictionary: Dictionary) =>
     ),
   }))
 
+const patternsFor = (dictionary: Dictionary): readonly PhrasalVerbPattern[] => {
+  const cached = patternsByDictionary.get(dictionary)
+  if (cached !== undefined) return cached
+
+  const compiled = compilePatterns(dictionary)
+  patternsByDictionary.set(dictionary, compiled)
+  return compiled
+}
+
 export function phrasalVerb(lines: readonly string[], dictionary: Dictionary): Violation[] {
-  return compilePatterns(dictionary).flatMap(({ pattern, suggestion }) =>
+  return patternsFor(dictionary).flatMap(({ pattern, suggestion }) =>
     scanLines(lines, pattern).map((match) => ({
       ruleId: "phrasal-verb",
       severity: "hard" as const,

--- a/src/engine/tokens.ts
+++ b/src/engine/tokens.ts
@@ -1,2 +1,2 @@
-export const TOKEN_CHARACTER_PATTERN = "[A-Za-z0-9_'’-]"
-export const TOKEN_RUN_PATTERN = new RegExp(`${TOKEN_CHARACTER_PATTERN}+`, "g")
+export const TOKEN_CHARACTER_PATTERN = String.raw`[\p{L}\p{N}_'’\u2010\u2011-]`
+export const TOKEN_RUN_PATTERN = new RegExp(`${TOKEN_CHARACTER_PATTERN}+`, "gu")

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,3 +1,4 @@
+import type { RuleData } from "../dictionary/rule-data.ts"
 import type { Dictionary } from "../dictionary/schema.ts"
 import type { RuleId } from "./rules/registry.ts"
 import type { Tagger } from "./tagger.ts"
@@ -24,11 +25,12 @@ export interface LintOptions {
   readonly rules?: Partial<Record<RuleId, RuleSetting>>
   readonly maxSentenceWords?: number
   readonly dictionary?: Dictionary
+  readonly ruleData?: RuleData
   // POS tagger for the verb-form rules and POS-aware dictionary entries.
   readonly tagger?: Tagger
   readonly sourceDialect?: SourceDialect
   /**
-   * The prior document text used to report only new violations.
+   * The previous document text used to report only new violations.
    * The engine compares sentence-scoped and paragraph-scoped violations structurally.
    * Omit this value to lint the current document in full.
    * Violation positions refer to the current text.

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -590,10 +590,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
         state.rejectedSayReplies.clear()
         if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
       }
-      ctx.ui.notify(
-        `Writing-rule enforcement ${state.enabled ? "enabled" : "disabled"}.`,
-        "info",
-      )
+      ctx.ui.notify(`Writing-rule enforcement ${state.enabled ? "enabled" : "disabled"}.`, "info")
     },
   })
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -29,10 +29,10 @@ import type { Tagger } from "../engine/tagger.ts"
 import type { LintReport, Violation } from "../engine/types.ts"
 import { makeWinkTagger } from "../tagger/wink.ts"
 
-const STE_COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
-  { value: "on", label: "on", description: "Enable STE enforcement" },
-  { value: "off", label: "off", description: "Disable STE enforcement" },
-  { value: "status", label: "status", description: "Show STE status" },
+const COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
+  { value: "on", label: "on", description: "Enable writing-rule enforcement" },
+  { value: "off", label: "off", description: "Disable writing-rule enforcement" },
+  { value: "status", label: "status", description: "Show writing-rule status" },
   { value: "strict", label: "strict", description: "Enable strict reply gating" },
 ]
 
@@ -54,7 +54,7 @@ interface SessionState {
 }
 
 const STRICT_MODE_NOTE = [
-  "## Simplified Technical English: strict mode",
+  "## Writing rules: strict mode",
   "",
   "Send every user-facing reply through the `say` tool.",
   "Write no prose outside that tool.",
@@ -77,7 +77,7 @@ function statusSummary(state: SessionState): string {
 }
 
 function formatReplyFeedback(violations: readonly Violation[]): string {
-  return `STE feedback for your previous reply:\n${violationDetails(violations)}`
+  return `Writing-rule feedback for your previous reply:\n${violationDetails(violations)}`
 }
 
 function lintReply(state: SessionState, text: string): LintReport {
@@ -101,7 +101,7 @@ type BoundaryGlobal = typeof globalThis & {
   __simpleEnglishStrictBoundaryV1?: BoundaryRegistry
 }
 
-const REDACTED_SAY_TEXT = "[redacted until STE approval]"
+const REDACTED_SAY_TEXT = "[redacted until writing-rule approval]"
 const boundaryGlobal = globalThis as BoundaryGlobal
 const boundaryRegistry = boundaryGlobal.__simpleEnglishStrictBoundaryV1 ?? {
   installed: false,
@@ -299,8 +299,8 @@ function showReplyReport(
 
   const status =
     report.summary.total === 0
-      ? "STE reply: clean"
-      : `STE reply: ${report.summary.hard} hard, ${softCount} soft`
+      ? "Writing-rule reply: clean"
+      : `Writing-rule reply: ${report.summary.hard} hard, ${softCount} soft`
   ctx.ui.setWidget("simple-english-reply", [status])
 }
 
@@ -339,7 +339,7 @@ function notifyWarnings(
   violations: readonly Violation[],
 ): void {
   if (violations.length === 0 || !ctx.hasUI) return
-  ctx.ui.notify(formatViolations(path, "STE warnings for", violations), "warning")
+  ctx.ui.notify(formatViolations(path, "Writing-rule warnings for", violations), "warning")
 }
 
 function lintProposedText(
@@ -365,13 +365,16 @@ function lintProposedText(
   notifyWarnings(ctx, path, soft)
   if (hard.length === 0) {
     if (soft.length > 0) {
-      state.pendingWarnings.set(toolCallId, formatViolations(path, "STE warnings for", soft))
+      state.pendingWarnings.set(
+        toolCallId,
+        formatViolations(path, "Writing-rule warnings for", soft),
+      )
     }
     return undefined
   }
   return {
     block: true,
-    reason: formatViolations(path, `STE blocked ${operation} for`, hard),
+    reason: formatViolations(path, `Writing rules blocked ${operation} for`, hard),
   }
 }
 
@@ -386,7 +389,7 @@ function lintCommitCommand(
   if (!state.ready) {
     return {
       block: true,
-      reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+      reason: `Writing-rule check is unavailable: ${state.error ?? "session setup is not complete"}`,
     }
   }
 
@@ -396,7 +399,7 @@ function lintCommitCommand(
       return {
         block: true,
         reason:
-          "STE could not check the git commit message. Use git commit with a static -m or --message argument.",
+          "Writing rules could not check the git commit message. Use git commit with a static -m or --message argument.",
       }
     }
 
@@ -412,11 +415,11 @@ function lintCommitCommand(
     if (hard.length > 0) {
       return {
         block: true,
-        reason: formatViolations("commit message", "STE blocked commit for", hard),
+        reason: formatViolations("commit message", "Writing rules blocked commit for", hard),
       }
     }
     if (soft.length > 0) {
-      warnings.push(formatViolations("commit message", "STE warnings for", soft))
+      warnings.push(formatViolations("commit message", "Writing-rule warnings for", soft))
     }
   }
 
@@ -445,7 +448,7 @@ function lintStrictReply(
   if (!state.ready) {
     return {
       block: true,
-      reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+      reason: `Writing-rule check is unavailable: ${state.error ?? "session setup is not complete"}`,
     }
   }
   const report = lintReply(state, text)
@@ -454,7 +457,7 @@ function lintStrictReply(
   if (hard.length === 0) return undefined
   return {
     block: true,
-    reason: formatViolations("reply", "STE blocked", hard),
+    reason: formatViolations("reply", "Writing rules blocked", hard),
   }
 }
 
@@ -469,7 +472,7 @@ function createGatedWriteTool(cwd: string, state: SessionState) {
           if (state.enabled) {
             if (!state.ready) {
               throw new Error(
-                `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+                `Writing-rule check is unavailable: ${state.error ?? "session setup is not complete"}`,
               )
             }
             const result = lintProposedText(state, ctx, "write", toolCallId, input.path, content)
@@ -503,7 +506,7 @@ function createGatedEditTool(cwd: string, state: SessionState) {
           if (state.enabled) {
             if (!state.ready) {
               throw new Error(
-                `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+                `Writing-rule check is unavailable: ${state.error ?? "session setup is not complete"}`,
               )
             }
             const result = lintProposedText(
@@ -544,9 +547,9 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
   }
 
   pi.registerCommand("ste", {
-    description: "Toggle STE enforcement or show status. Use strict to gate replies.",
+    description: "Toggle writing-rule enforcement or show status. Use strict to gate replies.",
     getArgumentCompletions: (prefix) => {
-      const completions = STE_COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(prefix))
+      const completions = COMMAND_COMPLETIONS.filter((item) => item.value.startsWith(prefix))
       return completions.length > 0 ? completions : null
     },
     handler: async (args, ctx) => {
@@ -559,13 +562,16 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
         state.enabled = true
         state.strict = true
         setSayActive(true)
-        ctx.ui.notify("STE strict mode enabled. Send every reply through the say tool.", "info")
+        ctx.ui.notify(
+          "Writing-rule strict mode enabled. Send every reply through the say tool.",
+          "info",
+        )
         return
       }
       if (command === "strict off") {
         state.strict = false
         setSayActive(false)
-        ctx.ui.notify("STE strict mode disabled.", "info")
+        ctx.ui.notify("Writing-rule strict mode disabled.", "info")
         return
       }
       if (command !== "" && command !== "on" && command !== "off") {
@@ -584,7 +590,10 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
         state.rejectedSayReplies.clear()
         if (ctx.hasUI) ctx.ui.setWidget("simple-english-reply", undefined)
       }
-      ctx.ui.notify(`STE enforcement ${state.enabled ? "enabled" : "disabled"}.`, "info")
+      ctx.ui.notify(
+        `Writing-rule enforcement ${state.enabled ? "enabled" : "disabled"}.`,
+        "info",
+      )
     },
   })
 
@@ -592,7 +601,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     name: "say",
     label: "Say",
     description:
-      "Send prose to the user. In STE strict mode, use this tool for every user-facing reply.",
+      "Send prose to the user. In writing-rule strict mode, use this tool for every user-facing reply.",
     parameters: Type.Object({
       text: Type.String({ description: "The complete user-facing reply" }),
     }),
@@ -601,7 +610,10 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
         const result = lintStrictReply(state, ctx, params.text)
         if (result?.block) {
           state.approvedSayReplies.delete(toolCallId)
-          state.rejectedSayReplies.set(toolCallId, result.reason ?? "STE blocked the reply.")
+          state.rejectedSayReplies.set(
+            toolCallId,
+            result.reason ?? "Writing rules blocked the reply.",
+          )
           throw new Error(result.reason)
         }
         state.approvedSayReplies.set(toolCallId, params.text)
@@ -739,13 +751,16 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
       if (savedArguments !== undefined) replaceRecord(event.input, structuredClone(savedArguments))
       const text = (event.input as { text?: unknown }).text
       if (typeof text !== "string") {
-        const reason = "STE could not check the reply: say requires text."
+        const reason = "Writing rules could not check the reply: say requires text."
         state.rejectedSayReplies.set(event.toolCallId, reason)
         return { block: true, reason }
       }
       const result = lintStrictReply(state, ctx, text)
       if (result?.block) {
-        state.rejectedSayReplies.set(event.toolCallId, result.reason ?? "STE blocked the reply.")
+        state.rejectedSayReplies.set(
+          event.toolCallId,
+          result.reason ?? "Writing rules blocked the reply.",
+        )
       }
       return result
     }
@@ -753,7 +768,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     if (state.ready) return undefined
     return {
       block: true,
-      reason: `STE check is unavailable: ${state.error ?? "session setup is not complete"}`,
+      reason: `Writing-rule check is unavailable: ${state.error ?? "session setup is not complete"}`,
     }
   })
 

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -20,7 +20,8 @@ import { formatViolations, violationDetails } from "../adapter/feedback.ts"
 import { formatStatusSummary, ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import type { SteConfig } from "../config/schema.ts"
-import { loadDictionary } from "../dictionary/load.ts"
+import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
+import type { RuleData } from "../dictionary/rule-data.ts"
 import type { Dictionary } from "../dictionary/schema.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
@@ -38,6 +39,7 @@ const STE_COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
 interface SessionState {
   config: SteConfig
   dictionary?: Dictionary
+  ruleData?: RuleData
   tagger?: Tagger
   enabled: boolean
   error?: string
@@ -82,6 +84,7 @@ function lintReply(state: SessionState, text: string): LintReport {
   return lint("prose-file", text, {
     ...state.config,
     dictionary: state.dictionary,
+    ruleData: state.ruleData,
     tagger: state.tagger,
   })
 }
@@ -352,6 +355,7 @@ function lintProposedText(
   const report = lint(classification.kind, text, {
     ...state.config,
     dictionary: state.dictionary,
+    ruleData: state.ruleData,
     tagger: state.tagger,
     sourceDialect: classification.sourceDialect,
     previousText,
@@ -399,6 +403,7 @@ function lintCommitCommand(
     const report = lint("commit-message", blankCommitMetadata(invocation.message), {
       ...state.config,
       dictionary: state.dictionary,
+      ruleData: state.ruleData,
       tagger: state.tagger,
     })
     const hard = report.violations.filter((violation) => violation.severity === "hard")
@@ -615,6 +620,7 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     setSayActive(state.enabled && state.strict)
     state.config = {}
     state.dictionary = undefined
+    state.ruleData = undefined
     state.tagger = undefined
     state.ready = false
     state.error = undefined
@@ -638,9 +644,14 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     }
 
     try {
-      state.dictionary = await Effect.runPromise(
-        loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+      const loadedData = await Effect.runPromise(
+        Effect.all({
+          dictionary: loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+          ruleData: loadRuleData(state.config.ruleDataExtensions, ctx.cwd),
+        }),
       )
+      state.dictionary = loadedData.dictionary
+      state.ruleData = loadedData.ruleData
     } catch (error) {
       state.dictionaryError = error instanceof Error ? error.message : String(error)
       state.error = state.dictionaryError

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -151,6 +151,16 @@ describe("simple-english CLI config", () => {
     ])
   })
 
+  test("reports extension failures as rule data", async () => {
+    const cwd = await makeProject({
+      ruleDataExtensions: { marketing: ["missing-marketing.json"] },
+    })
+    const result = await runCli([], { cwd, stdin: "A short sentence." })
+
+    expect(result.stderr).toContain("Cannot load rule data")
+    expect(result.stderr).not.toContain("Cannot load STE dictionary")
+  })
+
   test("--config points at an explicit file and ignores discovered configs", async () => {
     const cwd = await makeProject({ maxSentenceWords: 5 })
     const explicit = join(await makeTempDir(), "custom.json")

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -123,6 +123,34 @@ describe("simple-english CLI config", () => {
     expect(result.stdout.trim()).toBe("")
   })
 
+  test("project config extends rule data without replacing bundled entries", async () => {
+    const cwd = await makeProject({
+      ruleDataExtensions: { "phrasal-verb": ["custom-phrasal-verbs.json"] },
+    })
+    await writeJson(join(cwd, "custom-phrasal-verbs.json"), {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "custom-phrasal-verbs.json",
+      },
+      entries: [{ unapproved: ["follow through"], suggestions: ["continue"] }],
+    })
+
+    const result = await runCli(["--json"], {
+      cwd,
+      stdin: "Carry out the test. Follow through now.",
+    })
+
+    expect(result.code).toBe(1)
+    const report = JSON.parse(result.stdout)
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "phrasal-verb", suggestion: "do" }),
+      expect.objectContaining({ ruleId: "phrasal-verb", suggestion: "continue" }),
+    ])
+  })
+
   test("--config points at an explicit file and ignores discovered configs", async () => {
     const cwd = await makeProject({ maxSentenceWords: 5 })
     const explicit = join(await makeTempDir(), "custom.json")

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -211,7 +211,7 @@ describe("simple-english CLI hook mode", () => {
     )
     const disabledPrompt = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
 
-    expect(disabled).toMatchObject({ code: 0, stdout: "STE enforcement disabled.\n" })
+    expect(disabled).toMatchObject({ code: 0, stdout: "Writing-rule enforcement disabled.\n" })
     expect(decision(disabledWrite.output).permissionDecision).toBe("allow")
     expect(decision(parallelWrite.output).permissionDecision).toBe("deny")
     expect(disabledStart.output).toEqual({})
@@ -230,7 +230,7 @@ describe("simple-english CLI hook mode", () => {
     const enabled = await runSessionCommand("session-1", cwd, "on", xdgStateHome)
     const enabledWrite = await runReplyHook(violatingWrite("session-1"), cwd, xdgStateHome)
 
-    expect(enabled).toMatchObject({ code: 0, stdout: "STE enforcement enabled.\n" })
+    expect(enabled).toMatchObject({ code: 0, stdout: "Writing-rule enforcement enabled.\n" })
     expect(decision(enabledWrite.output).permissionDecision).toBe("deny")
     const enabledState = JSON.parse(
       await readFile(
@@ -376,7 +376,7 @@ describe("simple-english CLI hook mode", () => {
       xdgStateHome,
     )
 
-    expect(disabled).toMatchObject({ code: 0, stdout: "STE strict mode disabled.\n" })
+    expect(disabled).toMatchObject({ code: 0, stdout: "Writing-rule strict mode disabled.\n" })
     expect(stopped.output).toEqual({})
     expect(decision(submitted.output).additionalContext).toContain("[contraction]")
   })
@@ -688,7 +688,7 @@ describe("simple-english CLI hook mode", () => {
 
     expect(result.code).toBe(0)
     expect(result.output.continue).toBe(true)
-    expect(result.output.systemMessage).toContain("STE hook error")
+    expect(result.output.systemMessage).toContain("Writing-rule hook error")
     expect(await stateFiles(xdgStateHome)).toEqual([])
   })
 
@@ -1213,7 +1213,7 @@ describe("simple-english CLI hook mode", () => {
     expect(result.code).toBe(0)
     const output = decision(result.output)
     expect(output.permissionDecision).toBe("allow")
-    expect(output.additionalContext).toContain("STE warning")
+    expect(output.additionalContext).toContain("Writing-rule warning")
     expect(output.additionalContext).toContain("line 1, column 1 [hedging]")
     expect(output.additionalContext).toContain("Suggested fix:")
   })
@@ -1251,7 +1251,7 @@ describe("simple-english CLI hook mode", () => {
     expect(result.code).toBe(0)
     const output = decision(result.output)
     expect(output.permissionDecision).toBe("allow")
-    expect(output.additionalContext).toContain("STE hook warning")
+    expect(output.additionalContext).toContain("Writing-rule hook warning")
     expect(output.additionalContext).toContain(`invalid JSON in ${configPath}`)
     expect(result.output.continue).toBeUndefined()
   })
@@ -1270,7 +1270,7 @@ describe("simple-english CLI hook mode", () => {
     expect(result.code).toBe(0)
     const output = decision(result.output)
     expect(output.permissionDecision).toBe("allow")
-    expect(output.additionalContext).toContain("STE hook warning")
+    expect(output.additionalContext).toContain("Writing-rule hook warning")
     expect(output.additionalContext).toContain("forced tagger setup failure")
   })
 
@@ -1279,7 +1279,7 @@ describe("simple-english CLI hook mode", () => {
 
     expect(result.code).toBe(0)
     expect(result.output.continue).toBe(true)
-    expect(result.output.systemMessage).toContain("STE hook error")
+    expect(result.output.systemMessage).toContain("Writing-rule hook error")
     expect(result.output.hookSpecificOutput).toBeUndefined()
   })
 })

--- a/test/engine/hedging.test.ts
+++ b/test/engine/hedging.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import type { Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 
 const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
@@ -40,6 +41,25 @@ describe("lint prose-file: hedging rule", () => {
     "Do not use as mentioned’s wording.",
   ])("does not match within a token in %s", (text) => {
     expect(idsFor(text)).not.toContain("hedging")
+  })
+
+  test("returns no violations for an empty dictionary", () => {
+    const emptyDictionary = {
+      formatVersion: 1,
+      source: {
+        name: "empty test dictionary",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "hedging.json",
+      },
+      entries: [],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "Plain text.", {
+      ruleData: { hedging: emptyDictionary },
+    })
+
+    expect(report.violations).toEqual([])
   })
 
   test("does not flag plain prose that mentions notes", () => {

--- a/test/engine/hedging.test.ts
+++ b/test/engine/hedging.test.ts
@@ -28,6 +28,12 @@ describe("lint prose-file: hedging rule", () => {
     }
   })
 
+  test("flags a phrase separated by non-breaking spaces", () => {
+    expect(idsFor("It\u00a0is\u00a0important\u00a0to\u00a0note that the pump runs.")).toContain(
+      "hedging",
+    )
+  })
+
   test("soft hedging violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "It is worth noting that the pump runs.")
 

--- a/test/engine/hedging.test.ts
+++ b/test/engine/hedging.test.ts
@@ -43,6 +43,27 @@ describe("lint prose-file: hedging rule", () => {
     expect(idsFor(text)).not.toContain("hedging")
   })
 
+  test("case-folds Unicode extension forms without changing source offsets", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "hedging.json",
+      },
+      entries: [{ unapproved: ["große sache"], suggestions: ["delete"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "İ GROSSE SACHE.", {
+      ruleData: { hedging: extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "hedging", line: 1, column: 3 }),
+    ])
+  })
+
   test("returns no violations for an empty dictionary", () => {
     const emptyDictionary = {
       formatVersion: 1,

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -108,6 +108,32 @@ describe("lint prose-file: marketing rule", () => {
     ])
   })
 
+  test("matches Unicode case variants with different lowercase forms", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "marketing.json",
+      },
+      entries: [{ unapproved: ["σ"], suggestions: ["plain"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "A ς platform.", {
+      ruleData: { marketing: extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        ruleId: "marketing",
+        line: 1,
+        column: 3,
+        message: expect.stringContaining("ς"),
+      }),
+    ])
+  })
+
   test("preserves source columns when Unicode lowercase expands", () => {
     const extension = {
       formatVersion: 1,

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -134,6 +134,25 @@ describe("lint prose-file: marketing rule", () => {
     ])
   })
 
+  test("does not apply Turkic case equivalence", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "marketing.json",
+      },
+      entries: [{ unapproved: ["kisa"], suggestions: ["plain"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "A kısa platform.", {
+      ruleData: { marketing: extension },
+    })
+
+    expect(report.violations).toEqual([])
+  })
+
   test("preserves source columns when Unicode lowercase expands", () => {
     const extension = {
       formatVersion: 1,

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -82,6 +82,53 @@ describe("lint prose-file: marketing rule", () => {
     ])
   })
 
+  test("matches multi-word forms from an extension dictionary", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "marketing.json",
+      },
+      entries: [{ unapproved: ["best in class"], suggestions: ["excellent"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "A best in class platform.", {
+      ruleData: { marketing: extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        ruleId: "marketing",
+        line: 1,
+        column: 3,
+        message: expect.stringContaining("best in class"),
+      }),
+    ])
+  })
+
+  test("preserves source columns when Unicode lowercase expands", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "marketing.json",
+      },
+      entries: [{ unapproved: ["robust"], suggestions: ["delete"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "An İ-robust platform.", {
+      ruleData: { marketing: extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "marketing", line: 1, column: 6 }),
+    ])
+  })
+
   test("soft marketing violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "A robust and powerful tool.")
 

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import type { Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 
 const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
@@ -59,6 +60,27 @@ describe("lint prose-file: marketing rule", () => {
       expect(idsFor(text)).not.toContain("marketing")
     },
   )
+
+  test("matches Unicode words from an extension dictionary", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "marketing.json",
+      },
+      entries: [{ unapproved: ["über"], suggestions: ["excellent"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "An über platform.", {
+      ruleData: { marketing: extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "marketing", line: 1, column: 4 }),
+    ])
+  })
 
   test("soft marketing violations do not count as hard in the summary", () => {
     const report = lint("prose-file", "A robust and powerful tool.")

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -71,6 +71,45 @@ describe("lint prose-file: phrasal-verb rule", () => {
     ])
   })
 
+  test("accepts every ECMAScript same-line whitespace separator", () => {
+    const separators = [
+      "\t",
+      "\v",
+      "\f",
+      " ",
+      "\u00a0",
+      "\u1680",
+      "\u2000",
+      "\u2001",
+      "\u2002",
+      "\u2003",
+      "\u2004",
+      "\u2005",
+      "\u2006",
+      "\u2007",
+      "\u2008",
+      "\u2009",
+      "\u200a",
+      "\u202f",
+      "\u205f",
+      "\u3000",
+      "\ufeff",
+    ]
+
+    for (const separator of separators) {
+      expect(idsFor(`Carry${separator}out the test.`), separator.codePointAt(0)?.toString(16)).toContain(
+        "phrasal-verb",
+      )
+    }
+  })
+
+  test.each(["\n", "\r", "\u2028", "\u2029"])(
+    "does not match across line terminator U+%s",
+    (separator) => {
+      expect(idsFor(`Carry${separator}out the test.`)).not.toContain("phrasal-verb")
+    },
+  )
+
   test("case-folds Unicode extension forms without changing source offsets", () => {
     const extension = {
       formatVersion: 1,

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -97,9 +97,10 @@ describe("lint prose-file: phrasal-verb rule", () => {
     ]
 
     for (const separator of separators) {
-      expect(idsFor(`Carry${separator}out the test.`), separator.codePointAt(0)?.toString(16)).toContain(
-        "phrasal-verb",
-      )
+      expect(
+        idsFor(`Carry${separator}out the test.`),
+        separator.codePointAt(0)?.toString(16),
+      ).toContain("phrasal-verb")
     }
   })
 

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import type { Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 
 const idsFor = (text: string) => lint("prose-file", text).violations.map((v) => v.ruleId)
@@ -44,6 +45,30 @@ describe("lint prose-file: phrasal-verb rule", () => {
       const violation = report.violations.find((v) => v.ruleId === "phrasal-verb")
       expect(violation?.suggestion, text).toBe(suggestion)
     }
+  })
+
+  test("deduplicates repeated extension entries", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "phrasal-verbs.json",
+      },
+      entries: [
+        { unapproved: ["carry out"], suggestions: ["do"] },
+        { unapproved: ["carry out"], suggestions: ["do"] },
+      ],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "Carry out the test.", {
+      ruleData: { "phrasal-verb": extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "phrasal-verb", suggestion: "do" }),
+    ])
   })
 
   test("reports the column where the phrasal verb starts", () => {

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -47,7 +47,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
     }
   })
 
-  test("deduplicates repeated extension entries", () => {
+  test("deduplicates case and whitespace variants of extension entries", () => {
     const extension = {
       formatVersion: 1,
       source: {
@@ -57,12 +57,12 @@ describe("lint prose-file: phrasal-verb rule", () => {
         path: "phrasal-verbs.json",
       },
       entries: [
-        { unapproved: ["carry out"], suggestions: ["do"] },
+        { unapproved: ["Carry\tout"], suggestions: ["do"] },
         { unapproved: ["carry out"], suggestions: ["do"] },
       ],
     } as const satisfies Dictionary
 
-    const report = lint("prose-file", "Carry out the test.", {
+    const report = lint("prose-file", "CARRY   OUT the test.", {
       ruleData: { "phrasal-verb": extension },
     })
 

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -71,6 +71,32 @@ describe("lint prose-file: phrasal-verb rule", () => {
     ])
   })
 
+  test("case-folds Unicode extension forms without changing source offsets", () => {
+    const extension = {
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "phrasal-verbs.json",
+      },
+      entries: [{ unapproved: ["straße aus"], suggestions: ["leave"] }],
+    } as const satisfies Dictionary
+
+    const report = lint("prose-file", "İ STRASSE AUS now.", {
+      ruleData: { "phrasal-verb": extension },
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({
+        ruleId: "phrasal-verb",
+        line: 1,
+        column: 3,
+        suggestion: "leave",
+      }),
+    ])
+  })
+
   test("reports the column where the phrasal verb starts", () => {
     const report = lint("prose-file", "Please spin up the worker.")
 

--- a/test/extension/claude-plugin.test.ts
+++ b/test/extension/claude-plugin.test.ts
@@ -59,7 +59,9 @@ describe("Claude Code plugin wiring", () => {
   test("defines the session STE command", async () => {
     const command = await readFile(steCommandPath, "utf8")
 
-    expect(command).toContain("description: Control STE for this Claude Code session")
+    expect(command).toContain(
+      "description: Control writing-rule enforcement for this Claude Code session",
+    )
     expect(command).toContain("argument-hint: on|off|status|strict|strict off")
     expect(command).toContain("${CLAUDE_PLUGIN_ROOT}")
     expect(command).toContain("${CLAUDE_SESSION_ID}")

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -403,7 +403,10 @@ describe.sequential("pi extension wiring", () => {
       context,
     )
 
-    const systemPrompt = result?.systemPrompt ?? ""
+    const systemPrompt =
+      typeof result === "object" && result !== null && "systemPrompt" in result
+        ? String(result.systemPrompt)
+        : ""
     expect(systemPrompt).toContain("Rules derived from ASD-STE100 Simplified Technical English")
     expect(systemPrompt).toContain("[hard] Do not use semicolons")
     expect(systemPrompt).toContain("Keep each sentence to 8 words or fewer")

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -384,7 +384,7 @@ describe.sequential("pi extension wiring", () => {
     expect(manifest.devDependencies).toMatchObject({ typebox: "1.3.7" })
   })
 
-  test("injects an STE rule summary that reflects merged active settings", async () => {
+  test("injects a grouped rule summary that reflects merged active settings", async () => {
     const { pi, context } = await startExtension({
       globalConfig: {
         maxSentenceWords: 30,
@@ -402,21 +402,25 @@ describe.sequential("pi extension wiring", () => {
       context,
     )
 
-    expect(result).toMatchObject({
-      systemPrompt: expect.stringContaining("Simplified Technical English"),
-    })
-    expect(result).toMatchObject({
-      systemPrompt: expect.stringContaining("[hard] Do not use semicolons"),
-    })
-    expect(result).toMatchObject({
-      systemPrompt: expect.stringContaining("Keep each sentence to 8 words or fewer"),
-    })
-    expect(result).toMatchObject({
-      systemPrompt: expect.not.stringContaining("Do not use contractions"),
-    })
-    expect(result).toMatchObject({
-      systemPrompt: expect.stringContaining("git commit messages reject hard violations"),
-    })
+    const systemPrompt = result?.systemPrompt ?? ""
+    expect(systemPrompt).toContain("Rules derived from ASD-STE100 Simplified Technical English")
+    expect(systemPrompt).toContain("[hard] Do not use semicolons")
+    expect(systemPrompt).toContain("Keep each sentence to 8 words or fewer")
+    expect(systemPrompt).not.toContain("Do not use contractions")
+    expect(systemPrompt).toContain("git commit messages reject hard violations")
+
+    const steStart = systemPrompt.indexOf("### Rules derived from ASD-STE100")
+    const houseStart = systemPrompt.indexOf("### House-style rules")
+    expect(steStart).toBeGreaterThan(-1)
+    expect(houseStart).toBeGreaterThan(steStart)
+
+    const steRules = systemPrompt.slice(steStart, houseStart)
+    const houseRules = systemPrompt.slice(houseStart)
+    expect(steRules).not.toContain("Remove hedging phrases")
+    expect(steRules).not.toContain("marketing language")
+    expect(houseRules).toContain("Remove hedging phrases")
+    expect(houseRules).toContain("marketing language")
+    expect(houseRules).not.toContain("ASD-STE100")
   })
 
   test("blocks a hard commit message with structured feedback", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -373,6 +373,7 @@ describe.sequential("pi extension wiring", () => {
     expect(manifest.bin).toEqual({ "simple-english": "src/cli/main.ts" })
     expect(manifest.dependencies).toMatchObject({
       effect: expect.any(String),
+      "unicode-case-folding": expect.any(String),
       "wink-eng-lite-web-model": expect.any(String),
       "wink-nlp": expect.any(String),
     })
@@ -522,17 +523,17 @@ describe.sequential("pi extension wiring", () => {
     expect(error?.message).toContain("[contraction]")
   })
 
-  test("suggests STE command arguments and filters them by prefix", async () => {
+  test("suggests writing-rule command arguments and filters them by prefix", async () => {
     const { pi } = await startExtension()
 
     expect(pi.getArgumentCompletions("ste", "")).toEqual([
-      { value: "on", label: "on", description: "Enable STE enforcement" },
-      { value: "off", label: "off", description: "Disable STE enforcement" },
-      { value: "status", label: "status", description: "Show STE status" },
+      { value: "on", label: "on", description: "Enable writing-rule enforcement" },
+      { value: "off", label: "off", description: "Disable writing-rule enforcement" },
+      { value: "status", label: "status", description: "Show writing-rule status" },
       { value: "strict", label: "strict", description: "Enable strict reply gating" },
     ])
     expect(pi.getArgumentCompletions("ste", "s")).toEqual([
-      { value: "status", label: "status", description: "Show STE status" },
+      { value: "status", label: "status", description: "Show writing-rule status" },
       { value: "strict", label: "strict", description: "Enable strict reply gating" },
     ])
     expect(pi.getArgumentCompletions("ste", "missing")).toBeNull()
@@ -627,7 +628,7 @@ describe.sequential("pi extension wiring", () => {
       )?.message,
     ).toContain("[contraction]")
     await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: 1 hard, 0 soft"])
   })
 
   test("reports the mode, rule severity counts, and dictionary state", async () => {
@@ -809,10 +810,15 @@ describe.sequential("pi extension wiring", () => {
 
     expect(update.assistantMessageEvent.delta).toBe("")
     expect(message.content[0]?.arguments).toEqual({
-      text: "[redacted until STE approval]",
+      text: "[redacted until writing-rule approval]",
     })
     await expect(
-      pi.executeTool("say", "say-redacted", { text: "[redacted until STE approval]" }, context),
+      pi.executeTool(
+        "say",
+        "say-redacted",
+        { text: "[redacted until writing-rule approval]" },
+        context,
+      ),
     ).resolves.toMatchObject({ content: [{ type: "text", text: "Open the valve." }] })
   })
 
@@ -946,7 +952,7 @@ describe.sequential("pi extension wiring", () => {
 
     const reply = assistantMessage("This isn't permitted.")
     await expect(pi.finalizeAssistant(reply, context)).resolves.toBe(reply)
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: 1 hard, 0 soft"])
   })
 
   test("blocks a hard write with location, rule, and fix feedback, then permits a clean write", async () => {
@@ -1191,7 +1197,7 @@ describe.sequential("pi extension wiring", () => {
     expect(toolResult).toMatchObject({
       content: [
         { type: "text", text: "Wrote notes.md" },
-        { type: "text", text: expect.stringContaining("STE warnings for notes.md") },
+        { type: "text", text: expect.stringContaining("Writing-rule warnings for notes.md") },
       ],
     })
   })
@@ -1207,7 +1213,7 @@ describe.sequential("pi extension wiring", () => {
     const finalized = await pi.finalizeAssistant(reply, context)
 
     expect(finalized).toBe(reply)
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 1 soft"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: 1 hard, 1 soft"])
 
     const result = await pi.emit(
       "context",
@@ -1240,7 +1246,7 @@ describe.sequential("pi extension wiring", () => {
       sessionStartReason: "resume",
     })
 
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 1 hard, 0 soft"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: 1 hard, 0 soft"])
     const result = await pi.emit("context", { messages: [reply] }, context)
     expect(result).toMatchObject({
       messages: expect.arrayContaining([
@@ -1262,7 +1268,7 @@ describe.sequential("pi extension wiring", () => {
       sessionStartReason: "resume",
     })
 
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
@@ -1298,7 +1304,7 @@ describe.sequential("pi extension wiring", () => {
       context,
     )
 
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
@@ -1311,7 +1317,7 @@ describe.sequential("pi extension wiring", () => {
     const finalized = await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
 
     expect(finalized.content).toEqual([{ type: "text", text: "Open the valve." }])
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
@@ -1325,7 +1331,7 @@ describe.sequential("pi extension wiring", () => {
       context,
     )
 
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: 0 hard, 1 soft"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: 0 hard, 1 soft"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
@@ -1336,7 +1342,7 @@ describe.sequential("pi extension wiring", () => {
 
     await pi.finalizeAssistant(assistantMessage("Open the valve."), context)
 
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 
@@ -1348,7 +1354,7 @@ describe.sequential("pi extension wiring", () => {
 
     await pi.finalizeAssistant(assistantMessage(reply), context)
 
-    expect(widgets.get("simple-english-reply")).toEqual(["STE reply: clean"])
+    expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: clean"])
     await expect(pi.emit("context", { messages: [] }, context)).resolves.toBeUndefined()
   })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noUncheckedIndexedAccess": true,
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "verbatimModuleSyntax": true
   },


### PR DESCRIPTION
## Intent

Implement Linear HUF-155 and HUF-156 for simple-english in one change. Move the phrasal-verb, hedging, and marketing vocabularies from TypeScript rule modules into data files that use the documented package dictionary format. Load all three through the same loader path as the dictionary data. Keep rule behavior and findings identical, with the existing tests green. Give users a no-fork extension path for each list through data or config, and add one test that proves an extension works. Ensure no rule vocabulary remains hardcoded in rule modules. Replace the inline README marketing enumeration with a pointer to its data file, without generation. Split every README rule document into two labeled groups: rules derived from ASD-STE100 and house-style rules. Put hedging and marketing only in the house-style group. Keep both enabled, and use no wording that implies they come from ASD-STE100. Keep all existing tests, the new extension test, Biome, and TypeScript clean.

## What Changed

- Move phrasal-verb, hedging, and marketing vocabularies into validated dictionary-format data files with Unicode-aware matching.
- Add `ruleDataExtensions` configuration and load custom rule data across the CLI, Claude Code Hook, and pi Adapter.
- Separate ASD-STE100-derived and house-style rules in documentation and user-facing enforcement wording.

## Risk Assessment

✅ Low: The change is well-bounded, validates rule data consistently, preserves documented matching behavior, and has no remaining material source-verifiable defects.

## Testing

No separate baseline command was supplied; targeted engine, config, and adapter tests passed, manual source and documentation checks matched the intent, and an end-to-end CLI run loaded bundled plus custom entries for all three lists, emitted the six expected findings, and exited 1 for the two hard findings.

<details>
<summary>Evidence: End-to-end CLI rule-data extension report</summary>

```text
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "phrasal-verb",
      "severity": "hard",
      "message": "Do not use a phrasal verb. Use \"do\", not \"carry out\".",
      "line": 1,
      "column": 1,
      "suggestion": "do"
    },
    {
      "file": "<stdin>",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 1,
      "column": 15
    },
    {
      "file": "<stdin>",
      "ruleId": "phrasal-verb",
      "severity": "hard",
      "message": "Do not use a phrasal verb. Use \"continue\", not \"follow through\".",
      "line": 1,
      "column": 30,
      "suggestion": "continue"
    },
    {
      "file": "<stdin>",
      "ruleId": "hedging",
      "severity": "soft",
      "message": "Do not hedge. Delete \"it is important to note\".",
      "line": 1,
      "column": 50
    },
    {
      "file": "<stdin>",
      "ruleId": "hedging",
      "severity": "soft",
      "message": "Do not hedge. Delete \"for what it is worth\".",
      "line": 1,
      "column": 94
    },
    {
      "file": "<stdin>",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"crystal clear\".",
      "line": 1,
      "column": 122
    }
  ],
  "summary": {
    "total": 6,
    "hard": 2
  }
}
```
</details>
<details>
<summary>Evidence: CLI configuration referencing all three extension lists</summary>

```text
{
  "ruleDataExtensions": {
    "phrasal-verb": ["phrasal-extension.json"],
    "hedging": ["hedging-extension.json"],
    "marketing": ["marketing-extension.json"]
  },
  "rules": {
    "contraction": "off",
    "dictionary-not-approved-word": "off",
    "paragraph-length": "off",
    "semicolon": "off",
    "sentence-length": "off",
    "verb-progressive": "off",
    "verb-passive": "off",
    "verb-perfect": "off"
  }
}
```
</details>
<details>
<summary>Evidence: Phrasal-verb extension data</summary>

```text
{
  "formatVersion": 1,
  "source": {
    "name": "test phrasal extension",
    "repository": "https://example.test/rule-data",
    "commit": "fixture",
    "path": "phrasal-extension.json"
  },
  "entries": [
    { "unapproved": ["follow through"], "suggestions": ["continue"] }
  ]
}
```
</details>
<details>
<summary>Evidence: Hedging extension data</summary>

```text
{
  "formatVersion": 1,
  "source": {
    "name": "test hedging extension",
    "repository": "https://example.test/rule-data",
    "commit": "fixture",
    "path": "hedging-extension.json"
  },
  "entries": [
    { "unapproved": ["for what it is worth"], "suggestions": ["delete"] }
  ]
}
```
</details>
<details>
<summary>Evidence: Marketing extension data</summary>

```text
{
  "formatVersion": 1,
  "source": {
    "name": "test marketing extension",
    "repository": "https://example.test/rule-data",
    "commit": "fixture",
    "path": "marketing-extension.json"
  },
  "entries": [
    { "unapproved": ["crystal clear"], "suggestions": ["delete"] }
  ]
}
```
</details>
<details>
<summary>Evidence: CLI exit code</summary>

`1`

```text
1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (7) ✅</summary>

- 🚨 `src/engine/lint.ts:310` - Intent requires &#34;Load all three through the same loader path as the dictionary data,&#34; but `options.ruleData ?? BUNDLED_RULE_DATA` falls back to JSON imports cast directly to `Dictionary` without schema validation. If bundled data is schema-invalid, `loadRuleData` rejects it, the CLI passes `undefined`, and this fallback sends the rejected data into the engine. Route bundled defaults through the shared validation boundary or confirm that this trusted static fallback is authorized.
- 🚨 `src/engine/rules/marketing.ts:33` - Valid package dictionary forms can contain Unicode letters, but marketing still scans with the ASCII-only `TOKEN_RUN_PATTERN`. For example, a configured extension containing `&#34;über&#34;` loads successfully but never matches the token `über`, so the promised marketing extension path silently ignores supported data. Use Unicode-aware tokenization or explicitly validate a narrower rule-data format.
- ⚠️ `src/engine/rules/hedging.ts:7` - The dictionary schema permits an empty `entries` array, but compiling it produces the empty alternative `(?:)`, which reports empty hedging matches throughout the input. Return no violations when there are no unapproved forms.

🔧 Fix: Validate defaults and handle Unicode rule data
4 issues (2 errors, 2 warnings) still open:
- 🚨 `src/engine/rules/marketing.ts:33` - The required no-fork marketing extension path does not support all forms accepted by the documented package dictionary format. A valid extension form such as &#34;best in class&#34; loads successfully, but token-by-token scanning can never match it. Match complete validated forms while preserving the existing hyphen-component behavior.
- 🚨 `src/adapter/rule-summary.ts:78` - The requirement says to &#34;use no wording that implies&#34; hedging and marketing come from ASD-STE100, but the generated prompt places both enabled house-style rules beneath &#34;Simplified Technical English&#34; and &#34;Follow these STE rules&#34;. README.md:12 similarly calls all active rules STE rules. Split or neutralize these labels.
- ⚠️ `src/engine/rules/marketing.ts:24` - Offsets are calculated from the lowercased token, whose UTF-16 length can differ from the source. For example, &#34;İ-robust&#34; lowercases to &#34;i̇-robust&#34;, so the robust finding is reported one column late. Split the original token and lowercase only for lookup so source offsets remain unchanged.
- ⚠️ `src/engine/rules/phrasal-verb.ts:18` - The formerly module-level regexes and marketing set are now rebuilt for every extracted prose run. Source files with many separate comment runs and large extensions repeatedly compile every matcher, and edit checks repeat this for previous and current text. Cache compiled matchers by dictionary identity or prepare them once per evaluation.

🔧 Fix: Fix matching, caching, and house-style labels
2 errors still open:
- 🚨 `src/dictionary/load.ts:85` - Intent requires &#34;no wording that implies&#34; hedging or marketing come from ASD-STE100, but both new branches use `loadDictionary`, whose failure text is `Cannot load STE dictionary`. A missing or invalid marketing or hedging extension is therefore explicitly labeled an STE dictionary in CLI and Adapter output. Use neutral rule-data or dictionary-data wording.
- 🚨 `src/engine/rules/marketing.ts:31` - The package format accepts Unicode letters and promises case-insensitive matching, but `toLowerCase()` is not Unicode case folding. For example, valid form `σ` and source token `ς` have different lowercase keys although both case-fold to `σ`, so the marketing extension silently misses the finding. Use a consistent Unicode case-fold key while retaining original text for offsets.

🔧 Fix: Fix rule-data errors and Unicode marketing matching
3 issues (2 errors, 1 warning) still open:
- 🚨 `src/extension/index.ts:342` - The required &#34;no wording that implies&#34; house rules come from ASD-STE100 remains violated in enforcement output. A default marketing finding is labeled &#34;STE warnings for&#34;, while a configured hard marketing or hedging finding is labeled &#34;STE blocked&#34;. Hook mode has the same path at src/cli/hook.ts:562-564. Use neutral writing-rule terminology across user-facing enforcement output.
- 🚨 `src/engine/rules/marketing.ts:28` - `toLowerCase().toUpperCase().toLowerCase()` is not Unicode default case folding. It maps dotless `ı` through uppercase `I` to ASCII `i`, although Unicode default folding leaves U+0131 unchanged. Consequently, valid form `kisa` falsely matches source `kısa`. Use an actual Unicode fold mapping, or confirm that locale-specific Turkic equivalence is intended.
- ⚠️ `src/engine/rules/phrasal-verb.ts:13` - The loader appends extension entries without deduplication, and `compilePatterns` scans each entry independently. A valid extension that repeats bundled form `carry out` with the same suggestion therefore emits two identical hard findings for one span. Deduplicate identical form-suggestion pairs during compilation.

🔧 Fix: Fix rule matching and neutralize enforcement terminology
2 issues (1 error, 1 warning) still open:
- 🚨 `commands/ste.md:2` - Intent requires &#34;Keep all existing tests ... green,&#34; but this line changed to &#34;Control writing-rule enforcement&#34; while test/extension/claude-plugin.test.ts:62 still requires &#34;Control STE&#34;. Update the assertion to the required neutral wording.
- ⚠️ `src/engine/rules/phrasal-verb.ts:18` - Deduplication uses the literal form even though matching is case-insensitive and normalizes horizontal whitespace. An extension entry such as &#34;Carry out&#34; with suggestion &#34;do&#34; remains distinct from bundled &#34;carry out&#34;, so both patterns emit the same finding. Canonicalize the deduplication key according to the matcher semantics.

🔧 Fix: Fix phrasal deduplication and command assertion
1 error still open:
- 🚨 `src/engine/rules/phrasal-verb.ts:43` - The required no-fork extension path does not honor the documented case-independent matching for all schema-valid Unicode forms. ECMAScript `/iu` uses simple case folding, so an extension form such as `straße aus` does not match `STRASSE AUS`, contrary to README.md:348. Hedging has the same matcher at src/engine/rules/hedging.ts:21. Match case-folded keys while retaining original source spans, as marketing does.

🔧 Fix: Apply Unicode case folding to phrase rules
1 error still open:
- 🚨 `src/engine/phrase-matcher.ts:29` - Intent requires &#34;Keep rule behavior and findings identical,&#34; but this matcher accepts only tabs and ASCII spaces. The previous phrasal-verb and hedging regexes used `\s+`, so inputs such as `carry out` or `it is important to note` with a non-breaking space previously produced findings and now do not. Preserve the previous same-line whitespace semantics at this shared matcher boundary.

🔧 Fix: Preserve phrase matching across same-line Unicode whitespace
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bun run test -- test/engine/phrasal-verb.test.ts test/engine/hedging.test.ts test/engine/marketing.test.ts test/cli/config.test.ts`
- `bunx vitest run test/config/schema.test.ts test/config/merge.test.ts test/extension/extension.test.ts -t 'config schema|config merge|injects a grouped rule summary'`
- <code>End-to-end CLI run from the evidence directory using `bun &lt;worktree&gt;/src/cli/main.ts --config config.json --json` with bundled and custom phrasal-verb, hedging, and marketing terms</code>
- <code>Manual `rg` checks confirmed moved vocabulary literals are absent from `src/engine/rules` and README places hedging and marketing under House-style rules with marketing linked to its data file</code>
- <code>`git status --short` confirmed testing left no worktree artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
