### PR TITLE
feat(dictionary): add approved-word allowlist mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,6 @@ The global fallback is `simple-english.json` in the pi agent config directory.
 The default pi agent config directory is `~/.pi/agent`.
 `PI_CODING_AGENT_DIR` can change that directory.
 
-The loader resolves a relative value from the working directory that requested the config.
 The loader reads a fallback file only when the new file at the same level is absent.
 
 This example contains every config key and every rule:
@@ -304,7 +303,11 @@ The `off` value disables that rule.
 
 `maxSentenceWords` must be a positive integer and has a default value of 25.
 `approvedWordsPath` selects a user-owned approved-word list.
-The loader resolves a relative path from the working directory.
+The loader resolves a relative path from the working directory that requested the config.
+This list replaces the bundled not-approved sample and any `SIMPLE_ENGLISH_DICTIONARY` replacement.
+A missing, unreadable, or invalid list causes lint exit code 2.
+The enabled pi Adapter gates fail closed after this error.
+Claude Code Hook mode reports a warning and allows the event, as it does for other load errors.
 Unknown keys, unknown rule IDs, and invalid values cause a config error.
 
 `ruleDataExtensions` maps each list-backed rule to more JSON data files.
@@ -327,12 +330,11 @@ It also reports unambiguous forms that end in `'s`.
 #### `dictionary-not-approved-word`
 
 Default: hard.
-Without `approvedWordsPath`, this rule reports forms from the bundled not-approved sample and supplies approved alternatives.
+Without an approved-word list, this rule reports forms from the bundled not-approved sample and supplies approved alternatives.
 Part-of-speech data limits applicable sample entries when that data exists.
-With `approvedWordsPath`, this rule reports each token that the approved-word list does not contain.
-The list must contain each permitted word form.
-Checks do not depend on letter case.
-The configured approved-word list replaces the bundled sample and any `SIMPLE_ENGLISH_DICTIONARY` replacement.
+With an approved-word list, this rule reports each prose token that the list does not contain.
+Matching uses exact surface forms without regard to case.
+See [Configuration](#configuration) for list selection, precedence, and load errors.
 
 #### `paragraph-length`
 
@@ -410,18 +412,13 @@ This project has no affiliation with or endorsement from ASD.
 The package dictionary format and token rules are in [`src/dictionary/README.md`](src/dictionary/README.md).
 
 To create an approved-word list, use your own licensed copy of the current ASD-STE100 specification.
-Extract the approved words and every permitted form that you want the rule to accept.
-Store only one word form in each `approvedWords` item.
+Extract the approved words into the [package approved-word list format](src/dictionary/README.md#approved-word-list).
+Follow that format's exact surface-form requirements.
 Add source metadata that identifies your licensed revision and extraction record.
+Repeat the extraction and update the metadata when you adopt a new licensed revision.
 Keep the list private unless your license lets you distribute it.
 This package does not extract, include, or distribute that data.
-
-Set `approvedWordsPath` in the config to select the list.
-A relative path starts at the working directory that requested the config.
-This option has precedence over the bundled sample and `SIMPLE_ENGLISH_DICTIONARY`.
-A missing, unreadable, or invalid list causes lint exit code 2.
-The enabled pi Adapter gates fail closed after this error.
-Claude Code Hook mode reports a warning and allows the event, as it does for other load errors.
+See [Configuration](#configuration) to select the list.
 
 Set `SIMPLE_ENGLISH_DICTIONARY` to replace only the bundled not-approved sample.
 Hook mode resolves a relative replacement path from the session working directory.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ This example contains every config key and every rule:
 ```json
 {
   "maxSentenceWords": 25,
+  "approvedWordsPath": "./approved-words.json",
   "ruleDataExtensions": {
     "phrasal-verb": ["config/phrasal-verbs.json"],
     "hedging": ["config/hedging.json"],
@@ -302,6 +303,8 @@ A soft violation produces a report or warning but does not block the action.
 The `off` value disables that rule.
 
 `maxSentenceWords` must be a positive integer and has a default value of 25.
+`approvedWordsPath` selects a user-owned approved-word list.
+The loader resolves a relative path from the working directory.
 Unknown keys, unknown rule IDs, and invalid values cause a config error.
 
 `ruleDataExtensions` maps each list-backed rule to more JSON data files.
@@ -324,9 +327,12 @@ It also reports unambiguous forms that end in `'s`.
 #### `dictionary-not-approved-word`
 
 Default: hard.
-Reports an unapproved word or phrase from the bundled dictionary and supplies approved alternatives.
-Part-of-speech data limits applicable entries when that data exists.
-Matching does not depend on letter case.
+Without `approvedWordsPath`, this rule reports forms from the bundled not-approved sample and supplies approved alternatives.
+Part-of-speech data limits applicable sample entries when that data exists.
+With `approvedWordsPath`, this rule reports each token that the approved-word list does not contain.
+The list must contain each permitted word form.
+Checks do not depend on letter case.
+The configured approved-word list replaces the bundled sample and any `SIMPLE_ENGLISH_DICTIONARY` replacement.
 
 #### `paragraph-length`
 
@@ -401,8 +407,23 @@ This package does not include the official specification or the complete ASD dic
 Get the current official specification from the [ASD-STE100 site](https://www.asd-ste100.org/).
 This project has no affiliation with or endorsement from ASD.
 
-The package dictionary format and match rules are in [`src/dictionary/README.md`](src/dictionary/README.md).
-Set `SIMPLE_ENGLISH_DICTIONARY` to a replacement dictionary file if necessary.
+The package dictionary format and token rules are in [`src/dictionary/README.md`](src/dictionary/README.md).
+
+To create an approved-word list, use your own licensed copy of the current ASD-STE100 specification.
+Extract the approved words and every permitted form that you want the rule to accept.
+Store only one word form in each `approvedWords` item.
+Add source metadata that identifies your licensed revision and extraction record.
+Keep the list private unless your license lets you distribute it.
+This package does not extract, include, or distribute that data.
+
+Set `approvedWordsPath` in the config to select the list.
+A relative path starts at the working directory that requested the config.
+This option has precedence over the bundled sample and `SIMPLE_ENGLISH_DICTIONARY`.
+A missing, unreadable, or invalid list causes lint exit code 2.
+The enabled pi Adapter gates fail closed after this error.
+Claude Code Hook mode reports a warning and allows the event, as it does for other load errors.
+
+Set `SIMPLE_ENGLISH_DICTIONARY` to replace only the bundled not-approved sample.
 Hook mode resolves a relative replacement path from the session working directory.
 A lint command reports a replacement dictionary load error and continues with all other rules.
 The enabled pi Adapter fails closed after that error.

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "simple-english",
       "dependencies": {
         "effect": "^3.14.0",
+        "micromark": "^4.0.2",
         "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
@@ -283,9 +284,13 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
 
@@ -327,6 +332,8 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -335,7 +342,13 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
@@ -410,6 +423,46 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "effect": "^3.14.0",
+    "micromark": "^4.0.2",
     "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"

--- a/src/adapter/feedback.ts
+++ b/src/adapter/feedback.ts
@@ -8,7 +8,7 @@ function suggestedFix(violation: Violation): string {
   }
   const fixes: Readonly<Record<RuleId, string>> = {
     contraction: "Write the contracted words in full.",
-    "dictionary-not-approved-word": "Replace the unapproved word with an approved alternative.",
+    "dictionary-not-approved-word": "Use a word from the approved-word list.",
     hedging: "Delete the hedging phrase.",
     marketing: "Replace the phrase with factual language.",
     "paragraph-length": "Split the paragraph into shorter paragraphs.",

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -6,7 +6,8 @@ import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-me
 import { formatViolations } from "../adapter/feedback.ts"
 import { ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
-import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
+import { loadConfiguredDictionary } from "../dictionary/configured.ts"
+import { loadRuleData } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
@@ -511,28 +512,20 @@ const readSessionControl = (sessionId: string) =>
     catch: (cause) => new Error(`cannot read session state: ${cause}`),
   })
 
-const loadLintOptions = (cwd: string, tagger: Tagger) => {
-  const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
-  return loadConfig(undefined, cwd).pipe(
-    Effect.flatMap((config) =>
-      Effect.all({
-        dictionary: loadDictionary(
-          dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
-        ),
-        ruleData: loadRuleData(config.ruleDataExtensions, cwd),
-      }).pipe(
-        Effect.map(
-          ({ dictionary, ruleData }): LintOptions => ({
-            ...config,
-            dictionary,
-            ruleData,
-            tagger,
-          }),
-        ),
+const loadLintOptions = (cwd: string, tagger: Tagger) =>
+  Effect.gen(function* () {
+    const config = yield* loadConfig(undefined, cwd)
+    const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
+    const { dictionary, ruleData } = yield* Effect.all({
+      dictionary: loadConfiguredDictionary(
+        config,
+        cwd,
+        dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
       ),
-    ),
-  )
-}
+      ruleData: loadRuleData(config.ruleDataExtensions, cwd),
+    })
+    return { ...config, dictionary, ruleData, tagger } satisfies LintOptions
+  })
 
 function splitViolations(violations: readonly Violation[]): {
   readonly hard: Violation[]

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -3,7 +3,8 @@ import { readFile } from "node:fs/promises"
 import { Effect, Either } from "effect"
 import packageManifest from "../../package.json" with { type: "json" }
 import { loadConfig } from "../config/load.ts"
-import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
+import { loadConfiguredDictionary } from "../dictionary/configured.ts"
+import { loadRuleData } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { LintKind, LintReport } from "../engine/types.ts"
@@ -180,9 +181,12 @@ const lintProgram = Effect.gen(function* () {
   }
   const config = yield* loadConfig(configPath)
   const loadedDictionary = yield* Effect.either(
-    loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+    loadConfiguredDictionary(config, process.cwd(), process.env.SIMPLE_ENGLISH_DICTIONARY),
   )
   const loadedRuleData = yield* Effect.either(loadRuleData(config.ruleDataExtensions))
+  if (Either.isLeft(loadedDictionary) && config.approvedWordsPath !== undefined) {
+    return yield* Effect.fail(loadedDictionary.left)
+  }
   const dictionary = Either.getOrUndefined(loadedDictionary)
   const ruleData = Either.getOrUndefined(loadedRuleData)
   if (Either.isLeft(loadedDictionary)) {

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -2,7 +2,8 @@ import { resolve } from "node:path"
 import { Effect, Either } from "effect"
 import { formatFailedStatusSummary, formatStatusSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
-import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
+import { loadConfiguredDictionary } from "../dictionary/configured.ts"
+import { loadRuleData } from "../dictionary/load.ts"
 import {
   type SessionControl,
   getSessionControl,
@@ -47,7 +48,9 @@ function status(sessionId: string, cwd: string): Effect.Effect<string, Error> {
     const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
     const dictionaryResult = yield* Effect.either(
       Effect.all({
-        dictionary: loadDictionary(
+        dictionary: loadConfiguredDictionary(
+          configResult.right,
+          cwd,
           dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
         ),
         ruleData: loadRuleData(configResult.right.ruleDataExtensions, cwd),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -7,6 +7,7 @@ export interface SteConfig {
   readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
   readonly maxSentenceWords?: number
   readonly ruleDataExtensions?: RuleDataExtensions
+  readonly approvedWordsPath?: string
 }
 
 const RuleSettingSchema = Schema.Literal("hard", "soft", "off").annotations({
@@ -39,6 +40,7 @@ const SteConfigSchema = Schema.Struct({
   rules: Schema.optional(RulesSchema),
   maxSentenceWords: Schema.optional(MaxSentenceWordsSchema),
   ruleDataExtensions: Schema.optional(RuleDataExtensionsSchema),
+  approvedWordsPath: Schema.optional(Schema.NonEmptyTrimmedString),
 })
 
 const decodeUnknown = Schema.decodeUnknown(SteConfigSchema, {

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -2,9 +2,20 @@
 
 The JSON files in `data/` use the package-owned format that `schema.ts` defines and Effect Schema validates.
 The CLI and Adapters load all bundled data through `load.ts`.
+The bundled dictionary and rule-data files use the not-approved form.
+A user-owned approved-word list uses the approved form.
+
+## Shared fields
 
 - `formatVersion` identifies incompatible format changes.
-- `source` records the source name and pins the repository, commit, and path from which the data was converted.
+- `source.name` gives the source name.
+- `source.repository`, `source.commit`, and `source.path` record the source location and revision.
+
+Use private source identifiers when license restrictions apply.
+Unknown properties cause validation to fail.
+
+## Not-approved dictionary
+
 - `entries[].unapproved` lists exact case-insensitive word forms or phrases.
   Forms can contain letters, numbers, internal apostrophes, internal hyphens, and horizontal whitespace between words.
 - `entries[].suggestions` is a required list of rule responses.
@@ -12,7 +23,6 @@ The CLI and Adapters load all bundled data through `load.ts`.
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
   Only the `dictionary-not-approved-word` rule uses this field.
 
-Unknown properties and unsupported form syntax cause dictionary validation to fail.
 For the `dictionary-not-approved-word` rule, matching is token based.
 A hyphenated form matches only that exact hyphenated token.
 A phrase can span horizontal whitespace or a soft line break in the same Markdown paragraph, but it cannot span Markdown block boundaries or hard line breaks.
@@ -20,4 +30,36 @@ Fenced and indented Markdown code is excluded from matching.
 The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags for the form's first token.
 The rule checks an entry without `partsOfSpeech` by word or phrase alone.
 The root [README](../../README.md) documents match details for the three list-backed rules and their config extension paths.
-See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the STE dictionary's exact source, conversion scope, and license details.
+
+## Approved-word list
+
+An approved-word list replaces `entries` with one `approvedWords` array:
+
+```json
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "your licensed source",
+    "repository": "your private source location",
+    "commit": "your licensed revision",
+    "path": "your extraction record"
+  },
+  "approvedWords": ["your-approved-form"]
+}
+```
+
+The example contains a synthetic placeholder and no ASD dictionary data.
+`approvedWords` must contain at least one item.
+Each item must be one exact token in the same token format as a not-approved dictionary form.
+Phrases are not valid approved-word items.
+The rule compares each prose token with the list without regard to case.
+
+The rule does not infer roots, lemmas, plurals, or other forms.
+Add each permitted word form as a separate item.
+The rule excludes identifiers, Markdown link destinations, and fenced or indented Markdown code before this check.
+
+Set `approvedWordsPath` in the Simple English config to select this mode.
+The configured list has precedence over the bundled not-approved sample and `SIMPLE_ENGLISH_DICTIONARY`.
+The pure engine receives validated dictionary data and does not read this file.
+
+See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the bundled data source, conversion scope, and license details.

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -56,10 +56,13 @@ The rule compares each prose token with the list without regard to case.
 
 The rule does not infer roots, lemmas, plurals, or other forms.
 Add each permitted word form as a separate item.
-The rule excludes identifiers, Markdown link destinations, and fenced or indented Markdown code before this check.
+A listed hyphenated form approves only that exact hyphenated token.
 
-Set `approvedWordsPath` in the Simple English config to select this mode.
-The configured list has precedence over the bundled not-approved sample and `SIMPLE_ENGLISH_DICTIONARY`.
+The rule checks visible Markdown prose, including link and image labels.
+It excludes identifiers, Markdown code, link destinations and reference definitions, autolinks, character references, and HTML syntax.
+It also excludes raw content in `pre`, `script`, `style`, and `textarea` HTML flow blocks.
+
+See the root [Configuration](../../README.md#configuration) section for list selection, precedence, and load errors.
 The pure engine receives validated dictionary data and does not read this file.
 
 See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the bundled data source, conversion scope, and license details.

--- a/src/dictionary/configured.ts
+++ b/src/dictionary/configured.ts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path"
+import type { Effect } from "effect"
+import type { SteConfig } from "../config/schema.ts"
+import { type DictionaryLoadError, loadApprovedWordList, loadDictionary } from "./load.ts"
+import type { DictionaryData } from "./schema.ts"
+
+export const loadConfiguredDictionary = (
+  config: SteConfig,
+  cwd: string,
+  replacementPath?: string,
+): Effect.Effect<DictionaryData, DictionaryLoadError> => {
+  if (config.approvedWordsPath !== undefined) {
+    return loadApprovedWordList(resolve(cwd, config.approvedWordsPath))
+  }
+  return loadDictionary(replacementPath)
+}

--- a/src/dictionary/form.ts
+++ b/src/dictionary/form.ts
@@ -1,5 +1,7 @@
 export const DICTIONARY_TOKEN_SOURCE = String.raw`[\p{L}\p{N}]+(?:['’\u2010\u2011-][\p{L}\p{N}]+)*`
 
+export const DICTIONARY_WORD_PATTERN = new RegExp(`^${DICTIONARY_TOKEN_SOURCE}$`, "u")
+
 export const DICTIONARY_FORM_PATTERN = new RegExp(
   `^${DICTIONARY_TOKEN_SOURCE}(?:[\t ]+${DICTIONARY_TOKEN_SOURCE})*$`,
   "u",

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -3,7 +3,12 @@ import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Effect, ParseResult, Schema } from "effect"
 import type { RuleData, RuleDataExtensions, RuleDataId } from "./rule-data.ts"
-import { type Dictionary, DictionarySchema } from "./schema.ts"
+import {
+  type ApprovedWordList,
+  ApprovedWordListSchema,
+  type Dictionary,
+  DictionarySchema,
+} from "./schema.ts"
 
 export const BUNDLED_DICTIONARY_PATH = fileURLToPath(new URL("./data/pi-ste.json", import.meta.url))
 
@@ -45,10 +50,15 @@ const decodeDictionary = Schema.decode(Schema.parseJson(DictionarySchema), {
   errors: "all",
 })
 
-const loadDictionaryData = (
+const decodeApprovedWordList = Schema.decode(Schema.parseJson(ApprovedWordListSchema), {
+  onExcessProperty: "error",
+  errors: "all",
+})
+
+const readDictionaryFile = (
   path: string,
   label: DictionaryLoadLabel,
-): Effect.Effect<Dictionary, DictionaryLoadError> =>
+): Effect.Effect<string, DictionaryLoadError> =>
   Effect.tryPromise({
     try: () => readFile(path, "utf8"),
     catch: (cause) =>
@@ -57,7 +67,13 @@ const loadDictionaryData = (
         `cannot read file: ${cause instanceof Error ? cause.message : String(cause)}`,
         label,
       ),
-  }).pipe(
+  })
+
+const loadDictionaryData = (
+  path: string,
+  label: DictionaryLoadLabel,
+): Effect.Effect<Dictionary, DictionaryLoadError> =>
+  readDictionaryFile(path, label).pipe(
     Effect.flatMap(decodeDictionary),
     Effect.mapError((cause) =>
       cause instanceof DictionaryLoadError
@@ -69,6 +85,18 @@ const loadDictionaryData = (
 export const loadDictionary = (
   path = BUNDLED_DICTIONARY_PATH,
 ): Effect.Effect<Dictionary, DictionaryLoadError> => loadDictionaryData(path, "STE dictionary")
+
+export const loadApprovedWordList = (
+  path: string,
+): Effect.Effect<ApprovedWordList, DictionaryLoadError> =>
+  readDictionaryFile(path, "STE dictionary").pipe(
+    Effect.flatMap(decodeApprovedWordList),
+    Effect.mapError((cause) =>
+      cause instanceof DictionaryLoadError
+        ? cause
+        : new DictionaryLoadError(path, formatParseError(cause)),
+    ),
+  )
 
 const loadExtendedRuleData = (
   id: RuleDataId,

--- a/src/dictionary/schema.ts
+++ b/src/dictionary/schema.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect"
-import { DICTIONARY_FORM_PATTERN } from "./form.ts"
+import { DICTIONARY_FORM_PATTERN, DICTIONARY_WORD_PATTERN } from "./form.ts"
 
 const DictionarySourceSchema = Schema.Struct({
   name: Schema.NonEmptyTrimmedString,
@@ -10,6 +10,10 @@ const DictionarySourceSchema = Schema.Struct({
 
 const DictionaryFormSchema = Schema.NonEmptyTrimmedString.pipe(
   Schema.pattern(DICTIONARY_FORM_PATTERN),
+)
+
+const DictionaryWordSchema = Schema.NonEmptyTrimmedString.pipe(
+  Schema.pattern(DICTIONARY_WORD_PATTERN),
 )
 
 const DictionaryEntrySchema = Schema.Struct({
@@ -29,5 +33,13 @@ export const decodeDictionaryData = Schema.decodeUnknownSync(DictionarySchema, {
   errors: "all",
 })
 
+export const ApprovedWordListSchema = Schema.Struct({
+  formatVersion: Schema.Literal(1),
+  source: DictionarySourceSchema,
+  approvedWords: Schema.NonEmptyArray(DictionaryWordSchema),
+})
+
 export type Dictionary = typeof DictionarySchema.Type
 export type DictionaryEntry = typeof DictionaryEntrySchema.Type
+export type ApprovedWordList = typeof ApprovedWordListSchema.Type
+export type DictionaryData = Dictionary | ApprovedWordList

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -235,12 +235,29 @@ const lintProse = (
   )
   const offsets = lineOffsets(prepared.structuralLines)
   const sentenceIndex = indexSentenceScopes(sentences, prepared.lines.length, sourceOffset)
-  const sentenceFindings = (violations: readonly Violation[]): ScopedViolation[] =>
+  const approvedWordMode =
+    options.dictionary !== undefined && "approvedWords" in options.dictionary
+  const dictionarySentenceIndex = approvedWordMode
+    ? indexSentenceScopes(
+        segmentSentences(
+          prepared.dictionaryLines,
+          prepared.dictionaryLines.join("\n"),
+          prepared.structuralBlanks,
+        ),
+        prepared.dictionaryLines.length,
+        sourceOffset,
+      )
+    : sentenceIndex
+  const sentenceFindings = (
+    violations: readonly Violation[],
+    findingSentenceIndex: SentenceScopeIndex = sentenceIndex,
+    findingLines: readonly string[] = prepared.structuralLines,
+  ): ScopedViolation[] =>
     violations.map((violation) => {
       const scope = scopeForViolation(
         violation,
-        sentenceIndex,
-        prepared.structuralLines,
+        findingSentenceIndex,
+        findingLines,
         offsets,
         sourceOffset,
       )
@@ -286,6 +303,8 @@ const lintProse = (
             contentStarts,
             prepared.dictionaryLines,
           ),
+          dictionarySentenceIndex,
+          approvedWordMode ? prepared.dictionaryLines : prepared.structuralLines,
         )),
     ...(options.tagger === undefined
       ? []

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -7,11 +7,7 @@ import { blankIdentifiers } from "./identifiers.ts"
 import { blankMarkdownCodeWithStructure, blankMarkdownDestinations } from "./markdown.ts"
 import { type Paragraph, segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
-import {
-  type CompiledDictionary,
-  compileDictionary,
-  dictionaryRule,
-} from "./rules/dictionary.ts"
+import { type CompiledDictionary, compileDictionary, dictionaryRule } from "./rules/dictionary.ts"
 import { hedging } from "./rules/hedging.ts"
 import { marketing } from "./rules/marketing.ts"
 import { paragraphLength } from "./rules/paragraph-length.ts"

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -114,13 +114,7 @@ const prepareProse = (extracted: ProseRun, approvedWordMode: boolean): PreparedP
   const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
   const lines = blankIdentifiers(markdown.lines)
   const dictionaryLines = approvedWordMode
-    ? blankIdentifiers(
-        blankMarkdownDestinations(
-          markdown.lines,
-          markdown.contentStarts,
-          markdown.canStartDefinitions,
-        ),
-      )
+    ? blankIdentifiers(blankMarkdownDestinations(extracted.lines, extracted.contentStarts))
     : lines
   return {
     lines,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,11 +1,11 @@
 import { BUNDLED_RULE_DATA } from "../dictionary/bundled-rule-data.ts"
 import type { RuleData } from "../dictionary/rule-data.ts"
-import type { Dictionary } from "../dictionary/schema.ts"
+import type { DictionaryData } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
 import { type ScopedViolation, type ViolationScope, newFindings } from "./diff-match.ts"
 import { changedText } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
-import { blankMarkdownCodeWithStructure } from "./markdown.ts"
+import { blankMarkdownCodeWithStructure, blankMarkdownDestinations } from "./markdown.ts"
 import { type Paragraph, segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
 import { dictionaryRule } from "./rules/dictionary.ts"
@@ -24,7 +24,7 @@ export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
 interface ResolvedOptions {
   readonly maxSentenceWords: number
-  readonly dictionary?: Dictionary
+  readonly dictionary?: DictionaryData
   readonly ruleData?: RuleData
   readonly tagger?: Tagger
 }
@@ -43,6 +43,7 @@ interface ProseRun extends ExtractedProse {
 
 interface PreparedProse {
   readonly lines: readonly string[]
+  readonly dictionaryLines: readonly string[]
   readonly structuralLines: readonly string[]
   readonly mechanicalLines: readonly string[]
   readonly structuralBlanks: readonly boolean[]
@@ -110,6 +111,7 @@ const prepareProse = (extracted: ProseRun): PreparedProse => {
   const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
   return {
     lines: blankIdentifiers(markdown.lines),
+    dictionaryLines: blankIdentifiers(blankMarkdownDestinations(markdown.lines)),
     structuralLines: blankIdentifiers(markdown.structuralLines),
     mechanicalLines: blankIdentifiers(
       extracted.lines.map((line, index) =>
@@ -282,6 +284,7 @@ const lintProse = (
             options.dictionary,
             options.tagger,
             contentStarts,
+            prepared.dictionaryLines,
           ),
         )),
     ...(options.tagger === undefined

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -107,11 +107,24 @@ const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedP
   return wholeText(text)
 }
 
-const prepareProse = (extracted: ProseRun): PreparedProse => {
+const isApprovedWordMode = (dictionary: DictionaryData | undefined): boolean =>
+  dictionary !== undefined && "approvedWords" in dictionary
+
+const prepareProse = (extracted: ProseRun, approvedWordMode: boolean): PreparedProse => {
   const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
+  const lines = blankIdentifiers(markdown.lines)
+  const dictionaryLines = approvedWordMode
+    ? blankIdentifiers(
+        blankMarkdownDestinations(
+          markdown.lines,
+          markdown.contentStarts,
+          markdown.canStartDefinitions,
+        ),
+      )
+    : lines
   return {
-    lines: blankIdentifiers(markdown.lines),
-    dictionaryLines: blankIdentifiers(blankMarkdownDestinations(markdown.lines)),
+    lines,
+    dictionaryLines,
     structuralLines: blankIdentifiers(markdown.structuralLines),
     mechanicalLines: blankIdentifiers(
       extracted.lines.map((line, index) =>
@@ -235,8 +248,7 @@ const lintProse = (
   )
   const offsets = lineOffsets(prepared.structuralLines)
   const sentenceIndex = indexSentenceScopes(sentences, prepared.lines.length, sourceOffset)
-  const approvedWordMode =
-    options.dictionary !== undefined && "approvedWords" in options.dictionary
+  const approvedWordMode = isApprovedWordMode(options.dictionary)
   const dictionarySentenceIndex = approvedWordMode
     ? indexSentenceScopes(
         segmentSentences(
@@ -313,7 +325,12 @@ const lintProse = (
 }
 
 const lintExtracted = (extracted: ProseRun, options: ResolvedOptions): ScopedViolation[] =>
-  lintProse(prepareProse(extracted), extracted.contentStarts, extracted.sourceOffset, options)
+  lintProse(
+    prepareProse(extracted, isApprovedWordMode(options.dictionary)),
+    extracted.contentStarts,
+    extracted.sourceOffset,
+    options,
+  )
 
 function configuredFinding(
   finding: ScopedViolation,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -1,6 +1,5 @@
 import { BUNDLED_RULE_DATA } from "../dictionary/bundled-rule-data.ts"
 import type { RuleData } from "../dictionary/rule-data.ts"
-import type { DictionaryData } from "../dictionary/schema.ts"
 import { type ProseBreak, extractHashComments, extractSlashComments } from "./comments.ts"
 import { type ScopedViolation, type ViolationScope, newFindings } from "./diff-match.ts"
 import { changedText } from "./diff.ts"
@@ -8,7 +7,11 @@ import { blankIdentifiers } from "./identifiers.ts"
 import { blankMarkdownCodeWithStructure, blankMarkdownDestinations } from "./markdown.ts"
 import { type Paragraph, segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
-import { dictionaryRule } from "./rules/dictionary.ts"
+import {
+  type CompiledDictionary,
+  compileDictionary,
+  dictionaryRule,
+} from "./rules/dictionary.ts"
 import { hedging } from "./rules/hedging.ts"
 import { marketing } from "./rules/marketing.ts"
 import { paragraphLength } from "./rules/paragraph-length.ts"
@@ -24,7 +27,7 @@ export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
 interface ResolvedOptions {
   readonly maxSentenceWords: number
-  readonly dictionary?: DictionaryData
+  readonly dictionary?: CompiledDictionary
   readonly ruleData?: RuleData
   readonly tagger?: Tagger
 }
@@ -107,8 +110,8 @@ const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedP
   return wholeText(text)
 }
 
-const isApprovedWordMode = (dictionary: DictionaryData | undefined): boolean =>
-  dictionary !== undefined && "approvedWords" in dictionary
+const isApprovedWordMode = (dictionary: CompiledDictionary | undefined): boolean =>
+  dictionary?.mode === "approved-words"
 
 const prepareProse = (extracted: ProseRun, approvedWordMode: boolean): PreparedProse => {
   const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
@@ -336,13 +339,12 @@ function configuredFinding(
   return { ...finding, violation: { ...finding.violation, severity: setting } }
 }
 
-function evaluate(kind: LintKind, text: string, options: LintOptions): ScopedViolation[] {
-  const resolved: ResolvedOptions = {
-    maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
-    dictionary: options.dictionary,
-    ruleData: options.ruleData ?? BUNDLED_RULE_DATA,
-    tagger: options.tagger,
-  }
+function evaluate(
+  kind: LintKind,
+  text: string,
+  options: LintOptions,
+  resolved: ResolvedOptions,
+): ScopedViolation[] {
   return splitProseRuns(extract(kind, text, options))
     .flatMap((run) =>
       lintExtracted(run, resolved).map((finding) => ({
@@ -367,12 +369,19 @@ function evaluate(kind: LintKind, text: string, options: LintOptions): ScopedVio
 }
 
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
-  const current = evaluate(kind, text, options)
+  const resolved: ResolvedOptions = {
+    maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
+    dictionary:
+      options.dictionary === undefined ? undefined : compileDictionary(options.dictionary),
+    ruleData: options.ruleData ?? BUNDLED_RULE_DATA,
+    tagger: options.tagger,
+  }
+  const current = evaluate(kind, text, options, resolved)
   const findings =
     options.previousText === undefined
       ? current
       : newFindings(
-          evaluate(kind, options.previousText, options),
+          evaluate(kind, options.previousText, options, resolved),
           current,
           changedText(options.previousText, text).retained,
         )

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -317,7 +317,8 @@ const blankTextRange = (text: string[], start: number, end: number): void => {
 }
 
 interface ReferenceCandidate {
-  readonly imageIdentifier: string
+  readonly imageLabelStart: number
+  readonly imageLabelEnd: number
   readonly labelStart: number
   readonly sourceStart: number
   sourceEnd?: number
@@ -359,11 +360,29 @@ const normalizeIdentifier = (value: string): string =>
     .toLowerCase()
     .toUpperCase()
 
-const markdownLabelSize = (value: string): number =>
-  Array.from(value).reduce(
-    (size, character) => size + (character === "\n" || character === "\r" ? 0 : 1),
-    0,
-  )
+const MAX_MARKDOWN_LABEL_SIZE = 999
+const MAX_MARKDOWN_LABEL_SOURCE_SIZE = MAX_MARKDOWN_LABEL_SIZE * 4 + 2
+
+const normalizeIdentifierRange = (
+  source: string,
+  start: number,
+  end: number,
+): string | undefined => {
+  if (end - start > MAX_MARKDOWN_LABEL_SOURCE_SIZE) return undefined
+
+  let size = 0
+  for (let index = start; index < end; ) {
+    const codePoint = source.codePointAt(index)
+    if (codePoint === undefined) break
+    const character = String.fromCodePoint(codePoint)
+    if (character !== "\n" && character !== "\r") size++
+    if (size > MAX_MARKDOWN_LABEL_SIZE) return undefined
+    index += character.length
+  }
+
+  const identifier = normalizeIdentifier(source.slice(start, end))
+  return identifier === "" ? undefined : identifier
+}
 
 interface ResourceScanIndex {
   readonly escaped: Uint8Array
@@ -615,6 +634,7 @@ const prepareMarkdownSource = (
   source: string,
   delimiterSource: string,
   opaqueInlineRanges: readonly SourceRange[],
+  definedIdentifiers?: ReadonlySet<string>,
 ): PreparedMarkdownSource => {
   const brackets: BracketFrame[] = []
   let imageDepth = 0
@@ -707,16 +727,22 @@ const prepareMarkdownSource = (
       const frame = brackets.pop()
       if (frame?.referenceCandidate !== undefined) {
         const candidate = frame.referenceCandidate
-        const identifierSource = source.slice(frame.opening + 1, index)
         candidate.sourceEnd = index + 1
-        if (identifierSource === "") {
-          candidate.identifier = candidate.imageIdentifier
-        } else if (
-          candidate.valid &&
-          markdownLabelSize(identifierSource) <= 999 &&
-          identifierSource.trim() !== ""
-        ) {
-          candidate.identifier = normalizeIdentifier(identifierSource)
+        if (candidate.valid) {
+          candidate.identifier =
+            frame.opening + 1 === index
+              ? normalizeIdentifierRange(
+                  source,
+                  candidate.imageLabelStart,
+                  candidate.imageLabelEnd,
+                )
+              : normalizeIdentifierRange(source, frame.opening + 1, index)
+          if (
+            candidate.identifier !== undefined &&
+            definedIdentifiers?.has(candidate.identifier)
+          ) {
+            blankTextRange(characters, candidate.sourceStart, candidate.sourceEnd)
+          }
         }
       } else if (frame?.image) {
         if (frame.imageDepth > 32) {
@@ -728,7 +754,8 @@ const prepareMarkdownSource = (
             resourceCandidates.push(candidate)
           } else if (source[index + 1] === "[") {
             const candidate = {
-              imageIdentifier: normalizeIdentifier(source.slice(frame.opening + 1, index)),
+              imageLabelStart: frame.opening + 1,
+              imageLabelEnd: index,
               labelStart: frame.opening,
               sourceStart: index + 1,
               valid: true,
@@ -811,6 +838,80 @@ const rangeContaining = (
   }
   const range = ranges[low - 1]
   return range !== undefined && offset < range.end ? range : undefined
+}
+
+const definitionIdentifiers = (
+  source: string,
+  events: ReturnType<typeof markdownEvents>,
+): ReadonlySet<string> => {
+  const identifiers = new Set<string>()
+  for (const [phase, token] of events) {
+    if (phase === "enter" && token.type === "definitionLabelString") {
+      identifiers.add(normalizeIdentifier(source.slice(token.start.offset, token.end.offset)))
+    }
+  }
+  return identifiers
+}
+
+const referenceIdentifier = (
+  source: string,
+  candidate: ReferenceCandidate,
+): { identifier: string; end: number } | undefined => {
+  let backslashRun = 0
+  const contentStart = candidate.sourceStart + 1
+  const scanEnd = Math.min(source.length, contentStart + MAX_MARKDOWN_LABEL_SOURCE_SIZE + 1)
+
+  for (let index = contentStart; index < scanEnd; index++) {
+    const character = source[index]
+    if (character === "\\") {
+      backslashRun++
+      continue
+    }
+    const escaped = backslashRun % 2 !== 0
+    backslashRun = 0
+    if (escaped) continue
+    if (character === "[") return undefined
+    if (character !== "]") continue
+
+    const identifier =
+      index === contentStart
+        ? normalizeIdentifierRange(
+            source,
+            candidate.imageLabelStart,
+            candidate.imageLabelEnd,
+          )
+        : normalizeIdentifierRange(source, contentStart, index)
+    return identifier === undefined ? undefined : { identifier, end: index + 1 }
+  }
+  return undefined
+}
+
+const resolvedReferenceSyntaxRanges = (
+  source: string,
+  candidates: readonly ReferenceCandidate[],
+  inlineBlocks: readonly SourceRange[],
+  definedIdentifiers: ReadonlySet<string>,
+): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  for (const candidate of candidates) {
+    const reference = referenceIdentifier(source, candidate)
+    if (reference === undefined || !definedIdentifiers.has(reference.identifier)) continue
+    const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
+    if (
+      inlineBlock !== undefined &&
+      candidate.sourceStart >= inlineBlock.start &&
+      reference.end <= inlineBlock.end
+    ) {
+      ranges.push({ start: candidate.sourceStart, end: reference.end })
+    }
+  }
+  return ranges
+}
+
+const blankRanges = (source: string, ranges: readonly SourceRange[]): string => {
+  const characters = source.split("")
+  for (const range of ranges) blankTextRange(characters, range.start, range.end)
+  return characters.join("")
 }
 
 const fallbackReferenceRanges = (
@@ -917,15 +1018,36 @@ export function blankMarkdownDestinations(
     blankTextRange(blanked, outputOffset(start), outputOffset(end))
   }
 
-  const delimiterEvents = markdownEvents(opaqueInlineProbe(source))
-  const opaqueInlineRanges = tokenRanges(delimiterEvents, OPAQUE_INLINE_TOKENS)
-  const delimiterCharacters = source.split("")
-  for (const range of opaqueInlineRanges) {
-    blankTextRange(delimiterCharacters, range.start, range.end)
+  const opaqueRangesFor = (probe: string): readonly SourceRange[] =>
+    tokenRanges(markdownEvents(opaqueInlineProbe(probe)), OPAQUE_INLINE_TOKENS)
+  const delimiterSourceFor = (ranges: readonly SourceRange[]): string => blankRanges(source, ranges)
+
+  let opaqueInlineRanges = opaqueRangesFor(source)
+  let preparedSource = prepareMarkdownSource(
+    source,
+    delimiterSourceFor(opaqueInlineRanges),
+    opaqueInlineRanges,
+  )
+  let events = markdownEvents(preparedSource.value)
+  let definedIdentifiers = definitionIdentifiers(source, events)
+  const resolvedReferenceRanges = resolvedReferenceSyntaxRanges(
+    source,
+    preparedSource.referenceCandidates,
+    tokenRanges(events, INLINE_BLOCK_TOKENS),
+    definedIdentifiers,
+  )
+  if (resolvedReferenceRanges.length > 0) {
+    opaqueInlineRanges = opaqueRangesFor(blankRanges(source, resolvedReferenceRanges))
+    preparedSource = prepareMarkdownSource(
+      source,
+      delimiterSourceFor(opaqueInlineRanges),
+      opaqueInlineRanges,
+      definedIdentifiers,
+    )
+    events = markdownEvents(preparedSource.value)
+    definedIdentifiers = definitionIdentifiers(source, events)
   }
-  const delimiterSource = delimiterCharacters.join("")
-  const preparedSource = prepareMarkdownSource(source, delimiterSource, opaqueInlineRanges)
-  const events = markdownEvents(preparedSource.value)
+
   const contentColumns = new Int32Array(parseLines.length).fill(1)
   for (const [phase, token] of events) {
     if (
@@ -979,14 +1101,6 @@ export function blankMarkdownDestinations(
   }
 
   const inlineBlocks = tokenRanges(events, INLINE_BLOCK_TOKENS)
-  const definedIdentifiers = new Set<string>()
-  for (const [phase, token] of events) {
-    if (phase === "enter" && token.type === "definitionLabelString") {
-      definedIdentifiers.add(
-        normalizeIdentifier(source.slice(token.start.offset, token.end.offset)),
-      )
-    }
-  }
 
   for (const range of fallbackReferenceRanges(
     preparedSource.referenceCandidates,

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,9 +1,9 @@
+import { parse, postprocess, preprocess } from "micromark"
+
 const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
 const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const INDENTED = /^(?: {4,}|\t)/
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
-const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[ \t]*\r?$/
-const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})\r?$/
 const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])(?:([ \t]{1,4})(?![ \t])|[ \t])/
 
 const blankLine = (line: string): string => " ".repeat(line.length)
@@ -163,8 +163,6 @@ export interface MarkdownCodeResult {
   readonly lines: string[]
   readonly structuralLines: string[]
   readonly structuralBlanks: boolean[]
-  readonly contentStarts: number[]
-  readonly canStartDefinitions: boolean[]
 }
 
 export function blankMarkdownCodeWithStructure(
@@ -174,14 +172,10 @@ export function blankMarkdownCodeWithStructure(
   let fence: FenceState | null = null
   let activeList: Container | null = null
   let paragraphCanContinue = false
-  let definitionParagraphOpen = false
-  let definitionParagraphContainer: Container | null = null
   let inIndented = false
   const inlineEligible: boolean[] = []
   const structuralLines: string[] = []
   const structuralBlanks: boolean[] = []
-  const markdownContentStarts: number[] = []
-  const canStartDefinitions: boolean[] = []
   const lines = inputLines.map((line, index) => {
     const contentStart = contentStarts[index] ?? 0
 
@@ -196,23 +190,15 @@ export function blankMarkdownCodeWithStructure(
         inlineEligible.push(false)
         structuralLines.push(blankLine(line))
         structuralBlanks.push(true)
-        markdownContentStarts.push(line.length)
-        canStartDefinitions.push(false)
-        definitionParagraphOpen = false
-        definitionParagraphContainer = null
         return blankLine(line)
       }
       fence = null
       paragraphCanContinue = false
-      definitionParagraphOpen = false
-      definitionParagraphContainer = null
       inIndented = false
     }
 
     let content = markdownContent(line, contentStart)
-    const startsListItem = content.container.listIndent > 0
-    const explicitContainer = content.container
-    if (startsListItem) {
+    if (content.container.listIndent > 0) {
       activeList = content.container
     } else if (content.text.trim() !== "" && activeList !== null) {
       const continued = contentWithin(line, contentStart, activeList)
@@ -232,54 +218,25 @@ export function blankMarkdownCodeWithStructure(
       inlineEligible.push(false)
       structuralLines.push(blankLine(line))
       structuralBlanks.push(true)
-      markdownContentStarts.push(line.length)
-      canStartDefinitions.push(false)
-      definitionParagraphOpen = false
-      definitionParagraphContainer = null
       return blankLine(line)
     }
     if (content.text.trim() === "") {
       paragraphCanContinue = false
-      definitionParagraphOpen = false
-      definitionParagraphContainer = null
       inIndented = false
       inlineEligible.push(false)
       structuralLines.push(line)
       structuralBlanks.push(true)
-      markdownContentStarts.push(content.start)
-      canStartDefinitions.push(false)
       return visibleLine
     }
     if (INDENTED.test(content.text) && (!paragraphCanContinue || inIndented)) {
       paragraphCanContinue = false
-      definitionParagraphOpen = false
-      definitionParagraphContainer = null
       inIndented = true
       inlineEligible.push(false)
       structuralLines.push(blankLine(line))
       structuralBlanks.push(true)
-      markdownContentStarts.push(line.length)
-      canStartDefinitions.push(false)
       return blankLine(line)
     }
-
-    const blockBoundary =
-      ATX_HEADING.test(content.text) ||
-      SETEXT_UNDERLINE.test(content.text) ||
-      THEMATIC_BREAK.test(content.text)
-    const startsNewContainer =
-      startsListItem ||
-      (explicitContainer.quoteDepth > 0 &&
-        (definitionParagraphContainer === null ||
-          explicitContainer.quoteDepth !== definitionParagraphContainer.quoteDepth ||
-          explicitContainer.listIndent !== definitionParagraphContainer.listIndent))
-    markdownContentStarts.push(content.start)
-    canStartDefinitions.push(
-      !blockBoundary && (!definitionParagraphOpen || startsNewContainer),
-    )
     paragraphCanContinue = !ATX_HEADING.test(content.text)
-    definitionParagraphOpen = !blockBoundary
-    definitionParagraphContainer = blockBoundary ? null : content.container
     inIndented = false
     inlineEligible.push(true)
     structuralLines.push(line)
@@ -305,13 +262,7 @@ export function blankMarkdownCodeWithStructure(
   blankEligibleInlineCode(lines)
   blankEligibleInlineCode(structuralLines)
 
-  return {
-    lines,
-    structuralLines,
-    structuralBlanks,
-    contentStarts: markdownContentStarts,
-    canStartDefinitions,
-  }
+  return { lines, structuralLines, structuralBlanks }
 }
 
 export function blankMarkdownCode(
@@ -325,376 +276,23 @@ export function maskMarkdownCode(text: string): string {
   return blankMarkdownCode(text.split("\n")).join("\n")
 }
 
-const blankTextRange = (text: string[], start: number, end: number): void => {
-  for (let index = start; index < end; index++) {
-    if (text[index] !== "\n") text[index] = " "
-  }
-}
+const MASKED_MARKDOWN_TOKENS = new Set([
+  "autolink",
+  "blockQuotePrefix",
+  "codeFenced",
+  "codeIndented",
+  "codeText",
+  "listItemPrefix",
+  "reference",
+  "resource",
+])
 
-interface DelimiterFrame {
-  readonly opening: number
-  nested: boolean
-}
-
-interface MarkdownSyntaxIndex {
-  readonly escaped: Uint8Array
-  readonly parenthesisEnds: Int32Array
-  readonly bracketEnds: Int32Array
-  readonly bracketStarts: Int32Array
-  readonly bracketParents: Int32Array
-  readonly bareDestinationEnds: Int32Array
-  readonly horizontalWhitespaceEnds: Int32Array
-  readonly nextAngleSpecials: Int32Array
-  readonly nextDoubleQuotes: Int32Array
-  readonly nextSingleQuotes: Int32Array
-  readonly blankLineStarts: readonly number[]
-}
-
-interface ReferenceDefinition {
-  readonly label: string
-  readonly start: number
-  readonly end: number
-}
-
-const isAsciiPunctuation = (character: string | undefined): boolean => {
-  if (character === undefined) return false
-  const code = character.charCodeAt(0)
-  return (
-    (code >= 0x21 && code <= 0x2f) ||
-    (code >= 0x3a && code <= 0x40) ||
-    (code >= 0x5b && code <= 0x60) ||
-    (code >= 0x7b && code <= 0x7e)
-  )
-}
-
-const encodedPairEnd = (value: number | undefined): number | undefined =>
-  value === undefined || value === 0 ? undefined : Math.abs(value) - 1
-
-const encodedDestinationEnd = (value: number | undefined): number | undefined =>
-  value === undefined || value === 0 ? undefined : value - 1
-
-const indexMarkdownSyntax = (
-  source: string,
-  lines: readonly string[],
-): MarkdownSyntaxIndex => {
-  const escaped = new Uint8Array(source.length)
-  const parenthesisEnds = new Int32Array(source.length)
-  const bracketEnds = new Int32Array(source.length)
-  const bracketStarts = new Int32Array(source.length)
-  const bracketParents = new Int32Array(source.length)
-  const parenthesisStack: DelimiterFrame[] = []
-  const bracketStack: DelimiterFrame[] = []
-
-  for (let index = 0; index < source.length; index++) {
-    const character = source[index]
-    if (
-      character === "\\" &&
-      escaped[index] === 0 &&
-      isAsciiPunctuation(source[index + 1])
-    ) {
-      escaped[index + 1] = 1
-    }
-    if (escaped[index] !== 0) continue
-
-    if (character === "(") {
-      const parent = parenthesisStack.at(-1)
-      if (parent !== undefined) parent.nested = true
-      parenthesisStack.push({ opening: index, nested: false })
-      continue
-    }
-    if (character === ")") {
-      const frame = parenthesisStack.pop()
-      if (frame !== undefined) {
-        parenthesisEnds[frame.opening] = frame.nested ? -(index + 1) : index + 1
-      }
-      continue
-    }
-    if (character === "[") {
-      const parent = bracketStack.at(-1)
-      if (parent !== undefined) {
-        parent.nested = true
-        bracketParents[index] = parent.opening + 1
-      }
-      bracketStack.push({ opening: index, nested: false })
-      continue
-    }
-    if (character !== "]") continue
-
-    const frame = bracketStack.pop()
-    if (frame === undefined) continue
-    const label = source.slice(frame.opening + 1, index)
-    const validLabel =
-      !frame.nested && Array.from(label).length <= 999 && /[^ \t\n\r]/u.test(label)
-    bracketEnds[frame.opening] = validLabel ? index + 1 : -(index + 1)
-    bracketStarts[index] = frame.opening + 1
-  }
-
-  const bareDestinationEnds = new Int32Array(source.length + 1)
-  const horizontalWhitespaceEnds = new Int32Array(source.length + 1)
-  const nextAngleSpecials = new Int32Array(source.length + 1)
-  const nextDoubleQuotes = new Int32Array(source.length + 1)
-  const nextSingleQuotes = new Int32Array(source.length + 1)
-  horizontalWhitespaceEnds[source.length] = source.length
-  bareDestinationEnds[source.length] = source.length + 1
-  let nextAngleSpecial = 0
-  let nextDoubleQuote = 0
-  let nextSingleQuote = 0
-
-  for (let index = source.length - 1; index >= 0; index--) {
-    const character = source[index]
-    horizontalWhitespaceEnds[index] =
-      character === " " || character === "\t"
-        ? (horizontalWhitespaceEnds[index + 1] ?? source.length)
-        : index
-
-    if (escaped[index] === 0) {
-      if (
-        character === "<" ||
-        character === ">" ||
-        character === "\n" ||
-        character === "\r"
-      ) {
-        nextAngleSpecial = index + 1
-      }
-      if (character === '"') nextDoubleQuote = index + 1
-      if (character === "'") nextSingleQuote = index + 1
-    }
-    nextAngleSpecials[index] = nextAngleSpecial
-    nextDoubleQuotes[index] = nextDoubleQuote
-    nextSingleQuotes[index] = nextSingleQuote
-
-    if (escaped[index] !== 0) {
-      bareDestinationEnds[index] = bareDestinationEnds[index + 1] ?? 0
-      continue
-    }
-    if (character === "(") {
-      const closing = encodedPairEnd(parenthesisEnds[index])
-      const nestedEnd = encodedDestinationEnd(bareDestinationEnds[index + 1])
-      bareDestinationEnds[index] =
-        closing !== undefined && nestedEnd === closing
-          ? (bareDestinationEnds[closing + 1] ?? 0)
-          : 0
-      continue
-    }
-    if (
-      character === ")" ||
-      character === " " ||
-      character === "\t" ||
-      character === "\n" ||
-      character === "\r"
-    ) {
-      bareDestinationEnds[index] = index + 1
-      continue
-    }
-    const code = character?.charCodeAt(0) ?? 0
-    bareDestinationEnds[index] =
-      character === "<" || character === ">" || code <= 0x1f || code === 0x7f
-        ? 0
-        : (bareDestinationEnds[index + 1] ?? 0)
-  }
-
-  const blankLineStarts: number[] = []
-  let lineOffset = 0
-  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-    const line = lines[lineIndex] ?? ""
-    const content = line.endsWith("\r") ? line.slice(0, -1) : line
-    if (/^[ \t]*$/u.test(content)) blankLineStarts.push(lineOffset)
-    lineOffset += line.length + (lineIndex < lines.length - 1 ? 1 : 0)
-  }
-
-  return {
-    escaped,
-    parenthesisEnds,
-    bracketEnds,
-    bracketStarts,
-    bracketParents,
-    bareDestinationEnds,
-    horizontalWhitespaceEnds,
-    nextAngleSpecials,
-    nextDoubleQuotes,
-    nextSingleQuotes,
-    blankLineStarts,
-  }
-}
-
-const isLineEnding = (character: string | undefined): boolean =>
-  character === "\n" || character === "\r"
-
-const lineEndingEnd = (source: string, start: number): number =>
-  source[start] === "\r" && source[start + 1] === "\n" ? start + 2 : start + 1
-
-const firstOffsetAtOrAfter = (offsets: readonly number[], target: number): number => {
-  let low = 0
-  let high = offsets.length
-  while (low < high) {
-    const middle = Math.floor((low + high) / 2)
-    if ((offsets[middle] ?? Number.POSITIVE_INFINITY) < target) low = middle + 1
-    else high = middle
-  }
-  return low
-}
-
-const hasBlankLine = (
-  syntax: MarkdownSyntaxIndex,
-  start: number,
-  end: number,
-): boolean => {
-  const blank = syntax.blankLineStarts[firstOffsetAtOrAfter(syntax.blankLineStarts, start)]
-  return blank !== undefined && blank < end
-}
-
-const markdownWhitespaceEnd = (
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  start: number,
-): number | undefined => {
-  let end = syntax.horizontalWhitespaceEnds[start] ?? start
-  if (!isLineEnding(source[end])) return end
-  end = lineEndingEnd(source, end)
-  end = syntax.horizontalWhitespaceEnds[end] ?? end
-  return isLineEnding(source[end]) ? undefined : end
-}
-
-const markdownAngleDestinationEnd = (
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  start: number,
-): number | undefined => {
-  if (source[start] !== "<") return undefined
-  const encoded = syntax.nextAngleSpecials[start + 1] ?? 0
-  if (encoded === 0) return undefined
-  const closing = encoded - 1
-  return source[closing] === ">" ? closing + 1 : undefined
-}
-
-const markdownLinkTitleEnd = (
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  start: number,
-): number | undefined => {
-  const opening = source[start]
-  let closing: number | undefined
-  if (opening === '"') {
-    const encoded = syntax.nextDoubleQuotes[start + 1] ?? 0
-    if (encoded !== 0) closing = encoded - 1
-  } else if (opening === "'") {
-    const encoded = syntax.nextSingleQuotes[start + 1] ?? 0
-    if (encoded !== 0) closing = encoded - 1
-  } else if (opening === "(") {
-    const encoded = syntax.parenthesisEnds[start] ?? 0
-    if (encoded > 0) closing = encoded - 1
-  }
-  if (closing === undefined || hasBlankLine(syntax, start + 1, closing)) return undefined
-  return closing + 1
-}
-
-const markdownInlineLinkEnd = (
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  opening: number,
-): number | undefined => {
-  const destinationStart = markdownWhitespaceEnd(source, syntax, opening + 1)
-  if (destinationStart === undefined) return undefined
-  if (source[destinationStart] === ")") return destinationStart
-
-  const destinationEnd =
-    source[destinationStart] === "<"
-      ? markdownAngleDestinationEnd(source, syntax, destinationStart)
-      : encodedDestinationEnd(syntax.bareDestinationEnds[destinationStart])
-  if (destinationEnd === undefined || destinationEnd === destinationStart) return undefined
-  if (source[destinationEnd] === ")") return destinationEnd
-
-  const titleStart = markdownWhitespaceEnd(source, syntax, destinationEnd)
-  if (titleStart === undefined || titleStart === destinationEnd) return undefined
-  if (source[titleStart] === ")") return titleStart
-
-  const titleEnd = markdownLinkTitleEnd(source, syntax, titleStart)
-  if (titleEnd === undefined) return undefined
-  const linkEnd = markdownWhitespaceEnd(source, syntax, titleEnd)
-  return linkEnd !== undefined && source[linkEnd] === ")" ? linkEnd : undefined
-}
-
-const markdownLabelEnd = (
-  syntax: MarkdownSyntaxIndex,
-  opening: number,
-): number | undefined => {
-  const encoded = syntax.bracketEnds[opening] ?? 0
-  if (encoded <= 0) return undefined
-  const closing = encoded - 1
-  return hasBlankLine(syntax, opening + 1, closing) ? undefined : closing
-}
-
-const normalizeReferenceLabel = (source: string, opening: number, closing: number): string =>
-  source
-    .slice(opening + 1, closing)
-    .replace(/[ \t\n\r]+/gu, " ")
-    .trim()
-    .toLowerCase()
-    .toUpperCase()
-    .toLowerCase()
-
-const markdownDefinitionTail = (
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  destinationEnd: number,
-): number | undefined => {
-  const sameLineEnd = syntax.horizontalWhitespaceEnds[destinationEnd] ?? destinationEnd
-  if (source[sameLineEnd] === undefined) return sameLineEnd
-
-  if (isLineEnding(source[sameLineEnd])) {
-    const baseEnd = sameLineEnd
-    const nextLineStart = syntax.horizontalWhitespaceEnds[
-      lineEndingEnd(source, sameLineEnd)
-    ]
-    if (nextLineStart === undefined) return baseEnd
-    const titleEnd = markdownLinkTitleEnd(source, syntax, nextLineStart)
-    if (titleEnd === undefined) return baseEnd
-    const trailingEnd = syntax.horizontalWhitespaceEnds[titleEnd] ?? titleEnd
-    return source[trailingEnd] === undefined || isLineEnding(source[trailingEnd])
-      ? trailingEnd
-      : baseEnd
-  }
-
-  if (sameLineEnd === destinationEnd) return undefined
-  const titleEnd = markdownLinkTitleEnd(source, syntax, sameLineEnd)
-  if (titleEnd === undefined) return undefined
-  const trailingEnd = syntax.horizontalWhitespaceEnds[titleEnd] ?? titleEnd
-  return source[trailingEnd] === undefined || isLineEnding(source[trailingEnd])
-    ? trailingEnd
-    : undefined
-}
-
-const markdownReferenceDefinition = (
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  start: number,
-): ReferenceDefinition | undefined => {
-  const labelEnd = markdownLabelEnd(syntax, start)
-  if (labelEnd === undefined || source[labelEnd + 1] !== ":") return undefined
-  const destinationStart = markdownWhitespaceEnd(source, syntax, labelEnd + 2)
-  if (destinationStart === undefined) return undefined
-
-  const destinationEnd =
-    source[destinationStart] === "<"
-      ? markdownAngleDestinationEnd(source, syntax, destinationStart)
-      : encodedDestinationEnd(syntax.bareDestinationEnds[destinationStart])
-  if (destinationEnd === undefined || destinationEnd === destinationStart) return undefined
-  const end = markdownDefinitionTail(source, syntax, destinationEnd)
-  if (end === undefined) return undefined
-
-  return {
-    label: normalizeReferenceLabel(source, start, labelEnd),
-    start,
-    end,
-  }
-}
-
-const markdownLineOffsets = (lines: readonly string[]): number[] => {
+const lineStartOffsets = (lines: readonly string[]): readonly number[] => {
   const offsets: number[] = []
-  let nextOffset = 0
+  let offset = 0
   for (let index = 0; index < lines.length; index++) {
-    offsets.push(nextOffset)
-    nextOffset += (lines[index]?.length ?? 0) + (index < lines.length - 1 ? 1 : 0)
+    offsets.push(offset)
+    offset += (lines[index]?.length ?? 0) + (index < lines.length - 1 ? 1 : 0)
   }
   return offsets
 }
@@ -710,114 +308,192 @@ const lineIndexAtOffset = (offsets: readonly number[], offset: number): number =
   return Math.max(0, low - 1)
 }
 
-const markdownReferenceDefinitions = (
-  lines: readonly string[],
-  source: string,
-  syntax: MarkdownSyntaxIndex,
-  contentStarts: readonly number[],
-  canStartDefinitions: readonly boolean[],
-): readonly ReferenceDefinition[] => {
-  const definitions: ReferenceDefinition[] = []
-  const offsets = markdownLineOffsets(lines)
-  let continuationLine = -1
+const blankTextRange = (text: string[], start: number, end: number): void => {
+  for (let index = start; index < end; index++) {
+    if (text[index] !== "\n") text[index] = " "
+  }
+}
 
-  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-    const canStart = (canStartDefinitions[lineIndex] ?? true) || lineIndex === continuationLine
-    continuationLine = -1
-    if (!canStart) continue
+interface BracketFrame {
+  readonly opening: number
+  readonly image: boolean
+  readonly imageDepth: number
+}
 
-    const line = lines[lineIndex] ?? ""
-    const lineOffset = offsets[lineIndex] ?? 0
-    const contentStart = Math.min(contentStarts[lineIndex] ?? 0, line.length)
-    const start = syntax.horizontalWhitespaceEnds[lineOffset + contentStart] ?? source.length
-    const contentEnd = lineOffset + (line.endsWith("\r") ? line.length - 1 : line.length)
-    if (start >= contentEnd || source[start] !== "[") continue
+interface ResourceCandidate {
+  readonly sourceStart: number
+  sourceEnd?: number
+}
 
-    const definition = markdownReferenceDefinition(source, syntax, start)
-    if (definition === undefined) continue
-    definitions.push(definition)
-    const endLine = lineIndexAtOffset(offsets, Math.max(definition.start, definition.end - 1))
-    continuationLine = endLine + 1
-    lineIndex = endLine
+interface PreparedMarkdownSource {
+  readonly value: string
+  readonly resourceCandidates: readonly ResourceCandidate[]
+}
+
+const markdownEvents = (source: string) =>
+  postprocess(parse().document().write(preprocess()(source, "utf8", true)))
+
+const prepareMarkdownSource = (source: string): PreparedMarkdownSource => {
+  const characters = source.split("")
+  const escaped = new Uint8Array(source.length)
+  const brackets: BracketFrame[] = []
+  const parentheses: number[] = []
+  const candidateByOpening = new Map<number, ResourceCandidate>()
+  const resourceCandidates: ResourceCandidate[] = []
+  let imageDepth = 0
+  let backslashRun = 0
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    if (character === "\\") {
+      backslashRun++
+      continue
+    }
+    if (backslashRun % 2 !== 0) escaped[index] = 1
+    backslashRun = 0
+    if (escaped[index] !== 0) continue
+
+    if (character === "[") {
+      const image = source[index - 1] === "!" && escaped[index - 1] === 0
+      if (image) imageDepth++
+      brackets.push({ opening: index, image, imageDepth })
+    } else if (character === "]") {
+      const frame = brackets.pop()
+      if (frame?.image) {
+        if (frame.imageDepth > 32 && source[index + 1] === "(") {
+          characters[frame.opening] = "x"
+          characters[index] = "x"
+          const candidate = { sourceStart: index + 1 }
+          candidateByOpening.set(index + 1, candidate)
+          resourceCandidates.push(candidate)
+        }
+        imageDepth--
+      }
+    } else if (character === "(") {
+      parentheses.push(index)
+    } else if (character === ")") {
+      const opening = parentheses.pop()
+      if (opening !== undefined) {
+        const candidate = candidateByOpening.get(opening)
+        if (candidate !== undefined) candidate.sourceEnd = index + 1
+      }
+    }
   }
 
-  return definitions
+  for (const opening of parentheses) characters[opening] = "x"
+  return { value: characters.join(""), resourceCandidates }
+}
+
+const fallbackResourceRanges = (
+  source: string,
+  candidates: readonly ResourceCandidate[],
+): readonly { start: number; end: number }[] => {
+  const chunks: string[] = []
+  const segments = new Map<number, { sourceStart: number; syntheticEnd: number }>()
+  let syntheticOffset = 0
+
+  for (const candidate of candidates) {
+    if (candidate.sourceEnd === undefined) continue
+    const resource = source.slice(candidate.sourceStart, candidate.sourceEnd)
+    const syntheticStart = syntheticOffset + 3
+    chunks.push(`[x]${resource}\n\n`)
+    syntheticOffset += resource.length + 5
+    segments.set(syntheticStart, {
+      sourceStart: candidate.sourceStart,
+      syntheticEnd: syntheticStart + resource.length,
+    })
+  }
+
+  if (chunks.length === 0) return []
+  const ranges: Array<{ start: number; end: number }> = []
+  for (const [phase, token] of markdownEvents(chunks.join(""))) {
+    if (phase !== "enter" || token.type !== "resource") continue
+    const segment = segments.get(token.start.offset)
+    if (segment === undefined || token.end.offset > segment.syntheticEnd) continue
+    ranges.push({
+      start: segment.sourceStart,
+      end: segment.sourceStart + token.end.offset - token.start.offset,
+    })
+  }
+  return ranges
 }
 
 export function blankMarkdownDestinations(
   lines: readonly string[],
   contentStarts: readonly number[] = lines.map(() => 0),
-  canStartDefinitions: readonly boolean[] = lines.map(() => true),
 ): string[] {
-  const source = lines.join("\n")
-  const blanked = source.split("")
-  const syntax = indexMarkdownSyntax(source, lines)
-  const definitions = markdownReferenceDefinitions(
-    lines,
-    source,
-    syntax,
-    contentStarts,
-    canStartDefinitions,
+  if (lines.length === 0) return []
+
+  const parseLines = lines.map((line, index) =>
+    line.slice(Math.min(contentStarts[index] ?? 0, line.length)),
   )
-  const labels = new Set(definitions.map((definition) => definition.label))
-  const inactiveLinkOpeners = new Uint8Array(source.length)
-  const isImageOpener = (opening: number): boolean =>
-    source[opening - 1] === "!" && syntax.escaped[opening - 1] === 0
-  const deactivateParentLinks = (opening: number): void => {
-    if (isImageOpener(opening)) return
-    let encodedParent = syntax.bracketParents[opening] ?? 0
-    while (encodedParent !== 0) {
-      const parent = encodedParent - 1
-      if (!isImageOpener(parent)) inactiveLinkOpeners[parent] = 1
-      encodedParent = syntax.bracketParents[parent] ?? 0
+  const source = parseLines.join("\n")
+  const sourceLineStarts = lineStartOffsets(parseLines)
+  const outputLineStarts = lineStartOffsets(lines)
+  const blanked = lines.join("\n").split("")
+  const outputOffset = (sourceOffset: number): number => {
+    const lineIndex = lineIndexAtOffset(sourceLineStarts, sourceOffset)
+    const line = lines[lineIndex] ?? ""
+    const contentStart = Math.min(contentStarts[lineIndex] ?? 0, line.length)
+    return (
+      (outputLineStarts[lineIndex] ?? 0) +
+      contentStart +
+      sourceOffset -
+      (sourceLineStarts[lineIndex] ?? 0)
+    )
+  }
+  const blankSourceRange = (start: number, end: number): void => {
+    blankTextRange(blanked, outputOffset(start), outputOffset(end))
+  }
+
+  const preparedSource = prepareMarkdownSource(source)
+  const events = markdownEvents(preparedSource.value)
+  const definitionMaskEnds = new Map<number, number>()
+  let activeDefinitionStart: number | undefined
+  let activeDefinitionLine = 0
+  let indentedDefinitionLine = 0
+  for (const [phase, token] of events) {
+    if (phase === "enter" && token.type === "definition") {
+      activeDefinitionStart = token.start.offset
+      activeDefinitionLine = token.start.line
+      indentedDefinitionLine = 0
+    } else if (
+      phase === "enter" &&
+      token.type === "linePrefix" &&
+      activeDefinitionStart !== undefined
+    ) {
+      indentedDefinitionLine = token.start.line
+    } else if (
+      phase === "enter" &&
+      token.type === "definitionTitle" &&
+      activeDefinitionStart !== undefined &&
+      token.start.line > activeDefinitionLine &&
+      indentedDefinitionLine !== token.start.line
+    ) {
+      definitionMaskEnds.set(activeDefinitionStart, token.start.offset)
+    } else if (phase === "exit" && token.type === "definition") {
+      activeDefinitionStart = undefined
     }
   }
 
-  for (const definition of definitions) {
-    blankTextRange(blanked, definition.start, definition.end)
+  for (const [phase, token] of events) {
+    if (phase !== "enter") continue
+    if (token.type === "definition") {
+      blankSourceRange(
+        token.start.offset,
+        definitionMaskEnds.get(token.start.offset) ?? token.end.offset,
+      )
+    } else if (MASKED_MARKDOWN_TOKENS.has(token.type)) {
+      blankSourceRange(token.start.offset, token.end.offset)
+    }
   }
 
-  for (let index = 0; index < source.length; index++) {
-    if (source[index] !== "]" || syntax.escaped[index] !== 0) continue
-    const encodedOpening = syntax.bracketStarts[index] ?? 0
-    if (encodedOpening === 0) continue
-    const opening = encodedOpening - 1
-    if (inactiveLinkOpeners[opening] !== 0 || hasBlankLine(syntax, opening + 1, index)) continue
-
-    const suffixStart = index + 1
-    if (source[suffixStart] === "(") {
-      const linkEnd = markdownInlineLinkEnd(source, syntax, suffixStart)
-      if (linkEnd === undefined) continue
-      blankTextRange(blanked, suffixStart, linkEnd + 1)
-      deactivateParentLinks(opening)
-      index = linkEnd
-      continue
-    }
-    if (source[suffixStart] !== "[") continue
-
-    const referenceEnd = encodedPairEnd(syntax.bracketEnds[suffixStart])
-    if (referenceEnd === undefined) continue
-    const labelEnd = markdownLabelEnd(syntax, suffixStart)
-    const collapsed = referenceEnd === suffixStart + 1
-    const resolves = collapsed
-      ? markdownLabelEnd(syntax, opening) === index &&
-        labels.has(normalizeReferenceLabel(source, opening, index))
-      : labelEnd === referenceEnd &&
-        labels.has(normalizeReferenceLabel(source, suffixStart, referenceEnd))
-    if (!resolves) continue
-
-    blankTextRange(blanked, suffixStart, referenceEnd + 1)
-    deactivateParentLinks(opening)
-    index = referenceEnd
+  for (const range of fallbackResourceRanges(source, preparedSource.resourceCandidates)) {
+    blankSourceRange(range.start, range.end)
   }
 
-  for (const pattern of [
-    /<(?:[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\s]*|[^<>\s@]+@[^<>\s@]+)>/gu,
-    /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<]+/gu,
-  ]) {
-    for (const match of source.matchAll(pattern)) {
-      blankTextRange(blanked, match.index, match.index + match[0].length)
-    }
+  for (const match of source.matchAll(/\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<]+/gu)) {
+    blankSourceRange(match.index, match.index + match[0].length)
   }
 
   return blanked.join("").split("\n")

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -344,14 +344,19 @@ const isMarkdownWhitespace = (character: string | undefined): boolean =>
 interface ResourceScanIndex {
   readonly escaped: Uint8Array
   readonly nextNonWhitespace: Int32Array
+  readonly nextWhitespace: Int32Array
   readonly nextLineEnding: Int32Array
   readonly nextGreater: Int32Array
+  readonly nextLess: Int32Array
   readonly nextDoubleQuote: Int32Array
   readonly nextSingleQuote: Int32Array
   readonly nextClosingParenthesis: Int32Array
+  readonly nextAsciiControl: Int32Array
   readonly depthBefore: Int32Array
   readonly boundariesByDepth: ReadonlyMap<number, readonly number[]>
+  readonly openingsByDepth: ReadonlyMap<number, readonly number[]>
   readonly boundaryCursors: Map<number, number>
+  readonly openingCursors: Map<number, number>
 }
 
 const escapedCharacters = (source: string): Uint8Array => {
@@ -368,41 +373,55 @@ const escapedCharacters = (source: string): Uint8Array => {
   return escaped
 }
 
-const resourceScanIndex = (source: string, delimiterSource: string): ResourceScanIndex => {
+const resourceScanIndex = (source: string): ResourceScanIndex => {
   const escaped = escapedCharacters(source)
   const nextNonWhitespace = new Int32Array(source.length + 1).fill(source.length)
+  const nextWhitespace = new Int32Array(source.length + 1).fill(-1)
   const nextLineEnding = new Int32Array(source.length + 1).fill(-1)
   const nextGreater = new Int32Array(source.length + 1).fill(-1)
+  const nextLess = new Int32Array(source.length + 1).fill(-1)
   const nextDoubleQuote = new Int32Array(source.length + 1).fill(-1)
   const nextSingleQuote = new Int32Array(source.length + 1).fill(-1)
   const nextClosingParenthesis = new Int32Array(source.length + 1).fill(-1)
+  const nextAsciiControl = new Int32Array(source.length + 1).fill(-1)
   let nonWhitespace = source.length
+  let whitespace = -1
   let lineEnding = -1
   let greater = -1
+  let less = -1
   let doubleQuote = -1
   let singleQuote = -1
   let closingParenthesis = -1
+  let asciiControl = -1
 
   for (let index = source.length - 1; index >= 0; index--) {
     const character = source[index]
-    if (!isMarkdownWhitespace(character)) nonWhitespace = index
+    const code = source.charCodeAt(index)
+    if (isMarkdownWhitespace(character)) whitespace = index
+    else nonWhitespace = index
     if (character === "\n" || character === "\r") lineEnding = index
+    if ((code < 32 || code === 127) && !isMarkdownWhitespace(character)) asciiControl = index
     if (escaped[index] === 0) {
       if (character === ">") greater = index
+      if (character === "<") less = index
       if (character === '"') doubleQuote = index
       if (character === "'") singleQuote = index
       if (character === ")") closingParenthesis = index
     }
     nextNonWhitespace[index] = nonWhitespace
+    nextWhitespace[index] = whitespace
     nextLineEnding[index] = lineEnding
     nextGreater[index] = greater
+    nextLess[index] = less
     nextDoubleQuote[index] = doubleQuote
     nextSingleQuote[index] = singleQuote
     nextClosingParenthesis[index] = closingParenthesis
+    nextAsciiControl[index] = asciiControl
   }
 
   const depthBefore = new Int32Array(source.length)
   const boundariesByDepth = new Map<number, number[]>()
+  const openingsByDepth = new Map<number, number[]>()
   let depth = 0
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
@@ -412,22 +431,33 @@ const resourceScanIndex = (source: string, delimiterSource: string): ResourceSca
       boundaries.push(index)
       boundariesByDepth.set(depth, boundaries)
     }
-    if (delimiterSource[index] !== character || escaped[index] !== 0) continue
-    if (character === "(") depth++
-    else if (character === ")") depth--
+    if (escaped[index] !== 0) continue
+    if (character === "(") {
+      const openings = openingsByDepth.get(depth) ?? []
+      openings.push(index)
+      openingsByDepth.set(depth, openings)
+      depth++
+    } else if (character === ")") {
+      depth--
+    }
   }
 
   return {
     escaped,
     nextNonWhitespace,
+    nextWhitespace,
     nextLineEnding,
     nextGreater,
+    nextLess,
     nextDoubleQuote,
     nextSingleQuote,
     nextClosingParenthesis,
+    nextAsciiControl,
     depthBefore,
     boundariesByDepth,
+    openingsByDepth,
     boundaryCursors: new Map(),
+    openingCursors: new Map(),
   }
 }
 
@@ -440,30 +470,48 @@ const nextResourceBoundary = (index: ResourceScanIndex, start: number): number =
   return boundaries[cursor] ?? -1
 }
 
-const resourceOpaqueRanges = (
-  source: string,
-  opening: number,
-  scanIndex: ResourceScanIndex,
-): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
+const nextResourceOpening = (index: ResourceScanIndex, depth: number, start: number): number => {
+  const openings = index.openingsByDepth.get(depth) ?? []
+  let cursor = index.openingCursors.get(depth) ?? 0
+  while ((openings[cursor] ?? Number.POSITIVE_INFINITY) < start) cursor++
+  index.openingCursors.set(depth, cursor)
+  return openings[cursor] ?? -1
+}
+
+const resourceEnd = (source: string, opening: number, scanIndex: ResourceScanIndex): number => {
   let index = scanIndex.nextNonWhitespace[opening + 1] ?? source.length
+  if (source[index] === ")") return index + 1
 
   if (source[index] === "<") {
     const end = scanIndex.nextGreater[index + 1] ?? -1
+    const less = scanIndex.nextLess[index + 1] ?? -1
     const lineEnding = scanIndex.nextLineEnding[index + 1] ?? -1
-    if (end < 0 || (lineEnding >= 0 && lineEnding < end)) return ranges
-    ranges.push({ start: index, end: end + 1 })
+    if (end < 0 || (less >= 0 && less < end) || (lineEnding >= 0 && lineEnding < end)) {
+      return -1
+    }
     index = end + 1
   } else {
-    index = nextResourceBoundary(scanIndex, index)
-    if (index < 0) return ranges
+    const destinationStart = index
+    const destinationDepth = scanIndex.depthBefore[destinationStart] ?? 0
+    index = nextResourceBoundary(scanIndex, destinationStart)
+    if (index < 0) return -1
+    const whitespace = scanIndex.nextWhitespace[destinationStart] ?? -1
+    const asciiControl = scanIndex.nextAsciiControl[destinationStart] ?? -1
+    const excessiveOpening = nextResourceOpening(scanIndex, destinationDepth + 32, destinationStart)
+    if (
+      (whitespace >= 0 && whitespace < index) ||
+      (asciiControl >= 0 && asciiControl < index) ||
+      (excessiveOpening >= 0 && excessiveOpening < index)
+    ) {
+      return -1
+    }
   }
 
-  const separatorStart = index
-  index = scanIndex.nextNonWhitespace[index] ?? source.length
-  if (index === separatorStart) return ranges
+  if (!isMarkdownWhitespace(source[index])) return source[index] === ")" ? index + 1 : -1
 
+  index = scanIndex.nextNonWhitespace[index] ?? source.length
   const delimiter = source[index]
+  if (delimiter === ")") return index + 1
   const closing =
     delimiter === '"'
       ? scanIndex.nextDoubleQuote[index + 1]
@@ -472,9 +520,12 @@ const resourceOpaqueRanges = (
         : delimiter === "("
           ? scanIndex.nextClosingParenthesis[index + 1]
           : -1
-  if (closing === undefined || closing < 0) return ranges
-  ranges.push({ start: index, end: closing + 1 })
-  return ranges
+  if (closing === undefined || closing < 0) return -1
+  index = closing + 1
+  if (isMarkdownWhitespace(source[index])) {
+    index = scanIndex.nextNonWhitespace[index] ?? source.length
+  }
+  return source[index] === ")" ? index + 1 : -1
 }
 
 const markdownEvents = (source: string) =>
@@ -510,23 +561,16 @@ const prepareMarkdownSource = (
   opaqueInlineRanges: readonly SourceRange[],
 ): PreparedMarkdownSource => {
   const characters = source.split("")
-  const scanIndex = resourceScanIndex(source, delimiterSource)
+  const scanIndex = resourceScanIndex(source)
   const escaped = scanIndex.escaped
   const brackets: BracketFrame[] = []
-  const parentheses: number[] = []
   const candidateByOpening = new Map<number, ResourceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
-  const resourceOpaqueEnds = new Int32Array(source.length).fill(-1)
   let imageDepth = 0
   let opaqueRangeIndex = 0
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
-    const resourceOpaqueEnd = resourceOpaqueEnds[index] ?? -1
-    if (resourceOpaqueEnd >= 0) {
-      index = resourceOpaqueEnd - 1
-      continue
-    }
     while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
       opaqueRangeIndex++
     }
@@ -555,17 +599,14 @@ const prepareMarkdownSource = (
         imageDepth--
       }
     } else if (character === "(") {
-      parentheses.push(index)
-      if (candidateByOpening.has(index)) {
-        for (const range of resourceOpaqueRanges(source, index, scanIndex)) {
-          resourceOpaqueEnds[range.start] = range.end
+      const candidate = candidateByOpening.get(index)
+      if (candidate !== undefined) {
+        const end = resourceEnd(source, index, scanIndex)
+        if (end >= 0) {
+          candidate.sourceEnd = end
+          blankTextRange(characters, index, end)
+          index = end - 1
         }
-      }
-    } else if (character === ")") {
-      const opening = parentheses.pop()
-      if (opening !== undefined) {
-        const candidate = candidateByOpening.get(opening)
-        if (candidate !== undefined) candidate.sourceEnd = index + 1
       }
     }
   }
@@ -633,9 +674,10 @@ const fallbackResourceRanges = (
   const chunks: string[] = []
   const segments = new Map<number, { sourceStart: number; syntheticEnd: number }>()
   let syntheticOffset = 0
+  let acceptedEnd = -1
 
   for (const candidate of candidates) {
-    if (candidate.sourceEnd === undefined) continue
+    if (candidate.sourceEnd === undefined || candidate.sourceStart < acceptedEnd) continue
     const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
     if (
       inlineBlock === undefined ||
@@ -645,6 +687,7 @@ const fallbackResourceRanges = (
     ) {
       continue
     }
+    acceptedEnd = candidate.sourceEnd
     const resource = source.slice(candidate.sourceStart, candidate.sourceEnd)
     const syntheticStart = syntheticOffset + 3
     chunks.push(`[x]${resource}\n\n`)

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -350,6 +350,7 @@ interface PreparedMarkdownSource {
   readonly value: string
   readonly resourceCandidates: readonly ResourceCandidate[]
   readonly referenceCandidates: readonly ReferenceCandidate[]
+  readonly deepFallback: boolean
 }
 
 const isMarkdownWhitespace = (character: string | undefined): boolean =>
@@ -573,6 +574,70 @@ const resourceEnd = (source: string, opening: number, scanIndex: ResourceScanInd
   return source[index] === ")" ? index + 1 : -1
 }
 
+const linearResourceEnd = (source: string, opening: number): number => {
+  let index = opening + 1
+  while (isMarkdownWhitespace(source[index])) index++
+  if (source[index] === ")") return index + 1
+
+  if (source[index] === "<") {
+    index++
+    for (; index < source.length; index++) {
+      if (source[index] === "\\") {
+        index++
+        continue
+      }
+      if (source[index] === ">") {
+        index++
+        break
+      }
+      if (source[index] === "<" || source[index] === "\n" || source[index] === "\r") return -1
+    }
+    if (source[index - 1] !== ">") return -1
+  } else {
+    let depth = 0
+    for (; index < source.length; index++) {
+      const character = source[index]
+      if (character === "\\") {
+        index++
+        continue
+      }
+      if (isMarkdownWhitespace(character)) break
+      const code = source.charCodeAt(index)
+      if (code < 32 || code === 127) return -1
+      if (character === "(") {
+        depth++
+        if (depth > 32) return -1
+      } else if (character === ")") {
+        if (depth === 0) return index + 1
+        depth--
+      }
+    }
+    if (index >= source.length) return -1
+  }
+
+  if (!isMarkdownWhitespace(source[index])) return source[index] === ")" ? index + 1 : -1
+  while (isMarkdownWhitespace(source[index])) index++
+  if (source[index] === ")") return index + 1
+
+  const delimiter = source[index]
+  const closingDelimiter = delimiter === "(" ? ")" : delimiter
+  if (delimiter !== '"' && delimiter !== "'" && delimiter !== "(") return -1
+  index++
+  for (; index < source.length; index++) {
+    if (source[index] === "\\") {
+      index++
+      continue
+    }
+    if (source[index] === closingDelimiter) {
+      index++
+      break
+    }
+  }
+  if (source[index - 1] !== closingDelimiter) return -1
+  while (isMarkdownWhitespace(source[index])) index++
+  return source[index] === ")" ? index + 1 : -1
+}
+
 const markdownEvents = (source: string) =>
   postprocess(
     parse()
@@ -636,15 +701,35 @@ const prepareMarkdownSource = (
   source: string,
   delimiterSource: string,
   opaqueInlineRanges: readonly SourceRange[],
+  inlineBlocks: readonly SourceRange[],
   definedIdentifiers?: ReadonlySet<string>,
 ): PreparedMarkdownSource => {
   const brackets: BracketFrame[] = []
+  const potentialResources: Array<{ opening: number; bracketDepth: number }> = []
   let opaqueRangeIndex = 0
+  let inlineBlockIndex = 0
+  let activeInlineBlockStart = -1
   let backslashRun = 0
   let needsDeepLabelFallback = false
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
+    while ((inlineBlocks[inlineBlockIndex]?.end ?? source.length + 1) <= index) {
+      inlineBlockIndex++
+    }
+    const inlineBlock = inlineBlocks[inlineBlockIndex]
+    if (inlineBlock === undefined || index < inlineBlock.start) {
+      brackets.length = 0
+      potentialResources.length = 0
+      activeInlineBlockStart = -1
+      continue
+    }
+    if (inlineBlock.start !== activeInlineBlockStart) {
+      brackets.length = 0
+      potentialResources.length = 0
+      activeInlineBlockStart = inlineBlock.start
+    }
+
     while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
       opaqueRangeIndex++
     }
@@ -673,16 +758,34 @@ const prepareMarkdownSource = (
       const image = source[index - 1] === "!" && precedingBackslashes % 2 === 0
       brackets.push({ opening: index, image, labelDepth: brackets.length + 1, linkEpoch: 0 })
       if (brackets.length > 32) {
+        const resource = potentialResources.at(-1)
+        if (resource !== undefined) {
+          const end = linearResourceEnd(source, resource.opening)
+          if (end > index && end <= inlineBlock.end) {
+            brackets.length = resource.bracketDepth
+            potentialResources.length = 0
+            index = end - 1
+            continue
+          }
+        }
         needsDeepLabelFallback = true
         break
       }
     } else if (character === "]") {
       brackets.pop()
+      if (source[index + 1] === "(") {
+        potentialResources.push({ opening: index + 1, bracketDepth: brackets.length })
+      }
     }
   }
 
   if (!needsDeepLabelFallback) {
-    return { value: boundCdataMarkers(source), resourceCandidates: [], referenceCandidates: [] }
+    return {
+      value: boundCdataMarkers(source),
+      resourceCandidates: [],
+      referenceCandidates: [],
+      deepFallback: false,
+    }
   }
 
   const characters = boundCdataMarkers(source).split("")
@@ -694,9 +797,25 @@ const prepareMarkdownSource = (
   const referenceCandidates: ReferenceCandidate[] = []
   brackets.length = 0
   opaqueRangeIndex = 0
+  inlineBlockIndex = 0
+  activeInlineBlockStart = -1
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
+    while ((inlineBlocks[inlineBlockIndex]?.end ?? source.length + 1) <= index) {
+      inlineBlockIndex++
+    }
+    const inlineBlock = inlineBlocks[inlineBlockIndex]
+    if (inlineBlock === undefined || index < inlineBlock.start) {
+      brackets.length = 0
+      activeInlineBlockStart = -1
+      continue
+    }
+    if (inlineBlock.start !== activeInlineBlockStart) {
+      brackets.length = 0
+      activeInlineBlockStart = inlineBlock.start
+    }
+
     while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
       opaqueRangeIndex++
     }
@@ -778,12 +897,26 @@ const prepareMarkdownSource = (
           } else if (needsFallback) {
             resourceCandidates.push({ labelStart: frame.opening, sourceStart: index + 1 })
           }
+        } else if (
+          !frame.image &&
+          frame.linkEpoch === linkEpoch &&
+          source[index + 1] !== "[" &&
+          definedIdentifiers?.has(
+            normalizeIdentifierRange(source, frame.opening + 1, index) ?? "",
+          )
+        ) {
+          linkEpoch++
         }
       }
     }
   }
 
-  return { value: characters.join(""), resourceCandidates, referenceCandidates }
+  return {
+    value: characters.join(""),
+    resourceCandidates,
+    referenceCandidates,
+    deepFallback: true,
+  }
 }
 
 const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
@@ -1021,15 +1154,24 @@ export function blankMarkdownDestinations(
     blankTextRange(blanked, outputOffset(start), outputOffset(end))
   }
 
-  const opaqueRangesFor = (probe: string): readonly SourceRange[] =>
-    tokenRanges(markdownEvents(opaqueInlineProbe(probe)), OPAQUE_INLINE_TOKENS)
+  const syntaxRangesFor = (
+    probe: string,
+  ): { opaqueInlineRanges: readonly SourceRange[]; inlineBlocks: readonly SourceRange[] } => {
+    const probeEvents = markdownEvents(opaqueInlineProbe(probe))
+    return {
+      opaqueInlineRanges: tokenRanges(probeEvents, OPAQUE_INLINE_TOKENS),
+      inlineBlocks: tokenRanges(probeEvents, INLINE_BLOCK_TOKENS),
+    }
+  }
   const delimiterSourceFor = (ranges: readonly SourceRange[]): string => blankRanges(source, ranges)
 
-  let opaqueInlineRanges = opaqueRangesFor(source)
+  let syntaxRanges = syntaxRangesFor(source)
+  let opaqueInlineRanges = syntaxRanges.opaqueInlineRanges
   let preparedSource = prepareMarkdownSource(
     source,
     delimiterSourceFor(opaqueInlineRanges),
     opaqueInlineRanges,
+    syntaxRanges.inlineBlocks,
   )
   let events = markdownEvents(preparedSource.value)
   let definedIdentifiers = definitionIdentifiers(source, events)
@@ -1039,12 +1181,14 @@ export function blankMarkdownDestinations(
     tokenRanges(events, INLINE_BLOCK_TOKENS),
     definedIdentifiers,
   )
-  if (resolvedReferenceRanges.length > 0) {
-    opaqueInlineRanges = opaqueRangesFor(blankRanges(source, resolvedReferenceRanges))
+  if (resolvedReferenceRanges.length > 0 || (preparedSource.deepFallback && definedIdentifiers.size > 0)) {
+    syntaxRanges = syntaxRangesFor(blankRanges(source, resolvedReferenceRanges))
+    opaqueInlineRanges = syntaxRanges.opaqueInlineRanges
     preparedSource = prepareMarkdownSource(
       source,
       delimiterSourceFor(opaqueInlineRanges),
       opaqueInlineRanges,
+      syntaxRanges.inlineBlocks,
       definedIdentifiers,
     )
     events = markdownEvents(preparedSource.value)

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -338,31 +338,62 @@ interface PreparedMarkdownSource {
   readonly resourceCandidates: readonly ResourceCandidate[]
 }
 
-const angleDestinationEnds = (source: string): Int32Array => {
-  const ends = new Int32Array(source.length).fill(-1)
-  let opening = -1
-  let backslashRun = 0
+const isMarkdownWhitespace = (character: string | undefined): boolean =>
+  character === " " || character === "\t" || character === "\n" || character === "\r"
 
-  for (let index = 0; index < source.length; index++) {
-    const character = source[index]
-    if (character === "\\") {
-      backslashRun++
-      continue
+const resourceOpaqueRanges = (source: string, opening: number): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  let index = opening + 1
+  while (isMarkdownWhitespace(source[index])) index++
+
+  if (source[index] === "<") {
+    const start = index
+    for (index++; index < source.length; index++) {
+      if (source[index] === "\\") {
+        index++
+      } else if (source[index] === "\n" || source[index] === "\r") {
+        return ranges
+      } else if (source[index] === ">") {
+        index++
+        ranges.push({ start, end: index })
+        break
+      }
     }
-    const escaped = backslashRun % 2 !== 0
-    backslashRun = 0
-
-    if (character === "\n" || character === "\r") {
-      opening = -1
-    } else if (!escaped && character === "<") {
-      opening = index
-    } else if (!escaped && character === ">" && opening >= 0) {
-      ends[opening] = index + 1
-      opening = -1
+  } else {
+    let depth = 0
+    for (; index < source.length; index++) {
+      const character = source[index]
+      if (character === "\\") {
+        index++
+      } else if (character === "(") {
+        depth++
+      } else if (character === ")") {
+        if (depth === 0) return ranges
+        depth--
+      } else if (depth === 0 && isMarkdownWhitespace(character)) {
+        break
+      }
     }
   }
 
-  return ends
+  const separatorStart = index
+  while (isMarkdownWhitespace(source[index])) index++
+  if (index === separatorStart) return ranges
+
+  const delimiter = source[index]
+  const closing = delimiter === "(" ? ")" : delimiter
+  if (delimiter !== '"' && delimiter !== "'" && delimiter !== "(") return ranges
+
+  const start = index
+  for (index++; index < source.length; index++) {
+    if (source[index] === "\\") {
+      index++
+    } else if (source[index] === closing) {
+      ranges.push({ start, end: index + 1 })
+      return ranges
+    }
+  }
+  return ranges
 }
 
 const markdownEvents = (source: string) =>
@@ -395,16 +426,17 @@ const prepareMarkdownSource = (
   const parentheses: number[] = []
   const candidateByOpening = new Map<number, ResourceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
-  const angleEnds = angleDestinationEnds(source)
+  const resourceOpaqueEnds = new Int32Array(source.length).fill(-1)
   let imageDepth = 0
   let backslashRun = 0
   let opaqueRangeIndex = 0
-  let resourceAngleEnd = -1
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
-    if (index < resourceAngleEnd) {
+    const resourceOpaqueEnd = resourceOpaqueEnds[index] ?? -1
+    if (resourceOpaqueEnd >= 0) {
       backslashRun = 0
+      index = resourceOpaqueEnd - 1
       continue
     }
     while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
@@ -444,16 +476,9 @@ const prepareMarkdownSource = (
     } else if (character === "(") {
       parentheses.push(index)
       if (candidateByOpening.has(index)) {
-        let destinationStart = index + 1
-        while (
-          source[destinationStart] === " " ||
-          source[destinationStart] === "\t" ||
-          source[destinationStart] === "\n" ||
-          source[destinationStart] === "\r"
-        ) {
-          destinationStart++
+        for (const range of resourceOpaqueRanges(source, index)) {
+          resourceOpaqueEnds[range.start] = range.end
         }
-        resourceAngleEnd = angleEnds[destinationStart] ?? -1
       }
     } else if (character === ")") {
       const opening = parentheses.pop()
@@ -597,21 +622,38 @@ export function blankMarkdownDestinations(
   const delimiterSource = delimiterCharacters.join("")
   const preparedSource = prepareMarkdownSource(source, delimiterSource, opaqueInlineRanges)
   const events = markdownEvents(preparedSource.value)
+  const contentColumns = new Int32Array(parseLines.length).fill(1)
+  for (const [phase, token] of events) {
+    if (
+      phase === "enter" &&
+      (token.type === "blockQuotePrefix" ||
+        token.type === "listItemPrefix" ||
+        token.type === "listItemIndent")
+    ) {
+      const lineIndex = token.start.line - 1
+      contentColumns[lineIndex] = Math.max(
+        contentColumns[lineIndex] ?? 1,
+        token.end.column,
+      )
+    }
+  }
+
   const definitionMaskEnds = new Map<number, number>()
   let activeDefinitionStart: number | undefined
   let activeDefinitionLine = 0
-  let activeDefinitionColumn = 0
+  let activeDefinitionContentColumn = 1
   for (const [phase, token] of events) {
     if (phase === "enter" && token.type === "definition") {
       activeDefinitionStart = token.start.offset
       activeDefinitionLine = token.start.line
-      activeDefinitionColumn = token.start.column
+      activeDefinitionContentColumn = contentColumns[token.start.line - 1] ?? 1
     } else if (
       phase === "enter" &&
       token.type === "definitionTitle" &&
       activeDefinitionStart !== undefined &&
       token.start.line > activeDefinitionLine &&
-      token.start.column <= activeDefinitionColumn
+      token.start.column <=
+        Math.max(activeDefinitionContentColumn, contentColumns[token.start.line - 1] ?? 1)
     ) {
       definitionMaskEnds.set(activeDefinitionStart, token.start.offset)
     } else if (phase === "exit" && token.type === "definition") {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -317,6 +317,7 @@ const blankTextRange = (text: string[], start: number, end: number): void => {
 }
 
 interface ReferenceCandidate {
+  readonly image: boolean
   readonly imageLabelStart: number
   readonly imageLabelEnd: number
   readonly labelStart: number
@@ -329,7 +330,7 @@ interface ReferenceCandidate {
 interface BracketFrame {
   readonly opening: number
   readonly image: boolean
-  readonly imageDepth: number
+  readonly labelDepth: number
   readonly linkEpoch: number
   readonly referenceCandidate?: ReferenceCandidate
 }
@@ -638,11 +639,9 @@ const prepareMarkdownSource = (
   definedIdentifiers?: ReadonlySet<string>,
 ): PreparedMarkdownSource => {
   const brackets: BracketFrame[] = []
-  let imageDepth = 0
-  let imageOpenings = 0
   let opaqueRangeIndex = 0
   let backslashRun = 0
-  let needsDeepImageFallback = false
+  let needsDeepLabelFallback = false
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
@@ -672,22 +671,17 @@ const prepareMarkdownSource = (
         precedingBackslashes++
       }
       const image = source[index - 1] === "!" && precedingBackslashes % 2 === 0
-      if (image) {
-        imageDepth++
-        imageOpenings++
-      }
-      brackets.push({ opening: index, image, imageDepth, linkEpoch: 0 })
-      if (imageOpenings > 32) {
-        needsDeepImageFallback = true
+      brackets.push({ opening: index, image, labelDepth: brackets.length + 1, linkEpoch: 0 })
+      if (brackets.length > 32) {
+        needsDeepLabelFallback = true
         break
       }
     } else if (character === "]") {
-      const frame = brackets.pop()
-      if (frame?.image) imageDepth--
+      brackets.pop()
     }
   }
 
-  if (!needsDeepImageFallback) {
+  if (!needsDeepLabelFallback) {
     return { value: boundCdataMarkers(source), resourceCandidates: [], referenceCandidates: [] }
   }
 
@@ -699,7 +693,6 @@ const prepareMarkdownSource = (
   const resourceCandidates: ResourceCandidate[] = []
   const referenceCandidates: ReferenceCandidate[] = []
   brackets.length = 0
-  imageDepth = 0
   opaqueRangeIndex = 0
 
   for (let index = 0; index < source.length; index++) {
@@ -719,11 +712,10 @@ const prepareMarkdownSource = (
       const parentReference = brackets.at(-1)?.referenceCandidate
       if (parentReference !== undefined) parentReference.valid = false
       const image = source[index - 1] === "!" && escaped[index - 1] === 0
-      if (image) imageDepth++
       brackets.push({
         opening: index,
         image,
-        imageDepth,
+        labelDepth: brackets.length + 1,
         linkEpoch,
         referenceCandidate: referenceCandidateByOpening.get(index),
       })
@@ -746,14 +738,17 @@ const prepareMarkdownSource = (
             definedIdentifiers?.has(candidate.identifier)
           ) {
             blankTextRange(characters, candidate.sourceStart, candidate.sourceEnd)
+            if (!candidate.image) linkEpoch++
           }
         }
       } else if (frame !== undefined) {
-        if (frame.image && frame.imageDepth > 32) {
-          characters[frame.opening] = "x"
-          characters[index] = "x"
+        const needsFallback = frame.labelDepth > 32
+        if (needsFallback) {
+          characters[frame.opening] = "^"
+          characters[index] = "^"
           if (source[index + 1] === "[") {
             const candidate = {
+              image: frame.image,
               imageLabelStart: frame.opening + 1,
               imageLabelEnd: index,
               labelStart: frame.opening,
@@ -769,7 +764,7 @@ const prepareMarkdownSource = (
           scanIndex ??= resourceScanIndex(source)
           const end = resourceEnd(source, index + 1, scanIndex)
           if (end >= 0) {
-            if (frame.image && frame.imageDepth > 32) {
+            if (needsFallback) {
               const candidate = {
                 labelStart: frame.opening,
                 sourceStart: index + 1,
@@ -777,15 +772,13 @@ const prepareMarkdownSource = (
               }
               resourceCandidates.push(candidate)
               blankTextRange(characters, index + 1, end)
-            } else if (!frame.image) {
-              linkEpoch++
             }
+            if (!frame.image) linkEpoch++
             index = end - 1
-          } else if (frame.image && frame.imageDepth > 32) {
+          } else if (needsFallback) {
             resourceCandidates.push({ labelStart: frame.opening, sourceStart: index + 1 })
           }
         }
-        if (frame.image) imageDepth--
       }
     }
   }

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -338,6 +338,33 @@ interface PreparedMarkdownSource {
   readonly resourceCandidates: readonly ResourceCandidate[]
 }
 
+const angleDestinationEnds = (source: string): Int32Array => {
+  const ends = new Int32Array(source.length).fill(-1)
+  let opening = -1
+  let backslashRun = 0
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    if (character === "\\") {
+      backslashRun++
+      continue
+    }
+    const escaped = backslashRun % 2 !== 0
+    backslashRun = 0
+
+    if (character === "\n" || character === "\r") {
+      opening = -1
+    } else if (!escaped && character === "<") {
+      opening = index
+    } else if (!escaped && character === ">" && opening >= 0) {
+      ends[opening] = index + 1
+      opening = -1
+    }
+  }
+
+  return ends
+}
+
 const markdownEvents = (source: string) =>
   postprocess(parse().document().write(preprocess()(source, "utf8", true)))
 
@@ -368,12 +395,18 @@ const prepareMarkdownSource = (
   const parentheses: number[] = []
   const candidateByOpening = new Map<number, ResourceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
+  const angleEnds = angleDestinationEnds(source)
   let imageDepth = 0
   let backslashRun = 0
   let opaqueRangeIndex = 0
+  let resourceAngleEnd = -1
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
+    if (index < resourceAngleEnd) {
+      backslashRun = 0
+      continue
+    }
     while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
       opaqueRangeIndex++
     }
@@ -410,6 +443,18 @@ const prepareMarkdownSource = (
       }
     } else if (character === "(") {
       parentheses.push(index)
+      if (candidateByOpening.has(index)) {
+        let destinationStart = index + 1
+        while (
+          source[destinationStart] === " " ||
+          source[destinationStart] === "\t" ||
+          source[destinationStart] === "\n" ||
+          source[destinationStart] === "\r"
+        ) {
+          destinationStart++
+        }
+        resourceAngleEnd = angleEnds[destinationStart] ?? -1
+      }
     } else if (character === ")") {
       const opening = parentheses.pop()
       if (opening !== undefined) {
@@ -555,24 +600,18 @@ export function blankMarkdownDestinations(
   const definitionMaskEnds = new Map<number, number>()
   let activeDefinitionStart: number | undefined
   let activeDefinitionLine = 0
-  let indentedDefinitionLine = 0
+  let activeDefinitionColumn = 0
   for (const [phase, token] of events) {
     if (phase === "enter" && token.type === "definition") {
       activeDefinitionStart = token.start.offset
       activeDefinitionLine = token.start.line
-      indentedDefinitionLine = 0
-    } else if (
-      phase === "enter" &&
-      token.type === "linePrefix" &&
-      activeDefinitionStart !== undefined
-    ) {
-      indentedDefinitionLine = token.start.line
+      activeDefinitionColumn = token.start.column
     } else if (
       phase === "enter" &&
       token.type === "definitionTitle" &&
       activeDefinitionStart !== undefined &&
       token.start.line > activeDefinitionLine &&
-      indentedDefinitionLine !== token.start.line
+      token.start.column <= activeDefinitionColumn
     ) {
       definitionMaskEnds.set(activeDefinitionStart, token.start.offset)
     } else if (phase === "exit" && token.type === "definition") {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -690,6 +690,17 @@ const opaqueInlineProbe = (source: string): string => {
       protectedEnd = end + 2
     } else if (boundedSource[index] === "<") {
       protectedEnd = nextGreater[index + 1] ?? -1
+      let keptOpening = false
+      let keptClosing = false
+      for (let delimiter = index + 1; delimiter < protectedEnd; delimiter++) {
+        if (boundedSource[delimiter] === "[") {
+          if (keptOpening) characters[delimiter] = "^"
+          keptOpening = true
+        } else if (boundedSource[delimiter] === "]") {
+          if (keptClosing) characters[delimiter] = "^"
+          keptClosing = true
+        }
+      }
     } else if (boundedSource[index] === "[" || boundedSource[index] === "]") {
       characters[index] = "^"
     }

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -280,6 +280,114 @@ const blankTextRange = (text: string[], start: number, end: number): void => {
   }
 }
 
+const isMarkdownWhitespace = (character: string | undefined): boolean =>
+  character === " " || character === "\t" || character === "\n" || character === "\r"
+
+const markdownWhitespaceEnd = (text: string, start: number): number | undefined => {
+  let index = start
+  let lineEndings = 0
+  while (index < text.length) {
+    const character = text[index]
+    if (character === " " || character === "\t") {
+      index++
+      continue
+    }
+    if (character !== "\n" && character !== "\r") break
+    lineEndings++
+    if (lineEndings > 1) return undefined
+    index += character === "\r" && text[index + 1] === "\n" ? 2 : 1
+  }
+  return index
+}
+
+const markdownLinkTitleEnd = (text: string, start: number): number | undefined => {
+  const opening = text[start]
+  const closing = opening === "(" ? ")" : opening
+  if (closing !== ")" && closing !== '"' && closing !== "'") return undefined
+
+  for (let index = start + 1; index < text.length; index++) {
+    const character = text[index]
+    if (character === "\\") {
+      index++
+      continue
+    }
+    if (character === closing) return index + 1
+    if (opening === "(" && character === "(") return undefined
+  }
+  return undefined
+}
+
+const markdownInlineLinkEnd = (text: string, opening: number): number | undefined => {
+  const destinationStart = markdownWhitespaceEnd(text, opening + 1)
+  if (destinationStart === undefined) return undefined
+  let index = destinationStart
+
+  if (text[index] === "<") {
+    let closed = false
+    for (index += 1; index < text.length; index++) {
+      const character = text[index]
+      if (character === "\\") {
+        index++
+        continue
+      }
+      if (character === "\n" || character === "<") return undefined
+      if (character === ">") {
+        index++
+        closed = true
+        break
+      }
+    }
+    if (!closed) return undefined
+  } else {
+    let depth = 0
+    while (index < text.length) {
+      const character = text[index]
+      if (character === "\\") {
+        index += 2
+        continue
+      }
+      if (character === "(") {
+        depth++
+        index++
+        continue
+      }
+      if (character === ")") {
+        if (depth === 0) return index
+        depth--
+        index++
+        continue
+      }
+      if (character === "<" || character === ">") return undefined
+      if (isMarkdownWhitespace(character)) break
+      index++
+    }
+    if (depth !== 0) return undefined
+  }
+
+  if (text[index] === ")") return index
+  const titleStart = markdownWhitespaceEnd(text, index)
+  if (titleStart === undefined || titleStart === index) return undefined
+  if (text[titleStart] === ")") return titleStart
+
+  const titleEnd = markdownLinkTitleEnd(text, titleStart)
+  if (titleEnd === undefined) return undefined
+  const linkEnd = markdownWhitespaceEnd(text, titleEnd)
+  return linkEnd !== undefined && text[linkEnd] === ")" ? linkEnd : undefined
+}
+
+const markdownReferenceEnd = (text: string, opening: number): number | undefined => {
+  for (let index = opening + 1; index < text.length; index++) {
+    const character = text[index]
+    if (character === "\\") {
+      index++
+      continue
+    }
+    if (character === "[" || character === "\n") return undefined
+    if (character === "]") return index
+  }
+  return undefined
+}
+
 export function blankMarkdownDestinations(lines: readonly string[]): string[] {
   const source = lines.join("\n")
   const blanked = source.split("")
@@ -288,27 +396,39 @@ export function blankMarkdownDestinations(lines: readonly string[]): string[] {
     blankTextRange(blanked, match.index, match.index + match[0].length)
   }
 
-  for (const match of source.matchAll(/\]\[[^\]\n]*\]/gu)) {
-    blankTextRange(blanked, match.index + 1, match.index + match[0].length)
-  }
-
-  // Link destinations can contain escaped and nested parentheses.
-  let opener = source.indexOf("](")
-  while (opener !== -1) {
-    let depth = 1
-    let index = opener + 2
-    while (index < source.length && depth > 0) {
-      if (source[index] === "\\") {
-        index += 2
-        continue
-      }
-      if (source[index] === "(") depth++
-      if (source[index] === ")") depth--
+  const labelOpeners: number[] = []
+  let lineStart = 0
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    if (character === "\\") {
       index++
+      continue
     }
-    if (depth === 0) blankTextRange(blanked, opener + 2, index - 1)
-    const nextStart = depth === 0 ? index : opener + 2
-    opener = source.indexOf("](", nextStart)
+    if (character === "\n") {
+      if (source.slice(lineStart, index).trim() === "") labelOpeners.length = 0
+      lineStart = index + 1
+      continue
+    }
+    if (character === "[") {
+      labelOpeners.push(index)
+      continue
+    }
+    if (character !== "]" || labelOpeners.pop() === undefined) continue
+
+    const suffixStart = index + 1
+    if (source[suffixStart] === "(") {
+      const linkEnd = markdownInlineLinkEnd(source, suffixStart)
+      if (linkEnd === undefined) continue
+      blankTextRange(blanked, suffixStart + 1, linkEnd)
+      index = linkEnd
+      continue
+    }
+    if (source[suffixStart] === "[") {
+      const referenceEnd = markdownReferenceEnd(source, suffixStart)
+      if (referenceEnd === undefined) continue
+      blankTextRange(blanked, suffixStart, referenceEnd + 1)
+      index = referenceEnd
+    }
   }
 
   for (const pattern of [

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -330,6 +330,7 @@ interface BracketFrame {
   readonly opening: number
   readonly image: boolean
   readonly imageDepth: number
+  readonly linkEpoch: number
   readonly referenceCandidate?: ReferenceCandidate
 }
 
@@ -638,6 +639,7 @@ const prepareMarkdownSource = (
 ): PreparedMarkdownSource => {
   const brackets: BracketFrame[] = []
   let imageDepth = 0
+  let imageOpenings = 0
   let opaqueRangeIndex = 0
   let backslashRun = 0
   let needsDeepImageFallback = false
@@ -670,17 +672,18 @@ const prepareMarkdownSource = (
         precedingBackslashes++
       }
       const image = source[index - 1] === "!" && precedingBackslashes % 2 === 0
-      if (image) imageDepth++
-      brackets.push({ opening: index, image, imageDepth })
+      if (image) {
+        imageDepth++
+        imageOpenings++
+      }
+      brackets.push({ opening: index, image, imageDepth, linkEpoch: 0 })
+      if (imageOpenings > 32) {
+        needsDeepImageFallback = true
+        break
+      }
     } else if (character === "]") {
       const frame = brackets.pop()
-      if (frame?.image) {
-        if (frame.imageDepth > 32) {
-          needsDeepImageFallback = true
-          break
-        }
-        imageDepth--
-      }
+      if (frame?.image) imageDepth--
     }
   }
 
@@ -691,7 +694,7 @@ const prepareMarkdownSource = (
   const characters = boundCdataMarkers(source).split("")
   const escaped = escapedCharacters(source)
   let scanIndex: ResourceScanIndex | undefined
-  const resourceCandidateByOpening = new Map<number, ResourceCandidate>()
+  let linkEpoch = 0
   const referenceCandidateByOpening = new Map<number, ReferenceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
   const referenceCandidates: ReferenceCandidate[] = []
@@ -721,6 +724,7 @@ const prepareMarkdownSource = (
         opening: index,
         image,
         imageDepth,
+        linkEpoch,
         referenceCandidate: referenceCandidateByOpening.get(index),
       })
     } else if (character === "]") {
@@ -744,15 +748,11 @@ const prepareMarkdownSource = (
             blankTextRange(characters, candidate.sourceStart, candidate.sourceEnd)
           }
         }
-      } else if (frame?.image) {
-        if (frame.imageDepth > 32) {
+      } else if (frame !== undefined) {
+        if (frame.image && frame.imageDepth > 32) {
           characters[frame.opening] = "x"
           characters[index] = "x"
-          if (source[index + 1] === "(") {
-            const candidate = { labelStart: frame.opening, sourceStart: index + 1 }
-            resourceCandidateByOpening.set(index + 1, candidate)
-            resourceCandidates.push(candidate)
-          } else if (source[index + 1] === "[") {
+          if (source[index + 1] === "[") {
             const candidate = {
               imageLabelStart: frame.opening + 1,
               imageLabelEnd: index,
@@ -764,18 +764,28 @@ const prepareMarkdownSource = (
             referenceCandidates.push(candidate)
           }
         }
-        imageDepth--
-      }
-    } else if (character === "(") {
-      const candidate = resourceCandidateByOpening.get(index)
-      if (candidate !== undefined) {
-        scanIndex ??= resourceScanIndex(source)
-        const end = resourceEnd(source, index, scanIndex)
-        if (end >= 0) {
-          candidate.sourceEnd = end
-          blankTextRange(characters, index, end)
-          index = end - 1
+
+        if (source[index + 1] === "(" && (frame.image || frame.linkEpoch === linkEpoch)) {
+          scanIndex ??= resourceScanIndex(source)
+          const end = resourceEnd(source, index + 1, scanIndex)
+          if (end >= 0) {
+            if (frame.image && frame.imageDepth > 32) {
+              const candidate = {
+                labelStart: frame.opening,
+                sourceStart: index + 1,
+                sourceEnd: end,
+              }
+              resourceCandidates.push(candidate)
+              blankTextRange(characters, index + 1, end)
+            } else if (!frame.image) {
+              linkEpoch++
+            }
+            index = end - 1
+          } else if (frame.image && frame.imageDepth > 32) {
+            resourceCandidates.push({ labelStart: frame.opening, sourceStart: index + 1 })
+          }
         }
+        if (frame.image) imageDepth--
       }
     }
   }
@@ -786,7 +796,7 @@ const prepareMarkdownSource = (
 const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
 const OPAQUE_INLINE_TOKENS = new Set(["autolink", "codeText", "htmlText"])
 const HTML_FLOW_SYNTAX_TOKENS = new Set(["characterReference", "htmlText"])
-const RAW_HTML_FLOW_START = /^ {0,3}<(?:pre|script|style|textarea)(?:[\t\n\f />]|$)/iu
+const RAW_HTML_FLOW_START = /^ {0,3}<(?:pre|script|style|textarea)(?:[\t\n\r\f >]|$)/iu
 
 const tokenRanges = (
   events: ReturnType<typeof markdownEvents>,

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -846,16 +846,9 @@ const prepareMarkdownSource = (
         if (candidate.valid) {
           candidate.identifier =
             frame.opening + 1 === index
-              ? normalizeIdentifierRange(
-                  source,
-                  candidate.imageLabelStart,
-                  candidate.imageLabelEnd,
-                )
+              ? normalizeIdentifierRange(source, candidate.imageLabelStart, candidate.imageLabelEnd)
               : normalizeIdentifierRange(source, frame.opening + 1, index)
-          if (
-            candidate.identifier !== undefined &&
-            definedIdentifiers?.has(candidate.identifier)
-          ) {
+          if (candidate.identifier !== undefined && definedIdentifiers?.has(candidate.identifier)) {
             blankTextRange(characters, candidate.sourceStart, candidate.sourceEnd)
             if (!candidate.image) linkEpoch++
           }
@@ -901,9 +894,7 @@ const prepareMarkdownSource = (
           !frame.image &&
           frame.linkEpoch === linkEpoch &&
           source[index + 1] !== "[" &&
-          definedIdentifiers?.has(
-            normalizeIdentifierRange(source, frame.opening + 1, index) ?? "",
-          )
+          definedIdentifiers?.has(normalizeIdentifierRange(source, frame.opening + 1, index) ?? "")
         ) {
           linkEpoch++
         }
@@ -1011,11 +1002,7 @@ const referenceIdentifier = (
 
     const identifier =
       index === contentStart
-        ? normalizeIdentifierRange(
-            source,
-            candidate.imageLabelStart,
-            candidate.imageLabelEnd,
-          )
+        ? normalizeIdentifierRange(source, candidate.imageLabelStart, candidate.imageLabelEnd)
         : normalizeIdentifierRange(source, contentStart, index)
     return identifier === undefined ? undefined : { identifier, end: index + 1 }
   }
@@ -1181,7 +1168,10 @@ export function blankMarkdownDestinations(
     tokenRanges(events, INLINE_BLOCK_TOKENS),
     definedIdentifiers,
   )
-  if (resolvedReferenceRanges.length > 0 || (preparedSource.deepFallback && definedIdentifiers.size > 0)) {
+  if (
+    resolvedReferenceRanges.length > 0 ||
+    (preparedSource.deepFallback && definedIdentifiers.size > 0)
+  ) {
     syntaxRanges = syntaxRangesFor(blankRanges(source, resolvedReferenceRanges))
     opaqueInlineRanges = syntaxRanges.opaqueInlineRanges
     preparedSource = prepareMarkdownSource(

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -544,11 +544,24 @@ const markdownTextEvents = (source: string) =>
 
 const opaqueInlineProbe = (source: string): string => {
   const characters = source.split("")
+  const nextGreater = new Int32Array(source.length + 1).fill(-1)
+  let greater = -1
+  for (let index = source.length - 1; index >= 0; index--) {
+    if (source[index] === ">") greater = index
+    nextGreater[index] = greater
+  }
+
+  let protectedEnd = -1
   for (let index = 0; index < source.length; index++) {
     if (source.startsWith("<![CDATA[", index)) {
       const end = source.indexOf("]]>", index + 9)
-      index = end < 0 ? source.length : end + 2
-    } else if (source[index] === "[" || source[index] === "]") {
+      protectedEnd = end < 0 ? source.length : end + 2
+    } else if (source[index] === "<" && index > protectedEnd) {
+      protectedEnd = nextGreater[index + 1] ?? -1
+    } else if (
+      index > protectedEnd &&
+      (source[index] === "[" || source[index] === "]")
+    ) {
       characters[index] = "^"
     }
   }
@@ -617,6 +630,7 @@ const prepareMarkdownSource = (
 const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
 const OPAQUE_INLINE_TOKENS = new Set(["autolink", "codeText", "htmlText"])
 const HTML_FLOW_SYNTAX_TOKENS = new Set(["characterReference", "htmlText"])
+const RAW_HTML_FLOW_START = /^ {0,3}<(?:pre|script|style|textarea)(?:[\t\n\f />]|$)/iu
 
 const tokenRanges = (
   events: ReturnType<typeof markdownEvents>,
@@ -639,7 +653,12 @@ const htmlFlowSyntaxRanges = (
   for (const [phase, token] of events) {
     if (phase !== "enter" || token.type !== "htmlFlow") continue
     const start = token.start.offset
-    const flowSource = source.slice(start, token.end.offset)
+    const end = token.end.offset
+    const flowSource = source.slice(start, end)
+    if (RAW_HTML_FLOW_START.test(flowSource)) {
+      ranges.push({ start, end })
+      continue
+    }
     for (const range of tokenRanges(
       markdownTextEvents(opaqueInlineProbe(flowSource)),
       HTML_FLOW_SYNTAX_TOKENS,

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -274,6 +274,55 @@ export function maskMarkdownCode(text: string): string {
   return blankMarkdownCode(text.split("\n")).join("\n")
 }
 
+const blankTextRange = (text: string[], start: number, end: number): void => {
+  for (let index = start; index < end; index++) {
+    if (text[index] !== "\n") text[index] = " "
+  }
+}
+
+export function blankMarkdownDestinations(lines: readonly string[]): string[] {
+  const source = lines.join("\n")
+  const blanked = source.split("")
+
+  for (const match of source.matchAll(/^ {0,3}\[[^\]\n]+\]:[^\n]*$/gmu)) {
+    blankTextRange(blanked, match.index, match.index + match[0].length)
+  }
+
+  for (const match of source.matchAll(/\]\[[^\]\n]*\]/gu)) {
+    blankTextRange(blanked, match.index + 1, match.index + match[0].length)
+  }
+
+  // Link destinations can contain escaped and nested parentheses.
+  let opener = source.indexOf("](")
+  while (opener !== -1) {
+    let depth = 1
+    let index = opener + 2
+    while (index < source.length && depth > 0) {
+      if (source[index] === "\\") {
+        index += 2
+        continue
+      }
+      if (source[index] === "(") depth++
+      if (source[index] === ")") depth--
+      index++
+    }
+    if (depth === 0) blankTextRange(blanked, opener + 2, index - 1)
+    const nextStart = depth === 0 ? index : opener + 2
+    opener = source.indexOf("](", nextStart)
+  }
+
+  for (const pattern of [
+    /<(?:[A-Za-z][A-Za-z0-9+.-]{1,31}:[^<>\s]*|[^<>\s@]+@[^<>\s@]+)>/gu,
+    /\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<]+/gu,
+  ]) {
+    for (const match of source.matchAll(pattern)) {
+      blankTextRange(blanked, match.index, match.index + match[0].length)
+    }
+  }
+
+  return blanked.join("").split("\n")
+}
+
 interface InlineBacktickRun {
   readonly start: number
   readonly length: number

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -282,6 +282,8 @@ const MASKED_MARKDOWN_TOKENS = new Set([
   "codeFenced",
   "codeIndented",
   "codeText",
+  "characterReference",
+  "htmlText",
   "listItemPrefix",
   "reference",
   "resource",
@@ -339,9 +341,24 @@ interface PreparedMarkdownSource {
 const markdownEvents = (source: string) =>
   postprocess(parse().document().write(preprocess()(source, "utf8", true)))
 
+const opaqueInlineProbe = (source: string): string => {
+  const characters = source.split("")
+  for (let index = 1; index < source.length; index++) {
+    if (
+      source[index] === "[" &&
+      source[index - 1] === "!" &&
+      !source.startsWith("<![CDATA[", index - 2)
+    ) {
+      characters[index] = "x"
+    }
+  }
+  return characters.join("")
+}
+
 const prepareMarkdownSource = (
   source: string,
   delimiterSource: string,
+  opaqueInlineRanges: readonly SourceRange[],
 ): PreparedMarkdownSource => {
   const characters = source.split("")
   const escaped = new Uint8Array(source.length)
@@ -351,9 +368,19 @@ const prepareMarkdownSource = (
   const resourceCandidates: ResourceCandidate[] = []
   let imageDepth = 0
   let backslashRun = 0
+  let opaqueRangeIndex = 0
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
+    while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
+      opaqueRangeIndex++
+    }
+    const opaqueRange = opaqueInlineRanges[opaqueRangeIndex]
+    if (opaqueRange !== undefined && index >= opaqueRange.start) {
+      backslashRun = 0
+      index = opaqueRange.end - 1
+      continue
+    }
     if (delimiterSource[index] !== character && "[]()".includes(character ?? "")) continue
     if (character === "\\") {
       backslashRun++
@@ -497,7 +524,11 @@ export function blankMarkdownDestinations(
   const delimiterSource = blankMarkdownCode(lines, contentStarts)
     .map((line, index) => line.slice(Math.min(contentStarts[index] ?? 0, line.length)))
     .join("\n")
-  const preparedSource = prepareMarkdownSource(source, delimiterSource)
+  const opaqueInlineRanges = tokenRanges(
+    markdownEvents(opaqueInlineProbe(delimiterSource)),
+    OPAQUE_INLINE_TOKENS,
+  )
+  const preparedSource = prepareMarkdownSource(source, delimiterSource, opaqueInlineRanges)
   const events = markdownEvents(preparedSource.value)
   const definitionMaskEnds = new Map<number, number>()
   let activeDefinitionStart: number | undefined
@@ -543,7 +574,7 @@ export function blankMarkdownDestinations(
     source,
     preparedSource.resourceCandidates,
     tokenRanges(events, INLINE_BLOCK_TOKENS),
-    tokenRanges(events, OPAQUE_INLINE_TOKENS),
+    opaqueInlineRanges,
   )) {
     blankSourceRange(range.start, range.end)
   }

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -543,6 +543,8 @@ const markdownTextEvents = (source: string) =>
   )
 
 const boundCdataMarkers = (source: string): string => {
+  if (!source.includes("<![CDATA[")) return source
+
   const characters = source.split("")
   let protectedEnd = -1
 
@@ -590,14 +592,66 @@ const prepareMarkdownSource = (
   delimiterSource: string,
   opaqueInlineRanges: readonly SourceRange[],
 ): PreparedMarkdownSource => {
+  const brackets: BracketFrame[] = []
+  let imageDepth = 0
+  let opaqueRangeIndex = 0
+  let backslashRun = 0
+  let needsResourceIndex = false
+
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
+      opaqueRangeIndex++
+    }
+    const opaqueRange = opaqueInlineRanges[opaqueRangeIndex]
+    if (opaqueRange !== undefined && index >= opaqueRange.start) {
+      index = opaqueRange.end - 1
+      backslashRun = 0
+      continue
+    }
+
+    const escaped = backslashRun % 2 !== 0
+    if (character === "\\") {
+      backslashRun++
+      continue
+    }
+    backslashRun = 0
+
+    if (delimiterSource[index] !== character && "[]()".includes(character ?? "")) continue
+    if (escaped) continue
+
+    if (character === "[") {
+      let precedingBackslashes = 0
+      for (let previous = index - 2; previous >= 0 && source[previous] === "\\"; previous--) {
+        precedingBackslashes++
+      }
+      const image = source[index - 1] === "!" && precedingBackslashes % 2 === 0
+      if (image) imageDepth++
+      brackets.push({ opening: index, image, imageDepth })
+    } else if (character === "]") {
+      const frame = brackets.pop()
+      if (frame?.image) {
+        if (frame.imageDepth > 32 && source[index + 1] === "(") {
+          needsResourceIndex = true
+          break
+        }
+        imageDepth--
+      }
+    }
+  }
+
+  if (!needsResourceIndex) {
+    return { value: boundCdataMarkers(source), resourceCandidates: [] }
+  }
+
   const characters = boundCdataMarkers(source).split("")
   const scanIndex = resourceScanIndex(source)
   const escaped = scanIndex.escaped
-  const brackets: BracketFrame[] = []
   const candidateByOpening = new Map<number, ResourceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
-  let imageDepth = 0
-  let opaqueRangeIndex = 0
+  brackets.length = 0
+  imageDepth = 0
+  opaqueRangeIndex = 0
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -390,11 +390,15 @@ const prepareMarkdownSource = (source: string): PreparedMarkdownSource => {
 }
 
 const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
+const OPAQUE_INLINE_TOKENS = new Set(["autolink", "codeText", "htmlText"])
 
-const inlineBlockRanges = (events: ReturnType<typeof markdownEvents>): readonly SourceRange[] => {
+const tokenRanges = (
+  events: ReturnType<typeof markdownEvents>,
+  tokenTypes: ReadonlySet<string>,
+): readonly SourceRange[] => {
   const ranges: SourceRange[] = []
   for (const [phase, token] of events) {
-    if (phase === "enter" && INLINE_BLOCK_TOKENS.has(token.type)) {
+    if (phase === "enter" && tokenTypes.has(token.type)) {
       ranges.push({ start: token.start.offset, end: token.end.offset })
     }
   }
@@ -417,6 +421,7 @@ const fallbackResourceRanges = (
   source: string,
   candidates: readonly ResourceCandidate[],
   inlineBlocks: readonly SourceRange[],
+  opaqueInlineRanges: readonly SourceRange[],
 ): readonly SourceRange[] => {
   const chunks: string[] = []
   const segments = new Map<number, { sourceStart: number; syntheticEnd: number }>()
@@ -428,7 +433,8 @@ const fallbackResourceRanges = (
     if (
       inlineBlock === undefined ||
       candidate.sourceStart < inlineBlock.start ||
-      candidate.sourceEnd > inlineBlock.end
+      candidate.sourceEnd > inlineBlock.end ||
+      rangeContaining(opaqueInlineRanges, candidate.labelStart) !== undefined
     ) {
       continue
     }
@@ -529,13 +535,10 @@ export function blankMarkdownDestinations(
   for (const range of fallbackResourceRanges(
     source,
     preparedSource.resourceCandidates,
-    inlineBlockRanges(events),
+    tokenRanges(events, INLINE_BLOCK_TOKENS),
+    tokenRanges(events, OPAQUE_INLINE_TOKENS),
   )) {
     blankSourceRange(range.start, range.end)
-  }
-
-  for (const match of source.matchAll(/\b[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s<]+/gu)) {
-    blankSourceRange(match.index, match.index + match[0].length)
   }
 
   return blanked.join("").split("\n")

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -339,7 +339,10 @@ interface PreparedMarkdownSource {
 const markdownEvents = (source: string) =>
   postprocess(parse().document().write(preprocess()(source, "utf8", true)))
 
-const prepareMarkdownSource = (source: string): PreparedMarkdownSource => {
+const prepareMarkdownSource = (
+  source: string,
+  delimiterSource: string,
+): PreparedMarkdownSource => {
   const characters = source.split("")
   const escaped = new Uint8Array(source.length)
   const brackets: BracketFrame[] = []
@@ -351,6 +354,7 @@ const prepareMarkdownSource = (source: string): PreparedMarkdownSource => {
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
+    if (delimiterSource[index] !== character && "[]()".includes(character ?? "")) continue
     if (character === "\\") {
       backslashRun++
       continue
@@ -490,7 +494,10 @@ export function blankMarkdownDestinations(
     blankTextRange(blanked, outputOffset(start), outputOffset(end))
   }
 
-  const preparedSource = prepareMarkdownSource(source)
+  const delimiterSource = blankMarkdownCode(lines, contentStarts)
+    .map((line, index) => line.slice(Math.min(contentStarts[index] ?? 0, line.length)))
+    .join("\n")
+  const preparedSource = prepareMarkdownSource(source, delimiterSource)
   const events = markdownEvents(preparedSource.value)
   const definitionMaskEnds = new Map<number, number>()
   let activeDefinitionStart: number | undefined

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -321,8 +321,14 @@ interface BracketFrame {
 }
 
 interface ResourceCandidate {
+  readonly labelStart: number
   readonly sourceStart: number
   sourceEnd?: number
+}
+
+interface SourceRange {
+  readonly start: number
+  readonly end: number
 }
 
 interface PreparedMarkdownSource {
@@ -363,7 +369,7 @@ const prepareMarkdownSource = (source: string): PreparedMarkdownSource => {
         if (frame.imageDepth > 32 && source[index + 1] === "(") {
           characters[frame.opening] = "x"
           characters[index] = "x"
-          const candidate = { sourceStart: index + 1 }
+          const candidate = { labelStart: frame.opening, sourceStart: index + 1 }
           candidateByOpening.set(index + 1, candidate)
           resourceCandidates.push(candidate)
         }
@@ -380,20 +386,52 @@ const prepareMarkdownSource = (source: string): PreparedMarkdownSource => {
     }
   }
 
-  for (const opening of parentheses) characters[opening] = "x"
   return { value: characters.join(""), resourceCandidates }
+}
+
+const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
+
+const inlineBlockRanges = (events: ReturnType<typeof markdownEvents>): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  for (const [phase, token] of events) {
+    if (phase === "enter" && INLINE_BLOCK_TOKENS.has(token.type)) {
+      ranges.push({ start: token.start.offset, end: token.end.offset })
+    }
+  }
+  return ranges
+}
+
+const rangeContaining = (ranges: readonly SourceRange[], offset: number): SourceRange | undefined => {
+  let low = 0
+  let high = ranges.length
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2)
+    if ((ranges[middle]?.start ?? Number.POSITIVE_INFINITY) <= offset) low = middle + 1
+    else high = middle
+  }
+  const range = ranges[low - 1]
+  return range !== undefined && offset < range.end ? range : undefined
 }
 
 const fallbackResourceRanges = (
   source: string,
   candidates: readonly ResourceCandidate[],
-): readonly { start: number; end: number }[] => {
+  inlineBlocks: readonly SourceRange[],
+): readonly SourceRange[] => {
   const chunks: string[] = []
   const segments = new Map<number, { sourceStart: number; syntheticEnd: number }>()
   let syntheticOffset = 0
 
   for (const candidate of candidates) {
     if (candidate.sourceEnd === undefined) continue
+    const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
+    if (
+      inlineBlock === undefined ||
+      candidate.sourceStart < inlineBlock.start ||
+      candidate.sourceEnd > inlineBlock.end
+    ) {
+      continue
+    }
     const resource = source.slice(candidate.sourceStart, candidate.sourceEnd)
     const syntheticStart = syntheticOffset + 3
     chunks.push(`[x]${resource}\n\n`)
@@ -488,7 +526,11 @@ export function blankMarkdownDestinations(
     }
   }
 
-  for (const range of fallbackResourceRanges(source, preparedSource.resourceCandidates)) {
+  for (const range of fallbackResourceRanges(
+    source,
+    preparedSource.resourceCandidates,
+    inlineBlockRanges(events),
+  )) {
     blankSourceRange(range.start, range.end)
   }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -2,6 +2,8 @@ const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
 const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 const INDENTED = /^(?: {4,}|\t)/
 const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
+const SETEXT_UNDERLINE = /^ {0,3}(?:=+|-+)[ \t]*\r?$/
+const THEMATIC_BREAK = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})\r?$/
 const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])(?:([ \t]{1,4})(?![ \t])|[ \t])/
 
 const blankLine = (line: string): string => " ".repeat(line.length)
@@ -161,6 +163,8 @@ export interface MarkdownCodeResult {
   readonly lines: string[]
   readonly structuralLines: string[]
   readonly structuralBlanks: boolean[]
+  readonly contentStarts: number[]
+  readonly canStartDefinitions: boolean[]
 }
 
 export function blankMarkdownCodeWithStructure(
@@ -170,10 +174,14 @@ export function blankMarkdownCodeWithStructure(
   let fence: FenceState | null = null
   let activeList: Container | null = null
   let paragraphCanContinue = false
+  let definitionParagraphOpen = false
+  let definitionParagraphContainer: Container | null = null
   let inIndented = false
   const inlineEligible: boolean[] = []
   const structuralLines: string[] = []
   const structuralBlanks: boolean[] = []
+  const markdownContentStarts: number[] = []
+  const canStartDefinitions: boolean[] = []
   const lines = inputLines.map((line, index) => {
     const contentStart = contentStarts[index] ?? 0
 
@@ -188,15 +196,23 @@ export function blankMarkdownCodeWithStructure(
         inlineEligible.push(false)
         structuralLines.push(blankLine(line))
         structuralBlanks.push(true)
+        markdownContentStarts.push(line.length)
+        canStartDefinitions.push(false)
+        definitionParagraphOpen = false
+        definitionParagraphContainer = null
         return blankLine(line)
       }
       fence = null
       paragraphCanContinue = false
+      definitionParagraphOpen = false
+      definitionParagraphContainer = null
       inIndented = false
     }
 
     let content = markdownContent(line, contentStart)
-    if (content.container.listIndent > 0) {
+    const startsListItem = content.container.listIndent > 0
+    const explicitContainer = content.container
+    if (startsListItem) {
       activeList = content.container
     } else if (content.text.trim() !== "" && activeList !== null) {
       const continued = contentWithin(line, contentStart, activeList)
@@ -216,25 +232,54 @@ export function blankMarkdownCodeWithStructure(
       inlineEligible.push(false)
       structuralLines.push(blankLine(line))
       structuralBlanks.push(true)
+      markdownContentStarts.push(line.length)
+      canStartDefinitions.push(false)
+      definitionParagraphOpen = false
+      definitionParagraphContainer = null
       return blankLine(line)
     }
     if (content.text.trim() === "") {
       paragraphCanContinue = false
+      definitionParagraphOpen = false
+      definitionParagraphContainer = null
       inIndented = false
       inlineEligible.push(false)
       structuralLines.push(line)
       structuralBlanks.push(true)
+      markdownContentStarts.push(content.start)
+      canStartDefinitions.push(false)
       return visibleLine
     }
     if (INDENTED.test(content.text) && (!paragraphCanContinue || inIndented)) {
       paragraphCanContinue = false
+      definitionParagraphOpen = false
+      definitionParagraphContainer = null
       inIndented = true
       inlineEligible.push(false)
       structuralLines.push(blankLine(line))
       structuralBlanks.push(true)
+      markdownContentStarts.push(line.length)
+      canStartDefinitions.push(false)
       return blankLine(line)
     }
+
+    const blockBoundary =
+      ATX_HEADING.test(content.text) ||
+      SETEXT_UNDERLINE.test(content.text) ||
+      THEMATIC_BREAK.test(content.text)
+    const startsNewContainer =
+      startsListItem ||
+      (explicitContainer.quoteDepth > 0 &&
+        (definitionParagraphContainer === null ||
+          explicitContainer.quoteDepth !== definitionParagraphContainer.quoteDepth ||
+          explicitContainer.listIndent !== definitionParagraphContainer.listIndent))
+    markdownContentStarts.push(content.start)
+    canStartDefinitions.push(
+      !blockBoundary && (!definitionParagraphOpen || startsNewContainer),
+    )
     paragraphCanContinue = !ATX_HEADING.test(content.text)
+    definitionParagraphOpen = !blockBoundary
+    definitionParagraphContainer = blockBoundary ? null : content.container
     inIndented = false
     inlineEligible.push(true)
     structuralLines.push(line)
@@ -260,7 +305,13 @@ export function blankMarkdownCodeWithStructure(
   blankEligibleInlineCode(lines)
   blankEligibleInlineCode(structuralLines)
 
-  return { lines, structuralLines, structuralBlanks }
+  return {
+    lines,
+    structuralLines,
+    structuralBlanks,
+    contentStarts: markdownContentStarts,
+    canStartDefinitions,
+  }
 }
 
 export function blankMarkdownCode(
@@ -280,155 +331,484 @@ const blankTextRange = (text: string[], start: number, end: number): void => {
   }
 }
 
-const isMarkdownWhitespace = (character: string | undefined): boolean =>
-  character === " " || character === "\t" || character === "\n" || character === "\r"
-
-const markdownWhitespaceEnd = (text: string, start: number): number | undefined => {
-  let index = start
-  let lineEndings = 0
-  while (index < text.length) {
-    const character = text[index]
-    if (character === " " || character === "\t") {
-      index++
-      continue
-    }
-    if (character !== "\n" && character !== "\r") break
-    lineEndings++
-    if (lineEndings > 1) return undefined
-    index += character === "\r" && text[index + 1] === "\n" ? 2 : 1
-  }
-  return index
+interface DelimiterFrame {
+  readonly opening: number
+  nested: boolean
 }
 
-const markdownLinkTitleEnd = (text: string, start: number): number | undefined => {
-  const opening = text[start]
-  const closing = opening === "(" ? ")" : opening
-  if (closing !== ")" && closing !== '"' && closing !== "'") return undefined
-
-  for (let index = start + 1; index < text.length; index++) {
-    const character = text[index]
-    if (character === "\\") {
-      index++
-      continue
-    }
-    if (character === closing) return index + 1
-    if (opening === "(" && character === "(") return undefined
-  }
-  return undefined
+interface MarkdownSyntaxIndex {
+  readonly escaped: Uint8Array
+  readonly parenthesisEnds: Int32Array
+  readonly bracketEnds: Int32Array
+  readonly bracketStarts: Int32Array
+  readonly bracketParents: Int32Array
+  readonly bareDestinationEnds: Int32Array
+  readonly horizontalWhitespaceEnds: Int32Array
+  readonly nextAngleSpecials: Int32Array
+  readonly nextDoubleQuotes: Int32Array
+  readonly nextSingleQuotes: Int32Array
+  readonly blankLineStarts: readonly number[]
 }
 
-const markdownInlineLinkEnd = (text: string, opening: number): number | undefined => {
-  const destinationStart = markdownWhitespaceEnd(text, opening + 1)
-  if (destinationStart === undefined) return undefined
-  let index = destinationStart
-
-  if (text[index] === "<") {
-    let closed = false
-    for (index += 1; index < text.length; index++) {
-      const character = text[index]
-      if (character === "\\") {
-        index++
-        continue
-      }
-      if (character === "\n" || character === "<") return undefined
-      if (character === ">") {
-        index++
-        closed = true
-        break
-      }
-    }
-    if (!closed) return undefined
-  } else {
-    let depth = 0
-    while (index < text.length) {
-      const character = text[index]
-      if (character === "\\") {
-        index += 2
-        continue
-      }
-      if (character === "(") {
-        depth++
-        index++
-        continue
-      }
-      if (character === ")") {
-        if (depth === 0) return index
-        depth--
-        index++
-        continue
-      }
-      if (character === "<" || character === ">") return undefined
-      if (isMarkdownWhitespace(character)) break
-      index++
-    }
-    if (depth !== 0) return undefined
-  }
-
-  if (text[index] === ")") return index
-  const titleStart = markdownWhitespaceEnd(text, index)
-  if (titleStart === undefined || titleStart === index) return undefined
-  if (text[titleStart] === ")") return titleStart
-
-  const titleEnd = markdownLinkTitleEnd(text, titleStart)
-  if (titleEnd === undefined) return undefined
-  const linkEnd = markdownWhitespaceEnd(text, titleEnd)
-  return linkEnd !== undefined && text[linkEnd] === ")" ? linkEnd : undefined
+interface ReferenceDefinition {
+  readonly label: string
+  readonly start: number
+  readonly end: number
 }
 
-const markdownReferenceEnd = (text: string, opening: number): number | undefined => {
-  for (let index = opening + 1; index < text.length; index++) {
-    const character = text[index]
-    if (character === "\\") {
-      index++
-      continue
-    }
-    if (character === "[" || character === "\n") return undefined
-    if (character === "]") return index
-  }
-  return undefined
+const isAsciiPunctuation = (character: string | undefined): boolean => {
+  if (character === undefined) return false
+  const code = character.charCodeAt(0)
+  return (
+    (code >= 0x21 && code <= 0x2f) ||
+    (code >= 0x3a && code <= 0x40) ||
+    (code >= 0x5b && code <= 0x60) ||
+    (code >= 0x7b && code <= 0x7e)
+  )
 }
 
-export function blankMarkdownDestinations(lines: readonly string[]): string[] {
-  const source = lines.join("\n")
-  const blanked = source.split("")
+const encodedPairEnd = (value: number | undefined): number | undefined =>
+  value === undefined || value === 0 ? undefined : Math.abs(value) - 1
 
-  for (const match of source.matchAll(/^ {0,3}\[[^\]\n]+\]:[^\n]*$/gmu)) {
-    blankTextRange(blanked, match.index, match.index + match[0].length)
-  }
+const encodedDestinationEnd = (value: number | undefined): number | undefined =>
+  value === undefined || value === 0 ? undefined : value - 1
 
-  const labelOpeners: number[] = []
-  let lineStart = 0
+const indexMarkdownSyntax = (
+  source: string,
+  lines: readonly string[],
+): MarkdownSyntaxIndex => {
+  const escaped = new Uint8Array(source.length)
+  const parenthesisEnds = new Int32Array(source.length)
+  const bracketEnds = new Int32Array(source.length)
+  const bracketStarts = new Int32Array(source.length)
+  const bracketParents = new Int32Array(source.length)
+  const parenthesisStack: DelimiterFrame[] = []
+  const bracketStack: DelimiterFrame[] = []
+
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
-    if (character === "\\") {
-      index++
+    if (
+      character === "\\" &&
+      escaped[index] === 0 &&
+      isAsciiPunctuation(source[index + 1])
+    ) {
+      escaped[index + 1] = 1
+    }
+    if (escaped[index] !== 0) continue
+
+    if (character === "(") {
+      const parent = parenthesisStack.at(-1)
+      if (parent !== undefined) parent.nested = true
+      parenthesisStack.push({ opening: index, nested: false })
       continue
     }
-    if (character === "\n") {
-      if (source.slice(lineStart, index).trim() === "") labelOpeners.length = 0
-      lineStart = index + 1
+    if (character === ")") {
+      const frame = parenthesisStack.pop()
+      if (frame !== undefined) {
+        parenthesisEnds[frame.opening] = frame.nested ? -(index + 1) : index + 1
+      }
       continue
     }
     if (character === "[") {
-      labelOpeners.push(index)
+      const parent = bracketStack.at(-1)
+      if (parent !== undefined) {
+        parent.nested = true
+        bracketParents[index] = parent.opening + 1
+      }
+      bracketStack.push({ opening: index, nested: false })
       continue
     }
-    if (character !== "]" || labelOpeners.pop() === undefined) continue
+    if (character !== "]") continue
+
+    const frame = bracketStack.pop()
+    if (frame === undefined) continue
+    const label = source.slice(frame.opening + 1, index)
+    const validLabel =
+      !frame.nested && Array.from(label).length <= 999 && /[^ \t\n\r]/u.test(label)
+    bracketEnds[frame.opening] = validLabel ? index + 1 : -(index + 1)
+    bracketStarts[index] = frame.opening + 1
+  }
+
+  const bareDestinationEnds = new Int32Array(source.length + 1)
+  const horizontalWhitespaceEnds = new Int32Array(source.length + 1)
+  const nextAngleSpecials = new Int32Array(source.length + 1)
+  const nextDoubleQuotes = new Int32Array(source.length + 1)
+  const nextSingleQuotes = new Int32Array(source.length + 1)
+  horizontalWhitespaceEnds[source.length] = source.length
+  bareDestinationEnds[source.length] = source.length + 1
+  let nextAngleSpecial = 0
+  let nextDoubleQuote = 0
+  let nextSingleQuote = 0
+
+  for (let index = source.length - 1; index >= 0; index--) {
+    const character = source[index]
+    horizontalWhitespaceEnds[index] =
+      character === " " || character === "\t"
+        ? (horizontalWhitespaceEnds[index + 1] ?? source.length)
+        : index
+
+    if (escaped[index] === 0) {
+      if (
+        character === "<" ||
+        character === ">" ||
+        character === "\n" ||
+        character === "\r"
+      ) {
+        nextAngleSpecial = index + 1
+      }
+      if (character === '"') nextDoubleQuote = index + 1
+      if (character === "'") nextSingleQuote = index + 1
+    }
+    nextAngleSpecials[index] = nextAngleSpecial
+    nextDoubleQuotes[index] = nextDoubleQuote
+    nextSingleQuotes[index] = nextSingleQuote
+
+    if (escaped[index] !== 0) {
+      bareDestinationEnds[index] = bareDestinationEnds[index + 1] ?? 0
+      continue
+    }
+    if (character === "(") {
+      const closing = encodedPairEnd(parenthesisEnds[index])
+      const nestedEnd = encodedDestinationEnd(bareDestinationEnds[index + 1])
+      bareDestinationEnds[index] =
+        closing !== undefined && nestedEnd === closing
+          ? (bareDestinationEnds[closing + 1] ?? 0)
+          : 0
+      continue
+    }
+    if (
+      character === ")" ||
+      character === " " ||
+      character === "\t" ||
+      character === "\n" ||
+      character === "\r"
+    ) {
+      bareDestinationEnds[index] = index + 1
+      continue
+    }
+    const code = character?.charCodeAt(0) ?? 0
+    bareDestinationEnds[index] =
+      character === "<" || character === ">" || code <= 0x1f || code === 0x7f
+        ? 0
+        : (bareDestinationEnds[index + 1] ?? 0)
+  }
+
+  const blankLineStarts: number[] = []
+  let lineOffset = 0
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex] ?? ""
+    const content = line.endsWith("\r") ? line.slice(0, -1) : line
+    if (/^[ \t]*$/u.test(content)) blankLineStarts.push(lineOffset)
+    lineOffset += line.length + (lineIndex < lines.length - 1 ? 1 : 0)
+  }
+
+  return {
+    escaped,
+    parenthesisEnds,
+    bracketEnds,
+    bracketStarts,
+    bracketParents,
+    bareDestinationEnds,
+    horizontalWhitespaceEnds,
+    nextAngleSpecials,
+    nextDoubleQuotes,
+    nextSingleQuotes,
+    blankLineStarts,
+  }
+}
+
+const isLineEnding = (character: string | undefined): boolean =>
+  character === "\n" || character === "\r"
+
+const lineEndingEnd = (source: string, start: number): number =>
+  source[start] === "\r" && source[start + 1] === "\n" ? start + 2 : start + 1
+
+const firstOffsetAtOrAfter = (offsets: readonly number[], target: number): number => {
+  let low = 0
+  let high = offsets.length
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2)
+    if ((offsets[middle] ?? Number.POSITIVE_INFINITY) < target) low = middle + 1
+    else high = middle
+  }
+  return low
+}
+
+const hasBlankLine = (
+  syntax: MarkdownSyntaxIndex,
+  start: number,
+  end: number,
+): boolean => {
+  const blank = syntax.blankLineStarts[firstOffsetAtOrAfter(syntax.blankLineStarts, start)]
+  return blank !== undefined && blank < end
+}
+
+const markdownWhitespaceEnd = (
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  start: number,
+): number | undefined => {
+  let end = syntax.horizontalWhitespaceEnds[start] ?? start
+  if (!isLineEnding(source[end])) return end
+  end = lineEndingEnd(source, end)
+  end = syntax.horizontalWhitespaceEnds[end] ?? end
+  return isLineEnding(source[end]) ? undefined : end
+}
+
+const markdownAngleDestinationEnd = (
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  start: number,
+): number | undefined => {
+  if (source[start] !== "<") return undefined
+  const encoded = syntax.nextAngleSpecials[start + 1] ?? 0
+  if (encoded === 0) return undefined
+  const closing = encoded - 1
+  return source[closing] === ">" ? closing + 1 : undefined
+}
+
+const markdownLinkTitleEnd = (
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  start: number,
+): number | undefined => {
+  const opening = source[start]
+  let closing: number | undefined
+  if (opening === '"') {
+    const encoded = syntax.nextDoubleQuotes[start + 1] ?? 0
+    if (encoded !== 0) closing = encoded - 1
+  } else if (opening === "'") {
+    const encoded = syntax.nextSingleQuotes[start + 1] ?? 0
+    if (encoded !== 0) closing = encoded - 1
+  } else if (opening === "(") {
+    const encoded = syntax.parenthesisEnds[start] ?? 0
+    if (encoded > 0) closing = encoded - 1
+  }
+  if (closing === undefined || hasBlankLine(syntax, start + 1, closing)) return undefined
+  return closing + 1
+}
+
+const markdownInlineLinkEnd = (
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  opening: number,
+): number | undefined => {
+  const destinationStart = markdownWhitespaceEnd(source, syntax, opening + 1)
+  if (destinationStart === undefined) return undefined
+  if (source[destinationStart] === ")") return destinationStart
+
+  const destinationEnd =
+    source[destinationStart] === "<"
+      ? markdownAngleDestinationEnd(source, syntax, destinationStart)
+      : encodedDestinationEnd(syntax.bareDestinationEnds[destinationStart])
+  if (destinationEnd === undefined || destinationEnd === destinationStart) return undefined
+  if (source[destinationEnd] === ")") return destinationEnd
+
+  const titleStart = markdownWhitespaceEnd(source, syntax, destinationEnd)
+  if (titleStart === undefined || titleStart === destinationEnd) return undefined
+  if (source[titleStart] === ")") return titleStart
+
+  const titleEnd = markdownLinkTitleEnd(source, syntax, titleStart)
+  if (titleEnd === undefined) return undefined
+  const linkEnd = markdownWhitespaceEnd(source, syntax, titleEnd)
+  return linkEnd !== undefined && source[linkEnd] === ")" ? linkEnd : undefined
+}
+
+const markdownLabelEnd = (
+  syntax: MarkdownSyntaxIndex,
+  opening: number,
+): number | undefined => {
+  const encoded = syntax.bracketEnds[opening] ?? 0
+  if (encoded <= 0) return undefined
+  const closing = encoded - 1
+  return hasBlankLine(syntax, opening + 1, closing) ? undefined : closing
+}
+
+const normalizeReferenceLabel = (source: string, opening: number, closing: number): string =>
+  source
+    .slice(opening + 1, closing)
+    .replace(/[ \t\n\r]+/gu, " ")
+    .trim()
+    .toLowerCase()
+    .toUpperCase()
+    .toLowerCase()
+
+const markdownDefinitionTail = (
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  destinationEnd: number,
+): number | undefined => {
+  const sameLineEnd = syntax.horizontalWhitespaceEnds[destinationEnd] ?? destinationEnd
+  if (source[sameLineEnd] === undefined) return sameLineEnd
+
+  if (isLineEnding(source[sameLineEnd])) {
+    const baseEnd = sameLineEnd
+    const nextLineStart = syntax.horizontalWhitespaceEnds[
+      lineEndingEnd(source, sameLineEnd)
+    ]
+    if (nextLineStart === undefined) return baseEnd
+    const titleEnd = markdownLinkTitleEnd(source, syntax, nextLineStart)
+    if (titleEnd === undefined) return baseEnd
+    const trailingEnd = syntax.horizontalWhitespaceEnds[titleEnd] ?? titleEnd
+    return source[trailingEnd] === undefined || isLineEnding(source[trailingEnd])
+      ? trailingEnd
+      : baseEnd
+  }
+
+  if (sameLineEnd === destinationEnd) return undefined
+  const titleEnd = markdownLinkTitleEnd(source, syntax, sameLineEnd)
+  if (titleEnd === undefined) return undefined
+  const trailingEnd = syntax.horizontalWhitespaceEnds[titleEnd] ?? titleEnd
+  return source[trailingEnd] === undefined || isLineEnding(source[trailingEnd])
+    ? trailingEnd
+    : undefined
+}
+
+const markdownReferenceDefinition = (
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  start: number,
+): ReferenceDefinition | undefined => {
+  const labelEnd = markdownLabelEnd(syntax, start)
+  if (labelEnd === undefined || source[labelEnd + 1] !== ":") return undefined
+  const destinationStart = markdownWhitespaceEnd(source, syntax, labelEnd + 2)
+  if (destinationStart === undefined) return undefined
+
+  const destinationEnd =
+    source[destinationStart] === "<"
+      ? markdownAngleDestinationEnd(source, syntax, destinationStart)
+      : encodedDestinationEnd(syntax.bareDestinationEnds[destinationStart])
+  if (destinationEnd === undefined || destinationEnd === destinationStart) return undefined
+  const end = markdownDefinitionTail(source, syntax, destinationEnd)
+  if (end === undefined) return undefined
+
+  return {
+    label: normalizeReferenceLabel(source, start, labelEnd),
+    start,
+    end,
+  }
+}
+
+const markdownLineOffsets = (lines: readonly string[]): number[] => {
+  const offsets: number[] = []
+  let nextOffset = 0
+  for (let index = 0; index < lines.length; index++) {
+    offsets.push(nextOffset)
+    nextOffset += (lines[index]?.length ?? 0) + (index < lines.length - 1 ? 1 : 0)
+  }
+  return offsets
+}
+
+const lineIndexAtOffset = (offsets: readonly number[], offset: number): number => {
+  let low = 0
+  let high = offsets.length
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2)
+    if ((offsets[middle] ?? Number.POSITIVE_INFINITY) <= offset) low = middle + 1
+    else high = middle
+  }
+  return Math.max(0, low - 1)
+}
+
+const markdownReferenceDefinitions = (
+  lines: readonly string[],
+  source: string,
+  syntax: MarkdownSyntaxIndex,
+  contentStarts: readonly number[],
+  canStartDefinitions: readonly boolean[],
+): readonly ReferenceDefinition[] => {
+  const definitions: ReferenceDefinition[] = []
+  const offsets = markdownLineOffsets(lines)
+  let continuationLine = -1
+
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const canStart = (canStartDefinitions[lineIndex] ?? true) || lineIndex === continuationLine
+    continuationLine = -1
+    if (!canStart) continue
+
+    const line = lines[lineIndex] ?? ""
+    const lineOffset = offsets[lineIndex] ?? 0
+    const contentStart = Math.min(contentStarts[lineIndex] ?? 0, line.length)
+    const start = syntax.horizontalWhitespaceEnds[lineOffset + contentStart] ?? source.length
+    const contentEnd = lineOffset + (line.endsWith("\r") ? line.length - 1 : line.length)
+    if (start >= contentEnd || source[start] !== "[") continue
+
+    const definition = markdownReferenceDefinition(source, syntax, start)
+    if (definition === undefined) continue
+    definitions.push(definition)
+    const endLine = lineIndexAtOffset(offsets, Math.max(definition.start, definition.end - 1))
+    continuationLine = endLine + 1
+    lineIndex = endLine
+  }
+
+  return definitions
+}
+
+export function blankMarkdownDestinations(
+  lines: readonly string[],
+  contentStarts: readonly number[] = lines.map(() => 0),
+  canStartDefinitions: readonly boolean[] = lines.map(() => true),
+): string[] {
+  const source = lines.join("\n")
+  const blanked = source.split("")
+  const syntax = indexMarkdownSyntax(source, lines)
+  const definitions = markdownReferenceDefinitions(
+    lines,
+    source,
+    syntax,
+    contentStarts,
+    canStartDefinitions,
+  )
+  const labels = new Set(definitions.map((definition) => definition.label))
+  const inactiveLinkOpeners = new Uint8Array(source.length)
+  const isImageOpener = (opening: number): boolean =>
+    source[opening - 1] === "!" && syntax.escaped[opening - 1] === 0
+  const deactivateParentLinks = (opening: number): void => {
+    if (isImageOpener(opening)) return
+    let encodedParent = syntax.bracketParents[opening] ?? 0
+    while (encodedParent !== 0) {
+      const parent = encodedParent - 1
+      if (!isImageOpener(parent)) inactiveLinkOpeners[parent] = 1
+      encodedParent = syntax.bracketParents[parent] ?? 0
+    }
+  }
+
+  for (const definition of definitions) {
+    blankTextRange(blanked, definition.start, definition.end)
+  }
+
+  for (let index = 0; index < source.length; index++) {
+    if (source[index] !== "]" || syntax.escaped[index] !== 0) continue
+    const encodedOpening = syntax.bracketStarts[index] ?? 0
+    if (encodedOpening === 0) continue
+    const opening = encodedOpening - 1
+    if (inactiveLinkOpeners[opening] !== 0 || hasBlankLine(syntax, opening + 1, index)) continue
 
     const suffixStart = index + 1
     if (source[suffixStart] === "(") {
-      const linkEnd = markdownInlineLinkEnd(source, suffixStart)
+      const linkEnd = markdownInlineLinkEnd(source, syntax, suffixStart)
       if (linkEnd === undefined) continue
-      blankTextRange(blanked, suffixStart + 1, linkEnd)
+      blankTextRange(blanked, suffixStart, linkEnd + 1)
+      deactivateParentLinks(opening)
       index = linkEnd
       continue
     }
-    if (source[suffixStart] === "[") {
-      const referenceEnd = markdownReferenceEnd(source, suffixStart)
-      if (referenceEnd === undefined) continue
-      blankTextRange(blanked, suffixStart, referenceEnd + 1)
-      index = referenceEnd
-    }
+    if (source[suffixStart] !== "[") continue
+
+    const referenceEnd = encodedPairEnd(syntax.bracketEnds[suffixStart])
+    if (referenceEnd === undefined) continue
+    const labelEnd = markdownLabelEnd(syntax, suffixStart)
+    const collapsed = referenceEnd === suffixStart + 1
+    const resolves = collapsed
+      ? markdownLabelEnd(syntax, opening) === index &&
+        labels.has(normalizeReferenceLabel(source, opening, index))
+      : labelEnd === referenceEnd &&
+        labels.has(normalizeReferenceLabel(source, suffixStart, referenceEnd))
+    if (!resolves) continue
+
+    blankTextRange(blanked, suffixStart, referenceEnd + 1)
+    deactivateParentLinks(opening)
+    index = referenceEnd
   }
 
   for (const pattern of [

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -341,14 +341,16 @@ interface PreparedMarkdownSource {
 const markdownEvents = (source: string) =>
   postprocess(parse().document().write(preprocess()(source, "utf8", true)))
 
+const markdownTextEvents = (source: string) =>
+  postprocess(parse().text().write(preprocess()(source, "utf8", true)))
+
 const opaqueInlineProbe = (source: string): string => {
   const characters = source.split("")
-  for (let index = 1; index < source.length; index++) {
-    if (
-      source[index] === "[" &&
-      source[index - 1] === "!" &&
-      !source.startsWith("<![CDATA[", index - 2)
-    ) {
+  for (let index = 0; index < source.length; index++) {
+    if (source.startsWith("<![CDATA[", index)) {
+      const end = source.indexOf("]]>", index + 9)
+      index = end < 0 ? source.length : end + 2
+    } else if (source[index] === "[" || source[index] === "]") {
       characters[index] = "x"
     }
   }
@@ -422,6 +424,7 @@ const prepareMarkdownSource = (
 
 const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
 const OPAQUE_INLINE_TOKENS = new Set(["autolink", "codeText", "htmlText"])
+const HTML_FLOW_SYNTAX_TOKENS = new Set(["characterReference", "htmlText"])
 
 const tokenRanges = (
   events: ReturnType<typeof markdownEvents>,
@@ -431,6 +434,25 @@ const tokenRanges = (
   for (const [phase, token] of events) {
     if (phase === "enter" && tokenTypes.has(token.type)) {
       ranges.push({ start: token.start.offset, end: token.end.offset })
+    }
+  }
+  return ranges
+}
+
+const htmlFlowSyntaxRanges = (
+  source: string,
+  events: ReturnType<typeof markdownEvents>,
+): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  for (const [phase, token] of events) {
+    if (phase !== "enter" || token.type !== "htmlFlow") continue
+    const start = token.start.offset
+    const flowSource = source.slice(start, token.end.offset)
+    for (const range of tokenRanges(
+      markdownTextEvents(opaqueInlineProbe(flowSource)),
+      HTML_FLOW_SYNTAX_TOKENS,
+    )) {
+      ranges.push({ start: start + range.start, end: start + range.end })
     }
   }
   return ranges
@@ -521,13 +543,13 @@ export function blankMarkdownDestinations(
     blankTextRange(blanked, outputOffset(start), outputOffset(end))
   }
 
-  const delimiterSource = blankMarkdownCode(lines, contentStarts)
-    .map((line, index) => line.slice(Math.min(contentStarts[index] ?? 0, line.length)))
-    .join("\n")
-  const opaqueInlineRanges = tokenRanges(
-    markdownEvents(opaqueInlineProbe(delimiterSource)),
-    OPAQUE_INLINE_TOKENS,
-  )
+  const delimiterEvents = markdownEvents(opaqueInlineProbe(source))
+  const opaqueInlineRanges = tokenRanges(delimiterEvents, OPAQUE_INLINE_TOKENS)
+  const delimiterCharacters = source.split("")
+  for (const range of opaqueInlineRanges) {
+    blankTextRange(delimiterCharacters, range.start, range.end)
+  }
+  const delimiterSource = delimiterCharacters.join("")
   const preparedSource = prepareMarkdownSource(source, delimiterSource, opaqueInlineRanges)
   const events = markdownEvents(preparedSource.value)
   const definitionMaskEnds = new Map<number, number>()
@@ -568,6 +590,10 @@ export function blankMarkdownDestinations(
     } else if (MASKED_MARKDOWN_TOKENS.has(token.type)) {
       blankSourceRange(token.start.offset, token.end.offset)
     }
+  }
+
+  for (const range of htmlFlowSyntaxRanges(source, events)) {
+    blankSourceRange(range.start, range.end)
   }
 
   for (const range of fallbackResourceRanges(

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -542,26 +542,43 @@ const markdownTextEvents = (source: string) =>
       .write(preprocess()(source, "utf8", true)),
   )
 
-const opaqueInlineProbe = (source: string): string => {
+const boundCdataMarkers = (source: string): string => {
   const characters = source.split("")
-  const nextGreater = new Int32Array(source.length + 1).fill(-1)
+  let protectedEnd = -1
+
+  for (let index = 0; index < source.length; index++) {
+    if (!source.startsWith("<![CDATA[", index)) continue
+    if (index <= protectedEnd) {
+      characters[index] = " "
+      continue
+    }
+    const end = source.indexOf("]]>", index + 9)
+    protectedEnd = end < 0 ? source.length : end + 2
+  }
+
+  return characters.join("")
+}
+
+const opaqueInlineProbe = (source: string): string => {
+  const boundedSource = boundCdataMarkers(source)
+  const characters = boundedSource.split("")
+  const nextGreater = new Int32Array(boundedSource.length + 1).fill(-1)
   let greater = -1
-  for (let index = source.length - 1; index >= 0; index--) {
-    if (source[index] === ">") greater = index
+  for (let index = boundedSource.length - 1; index >= 0; index--) {
+    if (boundedSource[index] === ">") greater = index
     nextGreater[index] = greater
   }
 
   let protectedEnd = -1
-  for (let index = 0; index < source.length; index++) {
-    if (source.startsWith("<![CDATA[", index)) {
-      const end = source.indexOf("]]>", index + 9)
-      protectedEnd = end < 0 ? source.length : end + 2
-    } else if (source[index] === "<" && index > protectedEnd) {
+  for (let index = 0; index < boundedSource.length; index++) {
+    if (index <= protectedEnd) continue
+    if (boundedSource.startsWith("<![CDATA[", index)) {
+      const end = boundedSource.indexOf("]]>", index + 9)
+      if (end < 0) break
+      protectedEnd = end + 2
+    } else if (boundedSource[index] === "<") {
       protectedEnd = nextGreater[index + 1] ?? -1
-    } else if (
-      index > protectedEnd &&
-      (source[index] === "[" || source[index] === "]")
-    ) {
+    } else if (boundedSource[index] === "[" || boundedSource[index] === "]") {
       characters[index] = "^"
     }
   }
@@ -573,7 +590,7 @@ const prepareMarkdownSource = (
   delimiterSource: string,
   opaqueInlineRanges: readonly SourceRange[],
 ): PreparedMarkdownSource => {
-  const characters = source.split("")
+  const characters = boundCdataMarkers(source).split("")
   const scanIndex = resourceScanIndex(source)
   const escaped = scanIndex.escaped
   const brackets: BracketFrame[] = []

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -316,10 +316,20 @@ const blankTextRange = (text: string[], start: number, end: number): void => {
   }
 }
 
+interface ReferenceCandidate {
+  readonly imageIdentifier: string
+  readonly labelStart: number
+  readonly sourceStart: number
+  sourceEnd?: number
+  identifier?: string
+  valid: boolean
+}
+
 interface BracketFrame {
   readonly opening: number
   readonly image: boolean
   readonly imageDepth: number
+  readonly referenceCandidate?: ReferenceCandidate
 }
 
 interface ResourceCandidate {
@@ -336,10 +346,24 @@ interface SourceRange {
 interface PreparedMarkdownSource {
   readonly value: string
   readonly resourceCandidates: readonly ResourceCandidate[]
+  readonly referenceCandidates: readonly ReferenceCandidate[]
 }
 
 const isMarkdownWhitespace = (character: string | undefined): boolean =>
   character === " " || character === "\t" || character === "\n" || character === "\r"
+
+const normalizeIdentifier = (value: string): string =>
+  value
+    .replace(/[\t\n\r ]+/g, " ")
+    .replace(/^ | $/g, "")
+    .toLowerCase()
+    .toUpperCase()
+
+const markdownLabelSize = (value: string): number =>
+  Array.from(value).reduce(
+    (size, character) => size + (character === "\n" || character === "\r" ? 0 : 1),
+    0,
+  )
 
 interface ResourceScanIndex {
   readonly escaped: Uint8Array
@@ -596,7 +620,7 @@ const prepareMarkdownSource = (
   let imageDepth = 0
   let opaqueRangeIndex = 0
   let backslashRun = 0
-  let needsResourceIndex = false
+  let needsDeepImageFallback = false
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
@@ -631,8 +655,8 @@ const prepareMarkdownSource = (
     } else if (character === "]") {
       const frame = brackets.pop()
       if (frame?.image) {
-        if (frame.imageDepth > 32 && source[index + 1] === "(") {
-          needsResourceIndex = true
+        if (frame.imageDepth > 32) {
+          needsDeepImageFallback = true
           break
         }
         imageDepth--
@@ -640,15 +664,17 @@ const prepareMarkdownSource = (
     }
   }
 
-  if (!needsResourceIndex) {
-    return { value: boundCdataMarkers(source), resourceCandidates: [] }
+  if (!needsDeepImageFallback) {
+    return { value: boundCdataMarkers(source), resourceCandidates: [], referenceCandidates: [] }
   }
 
   const characters = boundCdataMarkers(source).split("")
-  const scanIndex = resourceScanIndex(source)
-  const escaped = scanIndex.escaped
-  const candidateByOpening = new Map<number, ResourceCandidate>()
+  const escaped = escapedCharacters(source)
+  let scanIndex: ResourceScanIndex | undefined
+  const resourceCandidateByOpening = new Map<number, ResourceCandidate>()
+  const referenceCandidateByOpening = new Map<number, ReferenceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
+  const referenceCandidates: ReferenceCandidate[] = []
   brackets.length = 0
   imageDepth = 0
   opaqueRangeIndex = 0
@@ -667,24 +693,56 @@ const prepareMarkdownSource = (
     if (character === "\\" || escaped[index] !== 0) continue
 
     if (character === "[") {
+      const parentReference = brackets.at(-1)?.referenceCandidate
+      if (parentReference !== undefined) parentReference.valid = false
       const image = source[index - 1] === "!" && escaped[index - 1] === 0
       if (image) imageDepth++
-      brackets.push({ opening: index, image, imageDepth })
+      brackets.push({
+        opening: index,
+        image,
+        imageDepth,
+        referenceCandidate: referenceCandidateByOpening.get(index),
+      })
     } else if (character === "]") {
       const frame = brackets.pop()
-      if (frame?.image) {
-        if (frame.imageDepth > 32 && source[index + 1] === "(") {
+      if (frame?.referenceCandidate !== undefined) {
+        const candidate = frame.referenceCandidate
+        const identifierSource = source.slice(frame.opening + 1, index)
+        candidate.sourceEnd = index + 1
+        if (identifierSource === "") {
+          candidate.identifier = candidate.imageIdentifier
+        } else if (
+          candidate.valid &&
+          markdownLabelSize(identifierSource) <= 999 &&
+          identifierSource.trim() !== ""
+        ) {
+          candidate.identifier = normalizeIdentifier(identifierSource)
+        }
+      } else if (frame?.image) {
+        if (frame.imageDepth > 32) {
           characters[frame.opening] = "x"
           characters[index] = "x"
-          const candidate = { labelStart: frame.opening, sourceStart: index + 1 }
-          candidateByOpening.set(index + 1, candidate)
-          resourceCandidates.push(candidate)
+          if (source[index + 1] === "(") {
+            const candidate = { labelStart: frame.opening, sourceStart: index + 1 }
+            resourceCandidateByOpening.set(index + 1, candidate)
+            resourceCandidates.push(candidate)
+          } else if (source[index + 1] === "[") {
+            const candidate = {
+              imageIdentifier: normalizeIdentifier(source.slice(frame.opening + 1, index)),
+              labelStart: frame.opening,
+              sourceStart: index + 1,
+              valid: true,
+            }
+            referenceCandidateByOpening.set(index + 1, candidate)
+            referenceCandidates.push(candidate)
+          }
         }
         imageDepth--
       }
     } else if (character === "(") {
-      const candidate = candidateByOpening.get(index)
+      const candidate = resourceCandidateByOpening.get(index)
       if (candidate !== undefined) {
+        scanIndex ??= resourceScanIndex(source)
         const end = resourceEnd(source, index, scanIndex)
         if (end >= 0) {
           candidate.sourceEnd = end
@@ -695,7 +753,7 @@ const prepareMarkdownSource = (
     }
   }
 
-  return { value: characters.join(""), resourceCandidates }
+  return { value: characters.join(""), resourceCandidates, referenceCandidates }
 }
 
 const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
@@ -753,6 +811,35 @@ const rangeContaining = (
   }
   const range = ranges[low - 1]
   return range !== undefined && offset < range.end ? range : undefined
+}
+
+const fallbackReferenceRanges = (
+  candidates: readonly ReferenceCandidate[],
+  inlineBlocks: readonly SourceRange[],
+  opaqueInlineRanges: readonly SourceRange[],
+  definedIdentifiers: ReadonlySet<string>,
+): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  for (const candidate of candidates) {
+    if (
+      candidate.sourceEnd === undefined ||
+      candidate.identifier === undefined ||
+      !definedIdentifiers.has(candidate.identifier)
+    ) {
+      continue
+    }
+    const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
+    if (
+      inlineBlock === undefined ||
+      candidate.sourceStart < inlineBlock.start ||
+      candidate.sourceEnd > inlineBlock.end ||
+      rangeContaining(opaqueInlineRanges, candidate.labelStart) !== undefined
+    ) {
+      continue
+    }
+    ranges.push({ start: candidate.sourceStart, end: candidate.sourceEnd })
+  }
+  return ranges
 }
 
 const fallbackResourceRanges = (
@@ -891,10 +978,29 @@ export function blankMarkdownDestinations(
     blankSourceRange(range.start, range.end)
   }
 
+  const inlineBlocks = tokenRanges(events, INLINE_BLOCK_TOKENS)
+  const definedIdentifiers = new Set<string>()
+  for (const [phase, token] of events) {
+    if (phase === "enter" && token.type === "definitionLabelString") {
+      definedIdentifiers.add(
+        normalizeIdentifier(source.slice(token.start.offset, token.end.offset)),
+      )
+    }
+  }
+
+  for (const range of fallbackReferenceRanges(
+    preparedSource.referenceCandidates,
+    inlineBlocks,
+    opaqueInlineRanges,
+    definedIdentifiers,
+  )) {
+    blankSourceRange(range.start, range.end)
+  }
+
   for (const range of fallbackResourceRanges(
     source,
     preparedSource.resourceCandidates,
-    tokenRanges(events, INLINE_BLOCK_TOKENS),
+    inlineBlocks,
     opaqueInlineRanges,
   )) {
     blankSourceRange(range.start, range.end)

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -341,66 +341,155 @@ interface PreparedMarkdownSource {
 const isMarkdownWhitespace = (character: string | undefined): boolean =>
   character === " " || character === "\t" || character === "\n" || character === "\r"
 
-const resourceOpaqueRanges = (source: string, opening: number): readonly SourceRange[] => {
+interface ResourceScanIndex {
+  readonly escaped: Uint8Array
+  readonly nextNonWhitespace: Int32Array
+  readonly nextLineEnding: Int32Array
+  readonly nextGreater: Int32Array
+  readonly nextDoubleQuote: Int32Array
+  readonly nextSingleQuote: Int32Array
+  readonly nextClosingParenthesis: Int32Array
+  readonly depthBefore: Int32Array
+  readonly boundariesByDepth: ReadonlyMap<number, readonly number[]>
+  readonly boundaryCursors: Map<number, number>
+}
+
+const escapedCharacters = (source: string): Uint8Array => {
+  const escaped = new Uint8Array(source.length)
+  let backslashRun = 0
+  for (let index = 0; index < source.length; index++) {
+    if (source[index] === "\\") {
+      backslashRun++
+      continue
+    }
+    if (backslashRun % 2 !== 0) escaped[index] = 1
+    backslashRun = 0
+  }
+  return escaped
+}
+
+const resourceScanIndex = (source: string, delimiterSource: string): ResourceScanIndex => {
+  const escaped = escapedCharacters(source)
+  const nextNonWhitespace = new Int32Array(source.length + 1).fill(source.length)
+  const nextLineEnding = new Int32Array(source.length + 1).fill(-1)
+  const nextGreater = new Int32Array(source.length + 1).fill(-1)
+  const nextDoubleQuote = new Int32Array(source.length + 1).fill(-1)
+  const nextSingleQuote = new Int32Array(source.length + 1).fill(-1)
+  const nextClosingParenthesis = new Int32Array(source.length + 1).fill(-1)
+  let nonWhitespace = source.length
+  let lineEnding = -1
+  let greater = -1
+  let doubleQuote = -1
+  let singleQuote = -1
+  let closingParenthesis = -1
+
+  for (let index = source.length - 1; index >= 0; index--) {
+    const character = source[index]
+    if (!isMarkdownWhitespace(character)) nonWhitespace = index
+    if (character === "\n" || character === "\r") lineEnding = index
+    if (escaped[index] === 0) {
+      if (character === ">") greater = index
+      if (character === '"') doubleQuote = index
+      if (character === "'") singleQuote = index
+      if (character === ")") closingParenthesis = index
+    }
+    nextNonWhitespace[index] = nonWhitespace
+    nextLineEnding[index] = lineEnding
+    nextGreater[index] = greater
+    nextDoubleQuote[index] = doubleQuote
+    nextSingleQuote[index] = singleQuote
+    nextClosingParenthesis[index] = closingParenthesis
+  }
+
+  const depthBefore = new Int32Array(source.length)
+  const boundariesByDepth = new Map<number, number[]>()
+  let depth = 0
+  for (let index = 0; index < source.length; index++) {
+    const character = source[index]
+    depthBefore[index] = depth
+    if (isMarkdownWhitespace(character) || (character === ")" && escaped[index] === 0)) {
+      const boundaries = boundariesByDepth.get(depth) ?? []
+      boundaries.push(index)
+      boundariesByDepth.set(depth, boundaries)
+    }
+    if (delimiterSource[index] !== character || escaped[index] !== 0) continue
+    if (character === "(") depth++
+    else if (character === ")") depth--
+  }
+
+  return {
+    escaped,
+    nextNonWhitespace,
+    nextLineEnding,
+    nextGreater,
+    nextDoubleQuote,
+    nextSingleQuote,
+    nextClosingParenthesis,
+    depthBefore,
+    boundariesByDepth,
+    boundaryCursors: new Map(),
+  }
+}
+
+const nextResourceBoundary = (index: ResourceScanIndex, start: number): number => {
+  const depth = index.depthBefore[start] ?? 0
+  const boundaries = index.boundariesByDepth.get(depth) ?? []
+  let cursor = index.boundaryCursors.get(depth) ?? 0
+  while ((boundaries[cursor] ?? Number.POSITIVE_INFINITY) < start) cursor++
+  index.boundaryCursors.set(depth, cursor)
+  return boundaries[cursor] ?? -1
+}
+
+const resourceOpaqueRanges = (
+  source: string,
+  opening: number,
+  scanIndex: ResourceScanIndex,
+): readonly SourceRange[] => {
   const ranges: SourceRange[] = []
-  let index = opening + 1
-  while (isMarkdownWhitespace(source[index])) index++
+  let index = scanIndex.nextNonWhitespace[opening + 1] ?? source.length
 
   if (source[index] === "<") {
-    const start = index
-    for (index++; index < source.length; index++) {
-      if (source[index] === "\\") {
-        index++
-      } else if (source[index] === "\n" || source[index] === "\r") {
-        return ranges
-      } else if (source[index] === ">") {
-        index++
-        ranges.push({ start, end: index })
-        break
-      }
-    }
+    const end = scanIndex.nextGreater[index + 1] ?? -1
+    const lineEnding = scanIndex.nextLineEnding[index + 1] ?? -1
+    if (end < 0 || (lineEnding >= 0 && lineEnding < end)) return ranges
+    ranges.push({ start: index, end: end + 1 })
+    index = end + 1
   } else {
-    let depth = 0
-    for (; index < source.length; index++) {
-      const character = source[index]
-      if (character === "\\") {
-        index++
-      } else if (character === "(") {
-        depth++
-      } else if (character === ")") {
-        if (depth === 0) return ranges
-        depth--
-      } else if (depth === 0 && isMarkdownWhitespace(character)) {
-        break
-      }
-    }
+    index = nextResourceBoundary(scanIndex, index)
+    if (index < 0) return ranges
   }
 
   const separatorStart = index
-  while (isMarkdownWhitespace(source[index])) index++
+  index = scanIndex.nextNonWhitespace[index] ?? source.length
   if (index === separatorStart) return ranges
 
   const delimiter = source[index]
-  const closing = delimiter === "(" ? ")" : delimiter
-  if (delimiter !== '"' && delimiter !== "'" && delimiter !== "(") return ranges
-
-  const start = index
-  for (index++; index < source.length; index++) {
-    if (source[index] === "\\") {
-      index++
-    } else if (source[index] === closing) {
-      ranges.push({ start, end: index + 1 })
-      return ranges
-    }
-  }
+  const closing =
+    delimiter === '"'
+      ? scanIndex.nextDoubleQuote[index + 1]
+      : delimiter === "'"
+        ? scanIndex.nextSingleQuote[index + 1]
+        : delimiter === "("
+          ? scanIndex.nextClosingParenthesis[index + 1]
+          : -1
+  if (closing === undefined || closing < 0) return ranges
+  ranges.push({ start: index, end: closing + 1 })
   return ranges
 }
 
 const markdownEvents = (source: string) =>
-  postprocess(parse().document().write(preprocess()(source, "utf8", true)))
+  postprocess(
+    parse()
+      .document()
+      .write(preprocess()(source, "utf8", true)),
+  )
 
 const markdownTextEvents = (source: string) =>
-  postprocess(parse().text().write(preprocess()(source, "utf8", true)))
+  postprocess(
+    parse()
+      .text()
+      .write(preprocess()(source, "utf8", true)),
+  )
 
 const opaqueInlineProbe = (source: string): string => {
   const characters = source.split("")
@@ -409,7 +498,7 @@ const opaqueInlineProbe = (source: string): string => {
       const end = source.indexOf("]]>", index + 9)
       index = end < 0 ? source.length : end + 2
     } else if (source[index] === "[" || source[index] === "]") {
-      characters[index] = "x"
+      characters[index] = "^"
     }
   }
   return characters.join("")
@@ -421,21 +510,20 @@ const prepareMarkdownSource = (
   opaqueInlineRanges: readonly SourceRange[],
 ): PreparedMarkdownSource => {
   const characters = source.split("")
-  const escaped = new Uint8Array(source.length)
+  const scanIndex = resourceScanIndex(source, delimiterSource)
+  const escaped = scanIndex.escaped
   const brackets: BracketFrame[] = []
   const parentheses: number[] = []
   const candidateByOpening = new Map<number, ResourceCandidate>()
   const resourceCandidates: ResourceCandidate[] = []
   const resourceOpaqueEnds = new Int32Array(source.length).fill(-1)
   let imageDepth = 0
-  let backslashRun = 0
   let opaqueRangeIndex = 0
 
   for (let index = 0; index < source.length; index++) {
     const character = source[index]
     const resourceOpaqueEnd = resourceOpaqueEnds[index] ?? -1
     if (resourceOpaqueEnd >= 0) {
-      backslashRun = 0
       index = resourceOpaqueEnd - 1
       continue
     }
@@ -444,18 +532,11 @@ const prepareMarkdownSource = (
     }
     const opaqueRange = opaqueInlineRanges[opaqueRangeIndex]
     if (opaqueRange !== undefined && index >= opaqueRange.start) {
-      backslashRun = 0
       index = opaqueRange.end - 1
       continue
     }
     if (delimiterSource[index] !== character && "[]()".includes(character ?? "")) continue
-    if (character === "\\") {
-      backslashRun++
-      continue
-    }
-    if (backslashRun % 2 !== 0) escaped[index] = 1
-    backslashRun = 0
-    if (escaped[index] !== 0) continue
+    if (character === "\\" || escaped[index] !== 0) continue
 
     if (character === "[") {
       const image = source[index - 1] === "!" && escaped[index - 1] === 0
@@ -476,7 +557,7 @@ const prepareMarkdownSource = (
     } else if (character === "(") {
       parentheses.push(index)
       if (candidateByOpening.has(index)) {
-        for (const range of resourceOpaqueRanges(source, index)) {
+        for (const range of resourceOpaqueRanges(source, index, scanIndex)) {
           resourceOpaqueEnds[range.start] = range.end
         }
       }
@@ -528,7 +609,10 @@ const htmlFlowSyntaxRanges = (
   return ranges
 }
 
-const rangeContaining = (ranges: readonly SourceRange[], offset: number): SourceRange | undefined => {
+const rangeContaining = (
+  ranges: readonly SourceRange[],
+  offset: number,
+): SourceRange | undefined => {
   let low = 0
   let high = ranges.length
   while (low < high) {
@@ -631,10 +715,7 @@ export function blankMarkdownDestinations(
         token.type === "listItemIndent")
     ) {
       const lineIndex = token.start.line - 1
-      contentColumns[lineIndex] = Math.max(
-        contentColumns[lineIndex] ?? 1,
-        token.end.column,
-      )
+      contentColumns[lineIndex] = Math.max(contentColumns[lineIndex] ?? 1, token.end.column)
     }
   }
 

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -1,10 +1,5 @@
 import { DICTIONARY_TOKEN_SOURCE } from "../../dictionary/form.ts"
-import type {
-  ApprovedWordList,
-  Dictionary,
-  DictionaryData,
-  DictionaryEntry,
-} from "../../dictionary/schema.ts"
+import type { Dictionary, DictionaryData, DictionaryEntry } from "../../dictionary/schema.ts"
 import type { TaggedToken, Tagger } from "../tagger.ts"
 import type { Violation } from "../types.ts"
 
@@ -19,6 +14,10 @@ interface Form {
   readonly entry: DictionaryEntry
   readonly words: readonly string[]
 }
+
+export type CompiledDictionary =
+  | { readonly mode: "approved-words"; readonly approvedWords: ReadonlySet<string> }
+  | { readonly mode: "not-approved"; readonly forms: readonly Form[] }
 
 interface MarkdownContext {
   readonly contentStart: number
@@ -54,6 +53,14 @@ const compileForms = (dictionary: Dictionary): readonly Form[] =>
       entry.unapproved.map((form) => ({ entry, words: form.toLowerCase().split(/\s+/) })),
     )
     .sort((left, right) => right.words.length - left.words.length)
+
+export const compileDictionary = (dictionary: DictionaryData): CompiledDictionary =>
+  "approvedWords" in dictionary
+    ? {
+        mode: "approved-words",
+        approvedWords: new Set(dictionary.approvedWords.map((word) => word.toLowerCase())),
+      }
+    : { mode: "not-approved", forms: compileForms(dictionary) }
 
 const markdownContext = (line: string, initialContentStart = 0): MarkdownContext => {
   let contentStart = Math.min(initialContentStart, line.length)
@@ -219,10 +226,9 @@ const messageFor = (suggestions: readonly string[], found: string): string => {
 
 const approvedWordRule = (
   lines: readonly string[],
-  approvedWordList: ApprovedWordList,
-): Violation[] => {
-  const approvedWords = new Set(approvedWordList.approvedWords.map((word) => word.toLowerCase()))
-  return tokenize(lines).flatMap((token) =>
+  approvedWords: ReadonlySet<string>,
+): Violation[] =>
+  tokenize(lines).flatMap((token) =>
     approvedWords.has(token.lower)
       ? []
       : [
@@ -236,19 +242,18 @@ const approvedWordRule = (
           },
         ],
   )
-}
 
 export function dictionaryRule(
   lines: readonly string[],
-  dictionary: DictionaryData,
+  dictionary: CompiledDictionary,
   tagger?: Tagger,
   contentStarts: readonly number[] = lines.map(() => 0),
   proseLines: readonly string[] = lines,
 ): Violation[] {
-  if ("approvedWords" in dictionary) {
-    return approvedWordRule(proseLines, dictionary)
+  if (dictionary.mode === "approved-words") {
+    return approvedWordRule(proseLines, dictionary.approvedWords)
   }
-  const forms = compileForms(dictionary)
+  const forms = dictionary.forms
   const violations: Violation[] = []
   const contexts = markdownContexts(lines, contentStarts)
   const tokens = tokenize(lines)

--- a/src/engine/rules/dictionary.ts
+++ b/src/engine/rules/dictionary.ts
@@ -1,5 +1,10 @@
 import { DICTIONARY_TOKEN_SOURCE } from "../../dictionary/form.ts"
-import type { Dictionary, DictionaryEntry } from "../../dictionary/schema.ts"
+import type {
+  ApprovedWordList,
+  Dictionary,
+  DictionaryData,
+  DictionaryEntry,
+} from "../../dictionary/schema.ts"
 import type { TaggedToken, Tagger } from "../tagger.ts"
 import type { Violation } from "../types.ts"
 
@@ -212,12 +217,37 @@ const messageFor = (suggestions: readonly string[], found: string): string => {
   return `Use ${alternatives}, not "${found}".`
 }
 
+const approvedWordRule = (
+  lines: readonly string[],
+  approvedWordList: ApprovedWordList,
+): Violation[] => {
+  const approvedWords = new Set(approvedWordList.approvedWords.map((word) => word.toLowerCase()))
+  return tokenize(lines).flatMap((token) =>
+    approvedWords.has(token.lower)
+      ? []
+      : [
+          {
+            ruleId: "dictionary-not-approved-word" as const,
+            severity: "hard" as const,
+            message: `"${token.text}" is not in the approved-word list.`,
+            suggestions: [],
+            line: token.lineIndex + 1,
+            column: token.offset + 1,
+          },
+        ],
+  )
+}
+
 export function dictionaryRule(
   lines: readonly string[],
-  dictionary: Dictionary,
+  dictionary: DictionaryData,
   tagger?: Tagger,
   contentStarts: readonly number[] = lines.map(() => 0),
+  proseLines: readonly string[] = lines,
 ): Violation[] {
+  if ("approvedWords" in dictionary) {
+    return approvedWordRule(proseLines, dictionary)
+  }
   const forms = compileForms(dictionary)
   const violations: Violation[] = []
   const contexts = markdownContexts(lines, contentStarts)

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,5 +1,5 @@
 import type { RuleData } from "../dictionary/rule-data.ts"
-import type { Dictionary } from "../dictionary/schema.ts"
+import type { DictionaryData } from "../dictionary/schema.ts"
 import type { RuleId } from "./rules/registry.ts"
 import type { Tagger } from "./tagger.ts"
 
@@ -24,7 +24,7 @@ export type SourceDialect = "general" | "shell"
 export interface LintOptions {
   readonly rules?: Partial<Record<RuleId, RuleSetting>>
   readonly maxSentenceWords?: number
-  readonly dictionary?: Dictionary
+  readonly dictionary?: DictionaryData
   readonly ruleData?: RuleData
   // POS tagger for the verb-form rules and POS-aware dictionary entries.
   readonly tagger?: Tagger

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -20,9 +20,10 @@ import { formatViolations, violationDetails } from "../adapter/feedback.ts"
 import { formatStatusSummary, ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import type { SteConfig } from "../config/schema.ts"
-import { loadDictionary, loadRuleData } from "../dictionary/load.ts"
+import { loadConfiguredDictionary } from "../dictionary/configured.ts"
+import { loadRuleData } from "../dictionary/load.ts"
 import type { RuleData } from "../dictionary/rule-data.ts"
-import type { Dictionary } from "../dictionary/schema.ts"
+import type { DictionaryData } from "../dictionary/schema.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
@@ -38,7 +39,7 @@ const COMMAND_COMPLETIONS: readonly AutocompleteItem[] = [
 
 interface SessionState {
   config: SteConfig
-  dictionary?: Dictionary
+  dictionary?: DictionaryData
   ruleData?: RuleData
   tagger?: Tagger
   enabled: boolean
@@ -655,7 +656,11 @@ export default function simpleEnglishExtension(pi: ExtensionAPI): void {
     try {
       const loadedData = await Effect.runPromise(
         Effect.all({
-          dictionary: loadDictionary(process.env.SIMPLE_ENGLISH_DICTIONARY),
+          dictionary: loadConfiguredDictionary(
+            state.config,
+            ctx.cwd,
+            process.env.SIMPLE_ENGLISH_DICTIONARY,
+          ),
           ruleData: loadRuleData(state.config.ruleDataExtensions, ctx.cwd),
         }),
       )

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -16,6 +16,21 @@ const makeProject = async (config?: unknown): Promise<string> => {
   return cwd
 }
 
+const writeApprovedWordList = (
+  path: string,
+  approvedWords: readonly string[] = ["alphaword"],
+): Promise<void> =>
+  writeJson(path, {
+    formatVersion: 1,
+    source: {
+      name: "synthetic test fixture",
+      repository: "https://example.test/approved-words",
+      commit: "fixture",
+      path: "approved-words.json",
+    },
+    approvedWords,
+  })
+
 const writeLegacyProjectConfig = (cwd: string, config: unknown): Promise<void> =>
   writeJson(join(cwd, ".pi", "simple-english.json"), config)
 
@@ -29,6 +44,54 @@ const writeLegacyGlobalConfig = (home: string, config: unknown): Promise<void> =
   writeJson(join(home, ".pi", "agent", "simple-english.json"), config)
 
 describe("simple-english CLI config", () => {
+  test("a configured approved-word list permits listed words and flags absent words", async () => {
+    const cwd = await makeProject({ approvedWordsPath: "approved-words.json" })
+    await writeApprovedWordList(join(cwd, "approved-words.json"))
+
+    const approved = await runCli([], {
+      cwd,
+      stdin: "ALPHAWORD.",
+      dictionaryPath: "missing-replacement-dictionary.json",
+    })
+    const absent = await runCli([], {
+      cwd,
+      stdin: "Betaword.",
+      dictionaryPath: "missing-replacement-dictionary.json",
+    })
+
+    expect(approved.code).toBe(0)
+    expect(approved.stdout).toBe("")
+    expect(approved.stderr).toBe("")
+    expect(absent.code).toBe(1)
+    expect(absent.stdout).toContain("dictionary-not-approved-word")
+    expect(absent.stdout).toContain('"Betaword" is not in the approved-word list.')
+    expect(absent.stderr).toBe("")
+  })
+
+  test("an invalid approved-word list exits 2 and names the invalid item", async () => {
+    const cwd = await makeProject({ approvedWordsPath: "approved-words.json" })
+    await writeApprovedWordList(join(cwd, "approved-words.json"), ["two words"])
+
+    const result = await runCli([], { cwd, stdin: "Alphaword." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain("approvedWords[0]")
+  })
+
+  test.each([
+    ["missing", "missing-approved-words.json"],
+    ["unreadable", "approved-words-directory"],
+  ])("a %s approved-word list exits 2 and names the path", async (kind, relativePath) => {
+    const cwd = await makeProject({ approvedWordsPath: relativePath })
+    if (kind === "unreadable") await mkdir(join(cwd, relativePath))
+
+    const result = await runCli([], { cwd, stdin: "Alphaword." })
+
+    expect(result.code).toBe(2)
+    expect(result.stderr).toContain(join(cwd, relativePath))
+    expect(result.stderr).toContain("cannot read file")
+  })
+
   test("project config changes the sentence word cap", async () => {
     const cwd = await makeProject({ maxSentenceWords: 5 })
     const result = await runCli([], { cwd, stdin: tenWords })

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -250,7 +250,7 @@ describe("simple-english CLI hook mode", () => {
       ),
     ) as SessionState
     expect(enabledState).toMatchObject({ version: 3, enabled: true, strict: false })
-  })
+  }, 15_000)
 
   test("starts a new session in enabled non-strict mode", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -51,6 +51,17 @@ async function makeProject(config?: object): Promise<string> {
   return cwd
 }
 
+const approvedWordList = (approvedWords: readonly string[]) => ({
+  formatVersion: 1,
+  source: {
+    name: "synthetic test fixture",
+    repository: "https://example.test/approved-words",
+    commit: "fixture",
+    path: "approved-words.json",
+  },
+  approvedWords,
+})
+
 function event(
   cwd: string,
   toolName: "Write" | "Edit" | "Bash",
@@ -287,6 +298,29 @@ describe("simple-english CLI hook mode", () => {
     expect(failedDictionary.code).toBe(0)
     expect(failedDictionary.stdout).toContain("Dictionary: failed (")
     expect(failedDictionary.stdout).toContain("missing-dictionary.json")
+  })
+
+  test("reports approved-word list status with dictionary precedence", async () => {
+    const cwd = await makeProject({ approvedWordsPath: "approved-words.json" })
+    const approvedWordsPath = join(cwd, "approved-words.json")
+    await writeFile(approvedWordsPath, JSON.stringify(approvedWordList(["alphaword"])))
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const loaded = await runSessionCommand(
+      "session-1",
+      cwd,
+      "status",
+      xdgStateHome,
+      join(cwd, "missing-dictionary.json"),
+    )
+
+    expect(loaded.stdout).toContain("Dictionary: loaded")
+
+    await rm(approvedWordsPath)
+    const missing = await runSessionCommand("session-1", cwd, "status", xdgStateHome)
+    expect(missing.stdout).toContain("Dictionary: failed (")
+    expect(missing.stdout).toContain("approved-words.json")
   })
 
   test("reports unavailable status details when config loading fails", async () => {
@@ -734,6 +768,51 @@ describe("simple-english CLI hook mode", () => {
     const output = decision(result.output)
     expect(output.hookEventName).toBe("SessionStart")
     expect(output.additionalContext).toContain("Simplified Technical English")
+  })
+
+  test("uses an approved-word list from the event directory", async () => {
+    const cwd = await makeProject({ approvedWordsPath: "approved-words.json" })
+    await writeFile(
+      join(cwd, "approved-words.json"),
+      JSON.stringify(approvedWordList(["alphaword"])),
+    )
+
+    const approved = await runHook(
+      event(cwd, "Write", {
+        file_path: join(cwd, "approved.md"),
+        content: "ALPHAWORD.",
+      }),
+      repoRoot,
+    )
+    const absent = await runHook(
+      event(cwd, "Write", {
+        file_path: join(cwd, "absent.md"),
+        content: "Betaword.",
+      }),
+      repoRoot,
+    )
+
+    expect(decision(approved.output).permissionDecision).toBe("allow")
+    expect(decision(absent.output).permissionDecision).toBe("deny")
+    expect(decision(absent.output).permissionDecisionReason).toContain(
+      '"Betaword" is not in the approved-word list.',
+    )
+  })
+
+  test("allows a hook event with a warning when the approved-word list is missing", async () => {
+    const cwd = await makeProject({ approvedWordsPath: "missing-approved-words.json" })
+    const result = await runHook(
+      event(cwd, "Write", {
+        file_path: join(cwd, "notes.md"),
+        content: "Alphaword.",
+      }),
+      repoRoot,
+    )
+
+    const output = decision(result.output)
+    expect(output.permissionDecision).toBe("allow")
+    expect(output.additionalContext).toContain("missing-approved-words.json")
+    expect(output.additionalContext).toContain("event is allowed")
   })
 
   test("resolves a custom dictionary from the event directory", async () => {

--- a/test/config/merge.test.ts
+++ b/test/config/merge.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from "vitest"
 import { mergeConfigs } from "../../src/config/merge.ts"
 
 describe("config merge", () => {
-  test("project scalar wins over global", () => {
-    const merged = mergeConfigs({ maxSentenceWords: 20 }, { maxSentenceWords: 15 })
+  test("project scalars win over global values", () => {
+    const merged = mergeConfigs(
+      { maxSentenceWords: 20, approvedWordsPath: "global.json" },
+      { maxSentenceWords: 15, approvedWordsPath: "project.json" },
+    )
 
-    expect(merged).toEqual({ maxSentenceWords: 15 })
+    expect(merged).toEqual({ maxSentenceWords: 15, approvedWordsPath: "project.json" })
   })
 
   test("rules deep-merge per key with project winning", () => {

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -15,6 +15,7 @@ describe("config schema", () => {
     const result = decode({
       rules: { "sentence-length": "soft" },
       maxSentenceWords: 20,
+      approvedWordsPath: "config/approved-words.json",
     })
 
     expect(result._tag).toBe("Right")
@@ -22,6 +23,7 @@ describe("config schema", () => {
       expect(result.right).toEqual({
         rules: { "sentence-length": "soft" },
         maxSentenceWords: 20,
+        approvedWordsPath: "config/approved-words.json",
       })
     }
   })
@@ -64,6 +66,13 @@ describe("config schema", () => {
       const message = expectDecodeError({ maxSentenceWords: bad })
       expect(message).toContain("maxSentenceWords")
       expect(message).toContain("positive integer")
+    }
+  })
+
+  test("approvedWordsPath must be a non-empty string", () => {
+    for (const bad of ["", "   ", 42]) {
+      const message = expectDecodeError({ approvedWordsPath: bad })
+      expect(message).toContain("approvedWordsPath")
     }
   })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -76,6 +76,23 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: approvedWordList }).violations).toEqual([])
   })
 
+  test("checks prose that only resembles a Markdown link destination", () => {
+    const report = lint("prose-file", "Alphaword ](betaword) word-form.", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 13,
+      },
+    ])
+  })
+
   test("flags a word that is absent from the approved-word list", () => {
     const report = lint("prose-file", "Alphaword betaword.", { dictionary: approvedWordList })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -305,6 +305,26 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("resolves deep image resources before inline code spans", () => {
+    const text = `${"![x ".repeat(33)}Alphaword](target\`) Betaword \`${"](v)".repeat(32)}`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 153,
+      },
+    ])
+  })
+
   test("invalidates parent links around resolved shortcut references", () => {
     const text = "[Alphaword [word-form]](Betaword)\n\n[word-form]: /target"
     const report = lint("prose-file", text, { dictionary: approvedWordList })
@@ -502,6 +522,18 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds unmatched resources in deeply nested images", () => {
     const depth = 10_000
     const text = `${"![x ".repeat(depth)}x${"](".repeat(depth)}`
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
+
+  test("bounds overlapping resources in deeply nested images", () => {
+    const count = 2_000
+    const text = `${`${"![".repeat(33)}x](`.repeat(count)}u${")".repeat(count)}`
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
     const list = {
       ...approvedWordList,

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -549,6 +549,17 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   }, 3_000)
 
+  test("bounds malformed CDATA probes", () => {
+    const text = "<![CDATA[".repeat(10_000)
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "cdata"],
+    }
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
+
   test("bounds unmatched resources in deeply nested images", () => {
     const depth = 10_000
     const text = `${"![x ".repeat(depth)}x${"](".repeat(depth)}`

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -140,6 +140,25 @@ describe("lint prose-file: dictionary rule", () => {
     ).toEqual([])
   })
 
+  test("ignores HTML flow tags while retaining visible content", () => {
+    const report = lint(
+      "prose-file",
+      '<div class="attribute">\nAlphaword Betaword\n</div>',
+      { dictionary: approvedWordList },
+    )
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 11,
+      },
+    ])
+  })
+
   test("does not pair link delimiters across Markdown inline blocks", () => {
     const report = lint("prose-file", "[Alphaword\n# word-form](Betaword)", {
       dictionary: approvedWordList,
@@ -223,6 +242,22 @@ describe("lint prose-file: dictionary rule", () => {
         const text = `${"![x ".repeat(depth)}${opaqueSegment}${"](v)".repeat(depth)}`
         expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
       }
+    },
+    3_000,
+  )
+
+  test(
+    "bounds deep image parsing after an unmatched code span in another block",
+    () => {
+      const depth = 5_000
+      const text = `\`\n# ${"![x ".repeat(depth)}x${"](v)".repeat(depth)}\``
+      const list = {
+        ...approvedWordList,
+        approvedWords: [...approvedWordList.approvedWords, "x"],
+      }
+      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+      expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
     },
     3_000,
   )

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -348,6 +348,25 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   }, 3_000)
 
+  test("bounds deeply nested unresolved labels", () => {
+    const depth = 16_000
+    const text = `${"[".repeat(depth)}Alphaword${"]".repeat(depth)}`
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: approvedWordList, rules }).violations).toEqual(
+      [],
+    )
+  }, 3_000)
+
+  test("masks resources on deeply nested link labels", () => {
+    const text = `${"[".repeat(33)}Alphaword](Betaword)${"]".repeat(32)}`
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(
+      lint("prose-file", text, { dictionary: approvedWordList, rules }).violations,
+    ).toEqual([])
+  })
+
   test.each([
     ["collapsed", "][]"],
     ["shortcut", "]"],
@@ -367,8 +386,10 @@ describe("lint prose-file: dictionary rule", () => {
     3_000,
   )
 
-  test("does not build deep-resource indexes for large plain prose", () => {
-    const text = "Alphaword ".repeat(100_000)
+  test.each([
+    ["large plain prose", "Alphaword ".repeat(100_000)],
+    ["many shallow images", "![Alphaword](target) ".repeat(10_000)],
+  ])("does not build deep-resource indexes for %s", (_name, text) => {
     const OriginalInt32Array = globalThis.Int32Array
     let fullDocumentAllocations = 0
     const instrumentedInt32Array = new Proxy(OriginalInt32Array, {
@@ -381,7 +402,7 @@ describe("lint prose-file: dictionary rule", () => {
 
     globalThis.Int32Array = instrumentedInt32Array
     try {
-      expect(blankMarkdownDestinations([text])).toEqual([text])
+      blankMarkdownDestinations([text])
     } finally {
       globalThis.Int32Array = OriginalInt32Array
     }

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -69,6 +69,7 @@ describe("lint prose-file: dictionary rule", () => {
     const text = [
       "[Alphaword](https://example.test/private-path)",
       "<https://example.test/private-path>",
+      "",
       "[target]: /private/path",
       "[Alphaword][target]",
     ].join("\n")
@@ -92,6 +93,87 @@ describe("lint prose-file: dictionary rule", () => {
       },
     ])
   })
+
+  test("checks destinations after nested links as prose", () => {
+    const report = lint(
+      "prose-file",
+      "[Alphaword [word-form](inner-target)](betaword)",
+      { dictionary: approvedWordList },
+    )
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 39,
+      },
+    ])
+  })
+
+  test("checks unresolved Markdown reference labels as prose", () => {
+    const report = lint("prose-file", "[Alphaword][Betaword]", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 13,
+      },
+    ])
+  })
+
+  test("resolves normalized references defined in nested Markdown containers", () => {
+    const text = [
+      "> > > > [TaRGeT   ẞ Label]: /private/path",
+      "",
+      "[Alphaword][target ss label]",
+    ].join("\n")
+
+    expect(lint("prose-file", text, { dictionary: approvedWordList }).violations).toEqual([])
+  })
+
+  test("resolves references defined after source-comment prefixes", () => {
+    const text = [
+      "const first = 1 // [Target Label]: /private/path",
+      "const second = 2 // [Alphaword][target label]",
+    ].join("\n")
+
+    expect(lint("slash-source", text, { dictionary: approvedWordList }).violations).toEqual([])
+  })
+
+  test.each([
+    ["[Alphaword]: betaword extra", ["betaword", "extra"]],
+    ["Alphaword\n[Alphaword]: betaword", ["betaword"]],
+  ])(
+    "checks malformed or interrupting reference definitions as prose: %s",
+    (text, unapproved) => {
+      const report = lint("prose-file", text, { dictionary: approvedWordList })
+
+      expect(report.violations.map((violation) => violation.message)).toEqual(
+        unapproved.map((word) => `"${word}" is not in the approved-word list.`),
+      )
+    },
+  )
+
+  test("bounds malformed Markdown destination parsing", () => {
+    const text = "[a](".repeat(50_000)
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "a"],
+    }
+
+    expect(lint("prose-file", text, { rules }).violations).toEqual([])
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
 
   test("flags a word that is absent from the approved-word list", () => {
     const report = lint("prose-file", "Alphaword betaword.", { dictionary: approvedWordList })

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import type { Dictionary } from "../../src/dictionary/schema.ts"
+import type { ApprovedWordList, Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 import type { Tagger } from "../../src/engine/tagger.ts"
 
@@ -19,6 +19,17 @@ const dictionary = {
     { unapproved: ["state-of-the-art"], suggestions: ["advanced"] },
   ],
 } as const satisfies Dictionary
+
+const approvedWordList = {
+  formatVersion: 1,
+  source: {
+    name: "synthetic test fixture",
+    repository: "https://example.test/approved-words",
+    commit: "fixture",
+    path: "approved-words.json",
+  },
+  approvedWords: ["alphaword", "word-form"],
+} as const satisfies ApprovedWordList
 
 const tagger: Tagger = (text) => {
   if (text === "Attempt the repair.") {
@@ -41,6 +52,59 @@ const tagger: Tagger = (text) => {
 }
 
 describe("lint prose-file: dictionary rule", () => {
+  test("allows listed words without regard to case in approved-word mode", () => {
+    expect(lint("prose-file", "ALPHAWORD.", { dictionary: approvedWordList }).violations).toEqual(
+      [],
+    )
+  })
+
+  test("ignores Markdown container markers in approved-word mode", () => {
+    expect(
+      lint("prose-file", "- ALPHAWORD.\n1. Alphaword.", { dictionary: approvedWordList })
+        .violations,
+    ).toEqual([])
+  })
+
+  test("ignores Markdown link destinations in approved-word mode", () => {
+    const text = [
+      "[Alphaword](https://example.test/private-path)",
+      "<https://example.test/private-path>",
+      "[target]: /private/path",
+      "[Alphaword][target]",
+    ].join("\n")
+
+    expect(lint("prose-file", text, { dictionary: approvedWordList }).violations).toEqual([])
+  })
+
+  test("flags a word that is absent from the approved-word list", () => {
+    const report = lint("prose-file", "Alphaword betaword.", { dictionary: approvedWordList })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 11,
+      },
+    ])
+  })
+
+  test("treats approved word forms and hyphenated words as exact tokens", () => {
+    expect(lint("prose-file", "Word-form.", { dictionary: approvedWordList }).violations).toEqual(
+      [],
+    )
+    expect(lint("prose-file", "Alphawords.", { dictionary: approvedWordList }).violations).toEqual([
+      expect.objectContaining({
+        ruleId: "dictionary-not-approved-word",
+        message: '"Alphawords" is not in the approved-word list.',
+        line: 1,
+        column: 1,
+      }),
+    ])
+  })
+
   test("flags an unapproved word as hard and suggests its approved alternative", () => {
     const report = lint("prose-file", "Attempt the repair.", { dictionary, tagger })
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -113,6 +113,77 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("does not pair link delimiters across Markdown inline blocks", () => {
+    const report = lint("prose-file", "[Alphaword\n# word-form](Betaword)", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 14,
+      },
+    ])
+  })
+
+  test("resolves link destinations before inline code spans", () => {
+    const report = lint("prose-file", "[Alphaword](target`) Betaword `", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 22,
+      },
+    ])
+  })
+
+  test("invalidates parent links around resolved shortcut references", () => {
+    const text = "[Alphaword [word-form]](Betaword)\n\n[word-form]: /target"
+    const report = lint("prose-file", text, { dictionary: approvedWordList })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 25,
+      },
+    ])
+  })
+
+  test("validates Markdown email autolinks", () => {
+    expect(
+      lint("prose-file", "<Alphaword@example.test>", { dictionary: approvedWordList })
+        .violations,
+    ).toEqual([])
+
+    expect(
+      lint("prose-file", "<Alphaword@-Betaword>", { dictionary: approvedWordList })
+        .violations,
+    ).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 13,
+      },
+    ])
+  })
+
   test("checks unresolved Markdown reference labels as prose", () => {
     const report = lint("prose-file", "[Alphaword][Betaword]", {
       dictionary: approvedWordList,
@@ -163,6 +234,62 @@ describe("lint prose-file: dictionary rule", () => {
     },
   )
 
+  test("requires horizontal separation before a next-line definition title", () => {
+    expect(
+      lint("prose-file", '[target]: /path\n "Betaword"', {
+        dictionary: approvedWordList,
+      }).violations,
+    ).toEqual([])
+
+    const report = lint("prose-file", '[target]: /path\n"Betaword"', {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 2,
+      },
+    ])
+  })
+
+  test("keeps noninterrupting ordered list markers in the paragraph", () => {
+    const report = lint("prose-file", "Alphaword\n2. [target]: Betaword", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"2" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 1,
+      },
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"target" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 5,
+      },
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 14,
+      },
+    ])
+  })
+
   test("bounds malformed Markdown destination parsing", () => {
     const text = "[a](".repeat(50_000)
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
@@ -172,6 +299,18 @@ describe("lint prose-file: dictionary rule", () => {
     }
 
     expect(lint("prose-file", text, { rules }).violations).toEqual([])
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
+
+  test("bounds nested link parsing in image descriptions", () => {
+    const depth = 10_000
+    const text = `${"![x [a](u) ".repeat(depth)}x${"](v)".repeat(depth)}`
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "a", "x"],
+    }
+
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   }, 3_000)
 

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -256,6 +256,65 @@ describe("lint prose-file: dictionary rule", () => {
     },
   )
 
+  test("masks resolved full references in deeply nested images", () => {
+    const text = `${"![x ".repeat(33)}Alphaword${"][r]".repeat(33)}\n\n[r]: /u`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  })
+
+  test("keeps unresolved deep image reference labels visible", () => {
+    const text = `${"![x ".repeat(33)}Alphaword${"][r]".repeat(33)}`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const violations = lint("prose-file", text, { dictionary: list, rules }).violations
+
+    expect(violations).toHaveLength(33)
+    expect(
+      violations.every(
+        (violation) => violation.message === '"r" is not in the approved-word list.',
+      ),
+    ).toBe(true)
+  })
+
+  test("bounds valid nested full reference images", () => {
+    const depth = 5_000
+    const text = `${"![x ".repeat(depth)}x${"][r]".repeat(depth)}\n\n[r]: /u`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
+
+  test.each([
+    ["collapsed", "][]"],
+    ["shortcut", "]"],
+  ])(
+    "bounds malformed nested %s reference images",
+    (_kind, closing) => {
+      const depth = 5_000
+      const text = `${"![x ".repeat(depth)}x${closing.repeat(depth)}`
+      const list = {
+        ...approvedWordList,
+        approvedWords: [...approvedWordList.approvedWords, "x"],
+      }
+      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+      expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+    },
+    3_000,
+  )
+
   test("does not build deep-resource indexes for large plain prose", () => {
     const text = "Alphaword ".repeat(100_000)
     const OriginalInt32Array = globalThis.Int32Array

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -234,6 +234,12 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("resets deep label fallback across Markdown inline blocks", () => {
+    const text = `${"[".repeat(33)}Alphaword\n\n[target]: /Betaword`
+
+    expect(lint("prose-file", text, { dictionary: approvedWordList }).violations).toEqual([])
+  })
+
   test("does not use deep image delimiters from code spans", () => {
     const text = `\`${"![".repeat(33)}\`](Betaword)`
     const report = lint("prose-file", text, { dictionary: approvedWordList })
@@ -389,6 +395,7 @@ describe("lint prose-file: dictionary rule", () => {
   test.each([
     ["large plain prose", "Alphaword ".repeat(100_000)],
     ["many shallow images", "![Alphaword](target) ".repeat(10_000)],
+    ["brackets in a shallow resource", `[Alphaword](path${"[".repeat(33)})`],
   ])("does not build deep-resource indexes for %s", (_name, text) => {
     const OriginalInt32Array = globalThis.Int32Array
     let fullDocumentAllocations = 0
@@ -522,6 +529,23 @@ describe("lint prose-file: dictionary rule", () => {
         suggestions: [],
         line: 1,
         column: 25,
+      },
+    ])
+  })
+
+  test("invalidates deep parent links around resolved shortcut references", () => {
+    const text = `${"[Alphaword ".repeat(33)}[word-form]](Betaword)${"]".repeat(32)}\n\n[word-form]: /target`
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const report = lint("prose-file", text, { dictionary: approvedWordList, rules })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: text.indexOf("Betaword") + 1,
       },
     ])
   })

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -154,6 +154,15 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test.each(["pre", "script", "style", "textarea"])(
+    "ignores raw content in %s HTML flow blocks",
+    (tag) => {
+      const text = `<${tag}>\nBetaword\n</${tag}>`
+
+      expect(lint("prose-file", text, { dictionary: approvedWordList }).violations).toEqual([])
+    },
+  )
+
   test("checks invalid tag-like text inside HTML flow blocks", () => {
     const report = lint("prose-file", "<div>\n<[Betaword]>\n</div>", {
       dictionary: approvedWordList,
@@ -274,6 +283,27 @@ describe("lint prose-file: dictionary rule", () => {
       const text = `${"![x ".repeat(depth)}${opaqueSegment}${"](v)".repeat(depth)}`
       expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
     }
+  }, 3_000)
+
+  test("bounds deep image parsing without creating email autolinks", () => {
+    const depth = 5_000
+    const text = `${"![x ".repeat(depth)}<a${"]".repeat(depth)}@x>](Betaword)`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "a", "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: text.indexOf("Betaword") + 1,
+      },
+    ])
   }, 3_000)
 
   test("bounds deep image parsing after an unmatched code span in another block", () => {

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -130,6 +130,16 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("ignores Markdown HTML and character reference syntax", () => {
+    expect(
+      lint(
+        "prose-file",
+        '<span class="betaword">Alphaword</span> &copy; <![CDATA[betaword]]>',
+        { dictionary: approvedWordList, rules: { semicolon: "off" } },
+      ).violations,
+    ).toEqual([])
+  })
+
   test("does not pair link delimiters across Markdown inline blocks", () => {
     const report = lint("prose-file", "[Alphaword\n# word-form](Betaword)", {
       dictionary: approvedWordList,
@@ -191,6 +201,28 @@ describe("lint prose-file: dictionary rule", () => {
       const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
       expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+    },
+    3_000,
+  )
+
+  test(
+    "bounds deep image parsing around opaque inline syntax",
+    () => {
+      const depth = 5_000
+      const opaqueSegments = [
+        `<http:${"[".repeat(depth)}>`,
+        `<span data-value="${"[".repeat(depth)}">`,
+      ]
+      const list = {
+        ...approvedWordList,
+        approvedWords: [...approvedWordList.approvedWords, "x"],
+      }
+      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+      for (const opaqueSegment of opaqueSegments) {
+        const text = `${"![x ".repeat(depth)}${opaqueSegment}${"](v)".repeat(depth)}`
+        expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+      }
     },
     3_000,
   )

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -352,7 +352,7 @@ describe("lint prose-file: dictionary rule", () => {
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
-  }, 3_000)
+  }, 10_000)
 
   test("bounds deeply nested unresolved labels", () => {
     const depth = 16_000
@@ -769,7 +769,7 @@ describe("lint prose-file: dictionary rule", () => {
     }
 
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
-  }, 3_000)
+  }, 10_000)
 
   test("compiles a large approved-word list once across prose runs", () => {
     const approvedWords: [string, ...string[]] = [

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -95,11 +95,9 @@ describe("lint prose-file: dictionary rule", () => {
   })
 
   test("checks destinations after nested links as prose", () => {
-    const report = lint(
-      "prose-file",
-      "[Alphaword [word-form](inner-target)](betaword)",
-      { dictionary: approvedWordList },
-    )
+    const report = lint("prose-file", "[Alphaword [word-form](inner-target)](betaword)", {
+      dictionary: approvedWordList,
+    })
 
     expect(report.violations).toEqual([
       {
@@ -132,20 +130,17 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("ignores Markdown HTML and character reference syntax", () => {
     expect(
-      lint(
-        "prose-file",
-        '<span class="betaword">Alphaword</span> &copy; <![CDATA[betaword]]>',
-        { dictionary: approvedWordList, rules: { semicolon: "off" } },
-      ).violations,
+      lint("prose-file", '<span class="betaword">Alphaword</span> &copy; <![CDATA[betaword]]>', {
+        dictionary: approvedWordList,
+        rules: { semicolon: "off" },
+      }).violations,
     ).toEqual([])
   })
 
   test("ignores HTML flow tags while retaining visible content", () => {
-    const report = lint(
-      "prose-file",
-      '<div class="attribute">\nAlphaword Betaword\n</div>',
-      { dictionary: approvedWordList },
-    )
+    const report = lint("prose-file", '<div class="attribute">\nAlphaword Betaword\n</div>', {
+      dictionary: approvedWordList,
+    })
 
     expect(report.violations).toEqual([
       {
@@ -155,6 +150,23 @@ describe("lint prose-file: dictionary rule", () => {
         suggestions: [],
         line: 2,
         column: 11,
+      },
+    ])
+  })
+
+  test("checks invalid tag-like text inside HTML flow blocks", () => {
+    const report = lint("prose-file", "<div>\n<[Betaword]>\n</div>", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 3,
       },
     ])
   })
@@ -220,12 +232,23 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   })
 
-  test.each([
-    'target "Betaword(foo"',
-    "target 'Betaword(foo'",
-    String.raw`target (Betaword\)foo)`,
-  ])("parses %s titles in deeply nested images", (resource) => {
-    const text = `${"![x ".repeat(33)}Alphaword](${resource})${"](v)".repeat(32)}`
+  test.each(['target "Betaword(foo"', "target 'Betaword(foo'", String.raw`target (Betaword\)foo)`])(
+    "parses %s titles in deeply nested images",
+    (resource) => {
+      const text = `${"![x ".repeat(33)}Alphaword](${resource})${"](v)".repeat(32)}`
+      const list = {
+        ...approvedWordList,
+        approvedWords: [...approvedWordList.approvedWords, "x"],
+      }
+      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+      expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+    },
+  )
+
+  test("bounds deep image parsing when code spans contain brackets", () => {
+    const depth = 10_000
+    const text = `${"![x ".repeat(depth)}\`${"[".repeat(depth)}\`${"](v)".repeat(depth)}`
     const list = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
@@ -233,61 +256,37 @@ describe("lint prose-file: dictionary rule", () => {
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
-  })
+  }, 3_000)
 
-  test(
-    "bounds deep image parsing when code spans contain brackets",
-    () => {
-      const depth = 10_000
-      const text = `${"![x ".repeat(depth)}\`${"[".repeat(depth)}\`${"](v)".repeat(depth)}`
-      const list = {
-        ...approvedWordList,
-        approvedWords: [...approvedWordList.approvedWords, "x"],
-      }
-      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+  test("bounds deep image parsing around opaque inline syntax", () => {
+    const depth = 5_000
+    const opaqueSegments = [
+      `<http:${"[".repeat(depth)}>`,
+      `<span data-value="${"[".repeat(depth)}">`,
+    ]
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
+    for (const opaqueSegment of opaqueSegments) {
+      const text = `${"![x ".repeat(depth)}${opaqueSegment}${"](v)".repeat(depth)}`
       expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
-    },
-    3_000,
-  )
+    }
+  }, 3_000)
 
-  test(
-    "bounds deep image parsing around opaque inline syntax",
-    () => {
-      const depth = 5_000
-      const opaqueSegments = [
-        `<http:${"[".repeat(depth)}>`,
-        `<span data-value="${"[".repeat(depth)}">`,
-      ]
-      const list = {
-        ...approvedWordList,
-        approvedWords: [...approvedWordList.approvedWords, "x"],
-      }
-      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+  test("bounds deep image parsing after an unmatched code span in another block", () => {
+    const depth = 5_000
+    const text = `\`\n# ${"![x ".repeat(depth)}x${"](v)".repeat(depth)}\``
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
-      for (const opaqueSegment of opaqueSegments) {
-        const text = `${"![x ".repeat(depth)}${opaqueSegment}${"](v)".repeat(depth)}`
-        expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
-      }
-    },
-    3_000,
-  )
-
-  test(
-    "bounds deep image parsing after an unmatched code span in another block",
-    () => {
-      const depth = 5_000
-      const text = `\`\n# ${"![x ".repeat(depth)}x${"](v)".repeat(depth)}\``
-      const list = {
-        ...approvedWordList,
-        approvedWords: [...approvedWordList.approvedWords, "x"],
-      }
-      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
-
-      expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
-    },
-    3_000,
-  )
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
 
   test("resolves link destinations before inline code spans", () => {
     const report = lint("prose-file", "[Alphaword](target`) Betaword `", {
@@ -324,13 +323,11 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("validates Markdown email autolinks", () => {
     expect(
-      lint("prose-file", "<Alphaword@example.test>", { dictionary: approvedWordList })
-        .violations,
+      lint("prose-file", "<Alphaword@example.test>", { dictionary: approvedWordList }).violations,
     ).toEqual([])
 
     expect(
-      lint("prose-file", "<Alphaword@-Betaword>", { dictionary: approvedWordList })
-        .violations,
+      lint("prose-file", "<Alphaword@-Betaword>", { dictionary: approvedWordList }).violations,
     ).toEqual([
       {
         ruleId: "dictionary-not-approved-word",
@@ -382,16 +379,13 @@ describe("lint prose-file: dictionary rule", () => {
   test.each([
     ["[Alphaword]: betaword extra", ["betaword", "extra"]],
     ["Alphaword\n[Alphaword]: betaword", ["betaword"]],
-  ])(
-    "checks malformed or interrupting reference definitions as prose: %s",
-    (text, unapproved) => {
-      const report = lint("prose-file", text, { dictionary: approvedWordList })
+  ])("checks malformed or interrupting reference definitions as prose: %s", (text, unapproved) => {
+    const report = lint("prose-file", text, { dictionary: approvedWordList })
 
-      expect(report.violations.map((violation) => violation.message)).toEqual(
-        unapproved.map((word) => `"${word}" is not in the approved-word list.`),
-      )
-    },
-  )
+    expect(report.violations.map((violation) => violation.message)).toEqual(
+      unapproved.map((word) => `"${word}" is not in the approved-word list.`),
+    )
+  })
 
   test("requires horizontal separation before a next-line definition title", () => {
     expect(
@@ -505,6 +499,18 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   }, 3_000)
 
+  test("bounds unmatched resources in deeply nested images", () => {
+    const depth = 10_000
+    const text = `${"![x ".repeat(depth)}x${"](".repeat(depth)}`
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  }, 3_000)
+
   test("bounds nested link parsing in image descriptions", () => {
     const depth = 10_000
     const text = `${"![x [a](u) ".repeat(depth)}x${"](v)".repeat(depth)}`
@@ -517,21 +523,17 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   }, 3_000)
 
-  test(
-    "compiles a large approved-word list once across prose runs",
-    () => {
-      const approvedWords = Array.from({ length: 100_000 }, (_, index) => `synthetic-${index}`)
-      approvedWords[0] = "alphaword"
-      const text = Array.from(
-        { length: 500 },
-        (_, index) => `// ALPHAWORD.\nconst separator${index} = 0;`,
-      ).join("\n")
-      const list = { ...approvedWordList, approvedWords }
+  test("compiles a large approved-word list once across prose runs", () => {
+    const approvedWords = Array.from({ length: 100_000 }, (_, index) => `synthetic-${index}`)
+    approvedWords[0] = "alphaword"
+    const text = Array.from(
+      { length: 500 },
+      (_, index) => `// ALPHAWORD.\nconst separator${index} = 0;`,
+    ).join("\n")
+    const list = { ...approvedWordList, approvedWords }
 
-      expect(lint("slash-source", text, { dictionary: list }).violations).toEqual([])
-    },
-    3_000,
-  )
+    expect(lint("slash-source", text, { dictionary: list }).violations).toEqual([])
+  }, 3_000)
 
   test("flags a word that is absent from the approved-word list", () => {
     const report = lint("prose-file", "Alphaword betaword.", { dictionary: approvedWordList })

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -220,6 +220,21 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   })
 
+  test.each([
+    'target "Betaword(foo"',
+    "target 'Betaword(foo'",
+    String.raw`target (Betaword\)foo)`,
+  ])("parses %s titles in deeply nested images", (resource) => {
+    const text = `${"![x ".repeat(33)}Alphaword](${resource})${"](v)".repeat(32)}`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  })
+
   test(
     "bounds deep image parsing when code spans contain brackets",
     () => {
@@ -381,6 +396,11 @@ describe("lint prose-file: dictionary rule", () => {
   test("requires horizontal separation before a next-line definition title", () => {
     expect(
       lint("prose-file", '[target]: /path\n "Betaword"', {
+        dictionary: approvedWordList,
+      }).violations,
+    ).toEqual([])
+    expect(
+      lint("prose-file", ' [target]: /path\n "Betaword"', {
         dictionary: approvedWordList,
       }).violations,
     ).toEqual([])

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -267,6 +267,27 @@ describe("lint prose-file: dictionary rule", () => {
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   })
 
+  test("resolves deep reference suffixes before inline code spans", () => {
+    const depth = 33
+    const text = `${"![x ".repeat(depth)}Alphaword][r\`] Betaword \`${"](v)".repeat(depth - 1)}\n\n[r\`]: /u`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: text.indexOf("Betaword") + 1,
+      },
+    ])
+  })
+
   test("keeps unresolved deep image reference labels visible", () => {
     const text = `${"![x ".repeat(33)}Alphaword${"][r]".repeat(33)}`
     const list = {
@@ -285,7 +306,7 @@ describe("lint prose-file: dictionary rule", () => {
   })
 
   test("bounds valid nested full reference images", () => {
-    const depth = 5_000
+    const depth = 16_000
     const text = `${"![x ".repeat(depth)}x${"][r]".repeat(depth)}\n\n[r]: /u`
     const list = {
       ...approvedWordList,

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -258,7 +258,7 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("parses angle-bracket destinations in deeply nested images", () => {
     const text = `${"![x ".repeat(33)}Alphaword](<Betaword(foo>)${"](v)".repeat(32)}`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -272,7 +272,7 @@ describe("lint prose-file: dictionary rule", () => {
     "parses %s titles in deeply nested images",
     (resource) => {
       const text = `${"![x ".repeat(33)}Alphaword](${resource})${"](v)".repeat(32)}`
-      const list = {
+      const list: ApprovedWordList = {
         ...approvedWordList,
         approvedWords: [...approvedWordList.approvedWords, "x"],
       }
@@ -284,7 +284,7 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("keeps resource brackets opaque in deeply nested images", () => {
     const text = `${"![x ".repeat(33)}[Alphaword](foo]bar)${"](v)".repeat(33)}`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -295,7 +295,7 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("masks resolved full references in deeply nested images", () => {
     const text = `${"![x ".repeat(33)}Alphaword${"][r]".repeat(33)}\n\n[r]: /u`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -307,7 +307,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("resolves deep reference suffixes before inline code spans", () => {
     const depth = 33
     const text = `${"![x ".repeat(depth)}Alphaword][r\`] Betaword \`${"](v)".repeat(depth - 1)}\n\n[r\`]: /u`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -327,7 +327,7 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("keeps unresolved deep image reference labels visible", () => {
     const text = `${"![x ".repeat(33)}Alphaword${"][r]".repeat(33)}`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -345,7 +345,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds valid nested full reference images", () => {
     const depth = 16_000
     const text = `${"![x ".repeat(depth)}x${"][r]".repeat(depth)}\n\n[r]: /u`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -359,18 +359,14 @@ describe("lint prose-file: dictionary rule", () => {
     const text = `${"[".repeat(depth)}Alphaword${"]".repeat(depth)}`
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
-    expect(lint("prose-file", text, { dictionary: approvedWordList, rules }).violations).toEqual(
-      [],
-    )
+    expect(lint("prose-file", text, { dictionary: approvedWordList, rules }).violations).toEqual([])
   }, 3_000)
 
   test("masks resources on deeply nested link labels", () => {
     const text = `${"[".repeat(33)}Alphaword](Betaword)${"]".repeat(32)}`
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
 
-    expect(
-      lint("prose-file", text, { dictionary: approvedWordList, rules }).violations,
-    ).toEqual([])
+    expect(lint("prose-file", text, { dictionary: approvedWordList, rules }).violations).toEqual([])
   })
 
   test.each([
@@ -381,7 +377,7 @@ describe("lint prose-file: dictionary rule", () => {
     (_kind, closing) => {
       const depth = 5_000
       const text = `${"![x ".repeat(depth)}x${closing.repeat(depth)}`
-      const list = {
+      const list: ApprovedWordList = {
         ...approvedWordList,
         approvedWords: [...approvedWordList.approvedWords, "x"],
       }
@@ -420,7 +416,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds deep image parsing when code spans contain brackets", () => {
     const depth = 10_000
     const text = `${"![x ".repeat(depth)}\`${"[".repeat(depth)}\`${"](v)".repeat(depth)}`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -435,7 +431,7 @@ describe("lint prose-file: dictionary rule", () => {
       `<http:${"[".repeat(depth)}>`,
       `<span data-value="${"[".repeat(depth)}">`,
     ]
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -450,7 +446,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds deep image parsing without creating email autolinks", () => {
     const depth = 5_000
     const text = `${"![x ".repeat(depth)}<a${"]".repeat(depth)}@x>](Betaword)`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "a", "x"],
     }
@@ -471,7 +467,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds deep image parsing after an unmatched code span in another block", () => {
     const depth = 5_000
     const text = `\`\n# ${"![x ".repeat(depth)}x${"](v)".repeat(depth)}\``
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -499,7 +495,7 @@ describe("lint prose-file: dictionary rule", () => {
 
   test("resolves deep image resources before inline code spans", () => {
     const text = `${"![x ".repeat(33)}Alphaword](target\`) Betaword \`${"](v)".repeat(32)}`
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -719,7 +715,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds malformed Markdown destination parsing", () => {
     const text = "[a](".repeat(10_000)
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "a"],
     }
@@ -731,7 +727,7 @@ describe("lint prose-file: dictionary rule", () => {
   test("bounds malformed CDATA probes", () => {
     const text = "<![CDATA[".repeat(10_000)
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "cdata"],
     }
@@ -743,7 +739,7 @@ describe("lint prose-file: dictionary rule", () => {
     const depth = 10_000
     const text = `${"![x ".repeat(depth)}x${"](".repeat(depth)}`
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -755,7 +751,7 @@ describe("lint prose-file: dictionary rule", () => {
     const count = 2_000
     const text = `${`${"![".repeat(33)}x](`.repeat(count)}u${")".repeat(count)}`
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "x"],
     }
@@ -767,7 +763,7 @@ describe("lint prose-file: dictionary rule", () => {
     const depth = 10_000
     const text = `${"![x [a](u) ".repeat(depth)}x${"](v)".repeat(depth)}`
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
-    const list = {
+    const list: ApprovedWordList = {
       ...approvedWordList,
       approvedWords: [...approvedWordList.approvedWords, "a", "x"],
     }
@@ -776,13 +772,15 @@ describe("lint prose-file: dictionary rule", () => {
   }, 3_000)
 
   test("compiles a large approved-word list once across prose runs", () => {
-    const approvedWords = Array.from({ length: 100_000 }, (_, index) => `synthetic-${index}`)
-    approvedWords[0] = "alphaword"
+    const approvedWords: [string, ...string[]] = [
+      "alphaword",
+      ...Array.from({ length: 99_999 }, (_, index) => `synthetic-${index + 1}`),
+    ]
     const text = Array.from(
       { length: 500 },
       (_, index) => `// ALPHAWORD.\nconst separator${index} = 0;`,
     ).join("\n")
-    const list = { ...approvedWordList, approvedWords }
+    const list: ApprovedWordList = { ...approvedWordList, approvedWords }
 
     expect(lint("slash-source", text, { dictionary: list }).violations).toEqual([])
   }, 3_000)

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -113,6 +113,23 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("does not extend URI destination masks into following prose", () => {
+    const report = lint("prose-file", "[Alphaword](https://example.test)Betaword", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 34,
+      },
+    ])
+  })
+
   test("does not pair link delimiters across Markdown inline blocks", () => {
     const report = lint("prose-file", "[Alphaword\n# word-form](Betaword)", {
       dictionary: approvedWordList,
@@ -142,6 +159,22 @@ describe("lint prose-file: dictionary rule", () => {
         suggestions: [],
         line: 2,
         column: 5,
+      },
+    ])
+  })
+
+  test("does not use deep image delimiters from code spans", () => {
+    const text = `\`${"![".repeat(33)}\`](Betaword)`
+    const report = lint("prose-file", text, { dictionary: approvedWordList })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 71,
       },
     ])
   })

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -164,6 +164,26 @@ describe("lint prose-file: dictionary rule", () => {
     },
   )
 
+  test.each(["pre", "script", "style", "textarea"])(
+    "retains prose after self-closing %s HTML flow tags",
+    (tag) => {
+      const report = lint("prose-file", `<${tag}/>\nBetaword`, {
+        dictionary: approvedWordList,
+      })
+
+      expect(report.violations).toEqual([
+        {
+          ruleId: "dictionary-not-approved-word",
+          severity: "hard",
+          message: '"Betaword" is not in the approved-word list.',
+          suggestions: [],
+          line: 2,
+          column: 1,
+        },
+      ])
+    },
+  )
+
   test("checks invalid tag-like text inside HTML flow blocks", () => {
     const report = lint("prose-file", "<div>\n<[Betaword]>\n</div>", {
       dictionary: approvedWordList,
@@ -255,6 +275,17 @@ describe("lint prose-file: dictionary rule", () => {
       expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
     },
   )
+
+  test("keeps resource brackets opaque in deeply nested images", () => {
+    const text = `${"![x ".repeat(33)}[Alphaword](foo]bar)${"](v)".repeat(33)}`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  })
 
   test("masks resolved full references in deeply nested images", () => {
     const text = `${"![x ".repeat(33)}Alphaword${"][r]".repeat(33)}\n\n[r]: /u`

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -130,6 +130,22 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("keeps deep image delimiters within one Markdown inline block", () => {
+    const text = `${"![".repeat(33)}Alphaword\n# ](Betaword)`
+    const report = lint("prose-file", text, { dictionary: approvedWordList })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 5,
+      },
+    ])
+  })
+
   test("resolves link destinations before inline code spans", () => {
     const report = lint("prose-file", "[Alphaword](target`) Betaword `", {
       dictionary: approvedWordList,
@@ -290,8 +306,25 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("checks unbalanced definition destinations as prose", () => {
+    const report = lint("prose-file", "[Alphaword]: Betaword(", {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 1,
+        column: 14,
+      },
+    ])
+  })
+
   test("bounds malformed Markdown destination parsing", () => {
-    const text = "[a](".repeat(50_000)
+    const text = "[a](".repeat(10_000)
     const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
     const list = {
       ...approvedWordList,

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -208,6 +208,18 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test("parses angle-bracket destinations in deeply nested images", () => {
+    const text = `${"![x ".repeat(33)}Alphaword](<Betaword(foo>)${"](v)".repeat(32)}`
+    const list = {
+      ...approvedWordList,
+      approvedWords: [...approvedWordList.approvedWords, "x"],
+    }
+
+    const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+    expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+  })
+
   test(
     "bounds deep image parsing when code spans contain brackets",
     () => {
@@ -387,6 +399,28 @@ describe("lint prose-file: dictionary rule", () => {
         column: 2,
       },
     ])
+  })
+
+  test("measures definition title indentation from list content", () => {
+    const report = lint("prose-file", '- [target]: /path\n "Betaword"', {
+      dictionary: approvedWordList,
+    })
+
+    expect(report.violations).toEqual([
+      {
+        ruleId: "dictionary-not-approved-word",
+        severity: "hard",
+        message: '"Betaword" is not in the approved-word list.',
+        suggestions: [],
+        line: 2,
+        column: 3,
+      },
+    ])
+    expect(
+      lint("prose-file", '- [target]: /path\n   "Betaword"', {
+        dictionary: approvedWordList,
+      }).violations,
+    ).toEqual([])
   })
 
   test("keeps noninterrupting ordered list markers in the paragraph", () => {

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest"
 import type { ApprovedWordList, Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
+import { blankMarkdownDestinations } from "../../src/engine/markdown.ts"
 import type { Tagger } from "../../src/engine/tagger.ts"
 
 const dictionary = {
@@ -254,6 +255,28 @@ describe("lint prose-file: dictionary rule", () => {
       expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
     },
   )
+
+  test("does not build deep-resource indexes for large plain prose", () => {
+    const text = "Alphaword ".repeat(100_000)
+    const OriginalInt32Array = globalThis.Int32Array
+    let fullDocumentAllocations = 0
+    const instrumentedInt32Array = new Proxy(OriginalInt32Array, {
+      construct(target, argumentsList) {
+        const length = argumentsList[0]
+        if (typeof length === "number" && length >= text.length) fullDocumentAllocations++
+        return Reflect.construct(target, argumentsList, target)
+      },
+    })
+
+    globalThis.Int32Array = instrumentedInt32Array
+    try {
+      expect(blankMarkdownDestinations([text])).toEqual([text])
+    } finally {
+      globalThis.Int32Array = OriginalInt32Array
+    }
+
+    expect(fullDocumentAllocations).toBe(1)
+  })
 
   test("bounds deep image parsing when code spans contain brackets", () => {
     const depth = 10_000

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -179,6 +179,22 @@ describe("lint prose-file: dictionary rule", () => {
     ])
   })
 
+  test(
+    "bounds deep image parsing when code spans contain brackets",
+    () => {
+      const depth = 10_000
+      const text = `${"![x ".repeat(depth)}\`${"[".repeat(depth)}\`${"](v)".repeat(depth)}`
+      const list = {
+        ...approvedWordList,
+        approvedWords: [...approvedWordList.approvedWords, "x"],
+      }
+      const rules = { "sentence-length": "off", "paragraph-length": "off" } as const
+
+      expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
+    },
+    3_000,
+  )
+
   test("resolves link destinations before inline code spans", () => {
     const report = lint("prose-file", "[Alphaword](target`) Betaword `", {
       dictionary: approvedWordList,
@@ -379,6 +395,22 @@ describe("lint prose-file: dictionary rule", () => {
 
     expect(lint("prose-file", text, { dictionary: list, rules }).violations).toEqual([])
   }, 3_000)
+
+  test(
+    "compiles a large approved-word list once across prose runs",
+    () => {
+      const approvedWords = Array.from({ length: 100_000 }, (_, index) => `synthetic-${index}`)
+      approvedWords[0] = "alphaword"
+      const text = Array.from(
+        { length: 500 },
+        (_, index) => `// ALPHAWORD.\nconst separator${index} = 0;`,
+      ).join("\n")
+      const list = { ...approvedWordList, approvedWords }
+
+      expect(lint("slash-source", text, { dictionary: list }).violations).toEqual([])
+    },
+    3_000,
+  )
 
   test("flags a word that is absent from the approved-word list", () => {
     const report = lint("prose-file", "Alphaword betaword.", { dictionary: approvedWordList })

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -267,15 +267,22 @@ describe("lint prose-file: diff-only linting via previousText", () => {
     ).toHaveLength(0)
   })
 
-  test("a link destination edit does not report an existing allowlist violation", () => {
-    const previous = "[Alphaword](old-target) Betaword."
-    const current = "[Alphaword](longer-target) Betaword."
+  test.each([
+    ["changes", "old-target", "longer-target"],
+    ["adds", "", "target"],
+    ["removes", "target", ""],
+  ])(
+    "%s a link destination without reporting an existing allowlist violation",
+    (_description, previousTarget, currentTarget) => {
+      const previous = `[Alphaword](${previousTarget}) Betaword.`
+      const current = `[Alphaword](${currentTarget}) Betaword.`
 
-    expect(
-      lint("prose-file", current, { previousText: previous, dictionary: approvedWordList })
-        .violations,
-    ).toHaveLength(0)
-  })
+      expect(
+        lint("prose-file", current, { previousText: previous, dictionary: approvedWordList })
+          .violations,
+      ).toHaveLength(0)
+    },
+  )
 
   test("an excluded-code insertion does not select unrelated deletion-only prose", () => {
     const previous = `${words(15)}  ${words(15)}.\n\n\`\`\`\nconst oldValue = 1;\n\`\`\``

--- a/test/engine/diff-lint.test.ts
+++ b/test/engine/diff-lint.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "vitest"
-import type { Dictionary } from "../../src/dictionary/schema.ts"
+import type { ApprovedWordList, Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 
 const fixture = (name: string) =>
@@ -20,6 +20,17 @@ const dictionary = {
     { unapproved: ["prior to"], suggestions: ["before"] },
   ],
 } as const satisfies Dictionary
+
+const approvedWordList = {
+  formatVersion: 1,
+  source: {
+    name: "synthetic test fixture",
+    repository: "https://example.test/approved-words",
+    commit: "fixture",
+    path: "approved-words.json",
+  },
+  approvedWords: ["alphaword"],
+} as const satisfies ApprovedWordList
 
 describe("lint prose-file: diff-only linting via previousText", () => {
   const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
@@ -253,6 +264,16 @@ describe("lint prose-file: diff-only linting via previousText", () => {
 
     expect(
       lint("prose-file", current, { previousText: previous, dictionary }).violations,
+    ).toHaveLength(0)
+  })
+
+  test("a link destination edit does not report an existing allowlist violation", () => {
+    const previous = "[Alphaword](old-target) Betaword."
+    const current = "[Alphaword](longer-target) Betaword."
+
+    expect(
+      lint("prose-file", current, { previousText: previous, dictionary: approvedWordList })
+        .violations,
     ).toHaveLength(0)
   })
 

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -651,6 +651,7 @@ describe.sequential("pi extension wiring", () => {
   })
 
   test("uses a configured approved-word list for extension gates", async () => {
+    process.env.SIMPLE_ENGLISH_DICTIONARY = join(process.cwd(), "missing-dictionary.json")
     const { pi, context } = await startExtension({
       projectConfig: { approvedWordsPath: "approved-words.json" },
       approvedWords: ["alphaword"],
@@ -672,6 +673,23 @@ describe.sequential("pi extension wiring", () => {
         context,
       ),
     ).rejects.toThrow('"Betaword" is not in the approved-word list.')
+  })
+
+  test("fails extension gates closed when the configured approved-word list is missing", async () => {
+    const { cwd, pi, context, notifications } = await startExtension({
+      projectConfig: { approvedWordsPath: "missing-approved-words.json" },
+    })
+
+    expect(notifications.at(-1)?.message).toContain("missing-approved-words.json")
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-with-missing-list",
+        { path: "notes.md", content: "Alphaword." },
+        context,
+      ),
+    ).rejects.toThrow("STE check is unavailable")
+    await expect(readFile(join(cwd, "notes.md"), "utf8")).rejects.toThrow()
   })
 
   test("reports the mode, rule severity counts, and dictionary state", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -216,6 +216,7 @@ afterEach(async () => {
 })
 
 async function startExtension(options?: {
+  readonly approvedWords?: readonly string[]
   readonly branch?: readonly Record<string, unknown>[]
   readonly globalConfig?: object | string
   readonly legacyGlobalConfig?: object | string
@@ -258,6 +259,21 @@ async function startExtension(options?: {
     await writeFile(
       join(projectDirectory, "simple-english.json"),
       JSON.stringify(options.legacyProjectConfig),
+    )
+  }
+  if (options?.approvedWords !== undefined) {
+    await writeFile(
+      join(cwd, "approved-words.json"),
+      JSON.stringify({
+        formatVersion: 1,
+        source: {
+          name: "synthetic test fixture",
+          repository: "https://example.test/approved-words",
+          commit: "fixture",
+          path: "approved-words.json",
+        },
+        approvedWords: options.approvedWords,
+      }),
     )
   }
 
@@ -632,6 +648,30 @@ describe.sequential("pi extension wiring", () => {
     ).toContain("[contraction]")
     await pi.finalizeAssistant(assistantMessage("This isn't permitted."), context)
     expect(widgets.get("simple-english-reply")).toEqual(["Writing-rule reply: 1 hard, 0 soft"])
+  })
+
+  test("uses a configured approved-word list for extension gates", async () => {
+    const { pi, context } = await startExtension({
+      projectConfig: { approvedWordsPath: "approved-words.json" },
+      approvedWords: ["alphaword"],
+    })
+
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-approved-word",
+        { path: "approved.md", content: "ALPHAWORD." },
+        context,
+      ),
+    ).resolves.toBeDefined()
+    await expect(
+      pi.executeTool(
+        "write",
+        "write-absent-word",
+        { path: "absent.md", content: "Betaword." },
+        context,
+      ),
+    ).rejects.toThrow('"Betaword" is not in the approved-word list.')
   })
 
   test("reports the mode, rule severity counts, and dictionary state", async () => {

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -688,7 +688,7 @@ describe.sequential("pi extension wiring", () => {
         { path: "notes.md", content: "Alphaword." },
         context,
       ),
-    ).rejects.toThrow("STE check is unavailable")
+    ).rejects.toThrow("Writing-rule check is unavailable")
     await expect(readFile(join(cwd, "notes.md"), "utf8")).rejects.toThrow()
   })
 


### PR DESCRIPTION
## Intent

Implement Linear HUF-158 for simple-english so users can select a user-supplied approved-word allowlist for the dictionary rule. Add the approvedWordsPath config option, which points to a file in the package-owned dictionary data format. Extend that format only as needed for an approvedWords array, and document the extension. In allowlist mode, keep the existing dictionary finding shape and flag every prose token absent from the list. Compare exact surface forms without regard to case, including current hyphenated-token handling, and do not infer lemmas or other forms. When approvedWordsPath is configured, its list replaces both the bundled not-approved sample and any SIMPLE_ENGLISH_DICTIONARY replacement. Without approvedWordsPath, preserve existing behavior exactly. Keep lint and the engine pure and synchronous. Keep Effect at file IO, config, schema, CLI, hook, and extension boundaries. Resolve a relative approvedWordsPath from the working directory that requested config. Preserve existing boundary error behavior: lint exits 2 for a missing, unreadable, or invalid configured list, enabled pi gates fail closed, and Claude Code Hook mode warns and allows the event as it does for other load errors. Document how users create and keep this list from their own licensed ASD-STE100 copy. Ship no ASD dictionary data in source, tests, fixtures, or examples. Add engine tests for an approved word, an absent word, case-insensitive checks, exact word forms, Markdown exclusions, and unchanged finding positions. Add config schema, merge, CLI, Hook, status, and pi extension tests, including missing or unreadable files, validation errors, and precedence. Keep all existing tests, Biome, and TypeScript checks clean.

## What Changed

- Add `approvedWordsPath` configuration and validated loading across the CLI, Hook, status command, and pi extension, with precedence over bundled and environment dictionaries.
- Flag prose tokens missing from approved-word lists using case-insensitive exact forms while excluding Markdown syntax, destinations, code, and HTML metadata.
- Document the approved-word data format and licensed-list workflow, with coverage for validation, errors, precedence, positions, and Markdown parsing.

## Risk Assessment

🚨 High: Two reachable Markdown fallback defects can suppress a required allowlist finding and restore quadratic parsing on malformed input.

## Testing

No prior baseline output was supplied. Targeted engine, config, CLI, Hook, status, and pi extension tests passed, including the added fail-closed regression test. Manual CLI and Hook checks demonstrated case-insensitive exact-form approval, Markdown destination exclusion, absent-word positions, replacement precedence, exit code 2 load errors, Hook denial, and Hook warning-and-allow behavior.

<details>
<summary>Evidence: Approved-word CLI E2E transcript</summary>

```text
$ simple-english --json approved.md
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit: 0

$ simple-english --json absent.md
{
  "violations": [
    {
      "file": "absent.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Betaword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 2,
      "column": 1
    }
  ],
  "summary": {
    "total": 1,
    "hard": 1
  }
}
exit: 1

$ simple-english --config missing-list-config.json approved.md
Cannot load STE dictionary from /tmp/no-mistakes-evidence/01KYZWH42X95T9YVJPND1H8B1C/cli-project/missing-approved-words.json: cannot read file: ENOENT: no such file or directory, open '/tmp/no-mistakes-evidence/01KYZWH42X95T9YVJPND1H8B1C/cli-project/missing-approved-words.json'
exit: 2

$ simple-english --config invalid-list-config.json approved.md
Cannot load STE dictionary from /tmp/no-mistakes-evidence/01KYZWH42X95T9YVJPND1H8B1C/cli-project/invalid-approved-words.json: approvedWords[0]: Expected a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$, actual "two words"
exit: 2
```
</details>
<details>
<summary>Evidence: Approved-word Claude Code Hook E2E transcript</summary>

```text
$ simple-english hook  # Write event with an absent prose word
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"STE blocked write for /tmp/no-mistakes-evidence/01KYZWH42X95T9YVJPND1H8B1C/cli-project/notes.md:\n- line 1, column 1 [dictionary-not-approved-word]: \"Betaword\" is not in the approved-word list. Suggested fix: Use a word from the approved-word list."}}

$ simple-english hook  # Write event with a missing configured list
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","additionalContext":"STE hook warning: Cannot load STE dictionary from /tmp/no-mistakes-evidence/01KYZWH42X95T9YVJPND1H8B1C/cli-project/missing-approved-words.json: cannot read file: ENOENT: no such file or directory, open '/tmp/no-mistakes-evidence/01KYZWH42X95T9YVJPND1H8B1C/cli-project/missing-approved-words.json'. The event is allowed."}}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 errors</summary>

- 🚨 `src/engine/markdown.ts:296` - User intent requires &#34;flag every prose token absent from the list,&#34; but the new `source.indexOf(&#34;](&#34;)` scan treats every balanced `](...)` sequence as a link without verifying a matching Markdown label. For example, prose such as `Use ](forbidden) here.` masks `forbidden` and produces no dictionary finding. Parse only syntactically valid links before blanking destinations.
- 🚨 `src/engine/lint.ts:278` - Approved-list findings use destination-masked `dictionaryLines`, but their sentence identities still come from unmasked `prepared.lines`. Editing only a link destination in `[Alphaword](old) Betaword.` changes the finding key, so the unchanged `Betaword` violation is reported as new and Edit gates block. Build dictionary finding scopes from the same dictionary-visible text so excluded destination changes cannot revive existing findings.

🔧 Fix: Fix Markdown masking and allowlist finding scopes
3 errors still open:
- 🚨 `src/engine/markdown.ts:395` - The requirement to &#34;flag every prose token absent from the list&#34; remains violated for reference syntax. The code masks unresolved `[Alphaword][Betaword]` references and blanket-masks malformed definitions such as `[Alphaword]: betaword extra`; it also misses valid definitions after longer container or comment prefixes. Parse valid definitions relative to Markdown content, normalize their labels, and mask only references that resolve to them.
- 🚨 `src/engine/markdown.ts:422` - The destination-scope fix still fails when a valid destination changes between empty and nonempty. Changing `[Alphaword]() Betaword.` to `[Alphaword](target) Betaword.` changes the masked sentence identity from `()` to `( )`, so the unchanged `Betaword` finding is treated as new and Edit gates block. Canonicalize the complete destination construct, including delimiters, and add both-direction regressions.
- 🚨 `src/engine/markdown.ts:420` - Each candidate `](` starts a new forward scan. For `&#34;[a](&#34;.repeat(n)`, every scan reaches EOF with unmatched nested parentheses, making lint O(n^2). `lint.ts` also prepares these destination lines when allowlist mode is inactive, so malformed input can stall every CLI and host gate. Parse delimiters in one pass and avoid destination preparation outside allowlist mode.

🔧 Fix: Harden Markdown destination and reference parsing
7 errors still open:
- 🚨 `src/engine/markdown.ts:388` - The document-wide delimiter stack never resets at Markdown leaf-block boundaries. In `[Alphaword\n# word-form](Betaword)`, the `[` is in a paragraph and `](` is in an ATX heading, so no link exists, but the code pairs them and masks `Betaword`. This contradicts the required &#34;flag every prose token absent from the list&#34; behavior. Index delimiters within actual inline blocks.
- 🚨 `src/engine/lint.ts:115` - Destination parsing receives `markdown.lines` after inline code is blanked. For the source &#39;[Alphaword](target`) Betaword `&#39; with `target` approved, the backtick in the valid destination pairs with the later prose backtick and blanks `Betaword` before link parsing. This contradicts &#34;flag every prose token absent from the list&#34;. Resolve code-span and link precedence in one context-aware pass.
- 🚨 `src/engine/markdown.ts:796` - Only inline and full or collapsed reference suffixes deactivate parent links. In `[Alphaword [word-form]](Betaword)` with `[word-form]: /target`, the resolved shortcut reference makes the outer link invalid, but the outer destination is still masked. This contradicts &#34;flag every prose token absent from the list&#34;. Detect resolved shortcut references before masking parent destinations.
- 🚨 `src/engine/markdown.ts:646` - `nextLineStart` skips horizontal whitespace without requiring any to exist. Consequently `[target]: /path\n&#34;Betaword&#34;` treats the unindented second line as a definition title, although it is ordinary paragraph text. This contradicts &#34;flag every prose token absent from the list&#34;. Require horizontal separation before accepting a next-line title.
- 🚨 `src/engine/markdown.ts:270` - Every `LIST_MARKER` is treated as starting a new container. In `Alphaword\n2. [target]: Betaword`, an ordered list starting at 2 cannot interrupt the open Markdown paragraph, but the code consumes the marker and accepts the remainder as a definition, hiding `Betaword`. This contradicts &#34;flag every prose token absent from the list&#34;. Preserve paragraph state for non-interrupting list markers.
- 🚨 `src/engine/markdown.ts:769` - `deactivateParentLinks` walks every bracket ancestor for each nested link. Repeating `![x [a](u) ` n times, then `x`, then `](v)` n times creates valid links inside increasingly nested image descriptions and causes 1 + ... + n parent visits. This leaves an O(n^2) allowlist lint path after the claimed linear-time fix. Precompute or path-compress the nearest relevant parent.
- 🚨 `src/engine/markdown.ts:815` - The email autolink branch accepts any nonspace domain. `&lt;Alphaword@-Betaword&gt;` is not a valid Markdown email autolink because its domain label begins with `-`, but the entire sequence is blanked. This contradicts &#34;flag every prose token absent from the list&#34;. Validate email autolinks with the Markdown email grammar before masking them.

🔧 Fix: Harden allowlist Markdown parsing and performance
2 errors still open:
- 🚨 `src/engine/markdown.ts:383` - The required behavior is to &#34;flag every prose token absent from the list,&#34; but `characters[opening] = &#34;x&#34;` turns invalid Markdown into valid syntax. For example, `[target]: Betaword(` has an unbalanced destination and should expose `Betaword` as prose; replacing `(` makes micromark accept and mask the whole definition. Bound malformed parsing without changing its validity.
- 🚨 `src/engine/markdown.ts:363` - The required behavior is to &#34;flag every prose token absent from the list,&#34; but the depth fallback still pairs brackets across inline-block boundaries. In `${&#34;![&#34;.repeat(33)}Alphaword\n# ](Betaword)`, the document-wide stack creates a fallback candidate from the paragraph opener and heading closer, then masks `Betaword` although no Markdown image exists. Constrain fallback candidates to parser-established inline blocks before synthetic resource parsing.

🔧 Fix: Preserve malformed Markdown prose and inline-block boundaries
2 errors still open:
- 🚨 `src/engine/markdown.ts:537` - The requirement says to &#34;flag every prose token absent from the list,&#34; but the document-wide URI regex can extend beyond a parsed destination. In `[Alphaword](https://example.test)Betaword`, it consumes `)Betaword` and hides the visible, absent `Betaword` token. Mask only parser-produced destination or autolink ranges.
- 🚨 `src/engine/markdown.ts:369` - The deep-image fallback collects brackets without respecting inline syntax. A code span containing 33 `![` sequences followed by `](Betaword)` records an opener inside code and a closer outside it; the synthetic fallback then accepts `(Betaword)` as a resource and hides visible prose. Derive fallback candidates from parser-active delimiters, or reject candidates crossing code and other opaque inline tokens.

🔧 Fix: Fix Markdown destination masking boundaries
2 issues (1 error, 1 warning) still open:
- 🚨 `src/engine/markdown.ts:362` - The fallback scanner still treats brackets inside code spans as active delimiters. For `&#34;![x &#34;.repeat(n) + &#34;`&#34; + &#34;[&#34;.repeat(n) + &#34;`&#34; + &#34;](v)&#34;.repeat(n)`, the code-span brackets consume every closing bracket in this raw stack, so no deep-image candidates are transformed and micromark receives all n nested images unchanged. Its label-end resolver scans backward for each close, restoring the O(n^2) allowlist path that the performance fix was meant to remove. Ignore opaque-inline delimiters while building the stack, not only when filtering completed candidates.
- ⚠️ `src/engine/rules/dictionary.ts:224` - The case-folded approved-word Set is rebuilt for every `ProseRun`. Source files with many separated block comments therefore perform O(runs * approvedWords) lowercasing and allocation, which is costly for a full licensed allowlist. Compile the Set once before `evaluate` processes its runs and reuse it.

🔧 Fix: Optimize Markdown fallback and approved-list compilation
2 errors still open:
- 🚨 `src/engine/markdown.ts:497` - The fallback stack suppresses code-span delimiters only, but micromark also treats autolinks and inline HTML as opaque. For `&#34;![x &#34;.repeat(n) + &#34;&lt;http:&#34; + &#34;[&#34;.repeat(n) + &#34;&gt;&#34; + &#34;](v)&#34;.repeat(n)`, autolink brackets consume every closing bracket in the fallback stack, so no deep image is transformed while micromark ignores those brackets and restores the quadratic nested-image parse path. Exclude all opaque-inline delimiters before building the fallback stack.
- 🚨 `src/engine/markdown.ts:279` - The intent requires Markdown exclusions and checking prose tokens, but the new `MASKED_MARKDOWN_TOKENS` omits `htmlText` and `characterReference`. With only `Alphaword` approved, `&lt;span class=&#34;betaword&#34;&gt;Alphaword&lt;/span&gt; &amp;copy;` incorrectly reports tag names, attributes, and the entity name as absent words even though they are Markdown syntax, not prose. Mask parser-produced HTML tag and character-reference ranges while retaining visible text content.

🔧 Fix: Harden Markdown syntax masking and fallback parsing
2 errors still open:
- 🚨 `src/engine/markdown.ts:279` - The required Markdown exclusions remain incomplete: `MASKED_MARKDOWN_TOKENS` masks inline `htmlText` but not block `htmlFlow`. With only `Alphaword` approved, `&lt;div&gt;\nAlphaword\n&lt;/div&gt;` reports both `div` tag names as absent prose words. Mask tag subranges within HTML flow blocks while retaining visible flow content.
- 🚨 `src/engine/markdown.ts:524` - The fallback delimiter source uses `blankMarkdownCode`, which pairs backticks across adjacent Markdown leaf-block boundaries. For `` `\n# ${&#34;![x &#34;.repeat(n)}x${&#34;](v)&#34;.repeat(n)}` ``, it blanks every heading delimiter as a false cross-block code span, so no deep-image candidate is transformed and micromark receives the quadratic nested-image input unchanged. Make code-span masking inline-block-aware before building the fallback stack.

🔧 Fix: Fix HTML flow and cross-block Markdown masking
2 errors still open:
- 🚨 `src/engine/markdown.ts:411` - The required Markdown exclusions fail for deeply nested images because the fallback treats every parenthesis as structural, including parentheses inside angle-bracket destinations. In `${&#34;![x &#34;.repeat(33)}Alphaword](&lt;Betaword(foo&gt;)${&#34;](v)&#34;.repeat(32)}`, the valid deepest destination&#39;s inner `(` prevents its candidate from receiving `sourceEnd`; the transformed source then exposes and flags destination text as prose. Parse resource syntax while building fallback candidates so delimiters inside valid angle destinations cannot affect the resource boundary.
- 🚨 `src/engine/markdown.ts:565` - The requirement to flag every absent prose token remains bypassable in list containers. For `- [target]: /path\n  &#34;Betaword&#34;`, the two spaces are only the required list continuation prefix, but any `linePrefix` marks the title line as horizontally separated and causes `Betaword` to be masked. Measure title indentation relative to the parser-established Markdown content start rather than treating container indentation as separation.

🔧 Fix: Fix deep Markdown resources and list definition titles
2 errors still open:
- 🚨 `src/engine/markdown.ts:444` - The required &#34;flag every prose token absent from the list&#34; behavior is contradicted by `parentheses.push(index)`, which treats parentheses inside quoted resource titles as structural. In `${&#34;![x &#34;.repeat(33)}Alphaword](target &#34;Betaword(foo&#34;)${&#34;](v)&#34;.repeat(32)}`, the valid quoted title&#39;s `(` consumes the resource&#39;s closing `)`, so the deep-image fallback does not mask the metadata and reports `Betaword` as prose. Parse the complete resource grammar, including quoted and parenthesized titles, when determining fallback boundaries.
- 🚨 `src/engine/markdown.ts:614` - The required Markdown exclusion behavior is contradicted by `token.start.column &lt;= activeDefinitionColumn`. In `  [target]: /path\n &#34;Betaword&#34;`, the title has the required horizontal separation from the root content start, but its column is less than the optionally indented definition label&#39;s column, so the valid title is exposed and flagged as prose. Compare title indentation with the parser-established content start for its line, not the definition label column.

🔧 Fix: Fix Markdown resource titles and definition indentation
2 errors still open:
- 🚨 `src/engine/markdown.ts:479` - The malformed-input performance failure remains reachable. For `&#34;![x &#34;.repeat(n) + &#34;x&#34; + &#34;](&#34;.repeat(n)`, every deep-image candidate calls `resourceOpaqueRanges`, which scans its unmatched resource to EOF, producing O(n²) work and potentially stalling CLI and host gates. Parse resource boundaries once in `prepareMarkdownSource` or memoize shared scan results.
- 🚨 `src/engine/markdown.ts:522` - The requirement to &#34;flag every prose token absent from the list&#34; is contradicted because `opaqueInlineProbe` changes syntax before HTML-flow ranges are parsed. In `&lt;div&gt;\n&lt;[Betaword]&gt;\n&lt;/div&gt;`, it changes the invalid tag-like prose to `&lt;xBetaword&gt;`, causing `Betaword` to be masked as HTML syntax. Derive syntax ranges without turning invalid source into valid HTML.

🔧 Fix: Harden Markdown resource scanning and HTML masking
2 errors still open:
- 🚨 `src/engine/markdown.ts:534` - The required behavior to &#34;flag every prose token absent from the list&#34; remains bypassable. For `${&#34;![x &#34;.repeat(33)}Alphaword](target`) Betaword `${&#34;](v)&#34;.repeat(32)}`, the bracket-stripped probe incorrectly pairs the destination backtick with the later unmatched backtick and marks `Betaword` as code. The fallback skips that probe-only range and the final parse masks `Betaword`, although it is prose inside the outer image description. Resolve resources before classifying code spans so only parser-valid code ranges become opaque.
- 🚨 `src/engine/markdown.ts:648` - Nested candidates can expand linear input into quadratic memory and parser work. For `(&#34;![&#34;.repeat(33) + &#34;x](&#34;).repeat(k) + &#34;u&#34; + &#34;)&#34;.repeat(k)`, each candidate receives a nested `sourceEnd`, then this loop copies every overlapping suffix into `chunks`, totaling O(k²) characters. Process candidate ranges without materializing overlapping copies, or parse their shared source once.

🔧 Fix: Fix deep Markdown resource parsing performance
2 errors still open:
- 🚨 `src/engine/markdown.ts:552` - The intent requires &#34;flag every prose token absent from the list,&#34; but replacing brackets with `^` can turn invalid email text into an autolink. In `${&#34;![x &#34;.repeat(33)}&lt;a${&#34;]&#34;.repeat(33)}@x&gt;](Betaword)`, the real closers consume all image openers, so `Betaword` is prose; the probe treats `&lt;a^^...@x&gt;` as an opaque autolink, skips those closers, and masks `(Betaword)` as a deep-image resource. Derive opaque ranges without changing autolink validity.
- 🚨 `src/engine/markdown.ts:643` - The intent limits allowlist checks to prose and requires Markdown exclusions, but HTML flow handling masks only tags and entities. Content inside CommonMark raw blocks such as `&lt;script&gt;\nBetaword\n&lt;/script&gt;` is code, yet `Betaword` remains visible and produces a hard dictionary finding. Mask complete raw-content blocks such as script, style, and pre while retaining visible text in ordinary HTML containers.

🔧 Fix: Fix Markdown autolink and raw HTML masking
1 error still open:
- 🚨 `src/engine/markdown.ts:557` - For `&#34;&lt;![CDATA[&#34;.repeat(n)`, every marker calls `source.indexOf(&#34;]]&gt;&#34;, index + 9)` and scans to EOF, making allowlist lint O(n²) on malformed input and potentially stalling CLI and host gates. Scan CDATA terminators once or advance directly past the protected range, and add malformed-input performance coverage.

🔧 Fix: Bound malformed CDATA parsing to linear time
1 warning still open:
- ⚠️ `src/engine/markdown.ts:378` - Every allowlist lint allocates ten full-document Int32Arrays plus an escape array before determining whether deep-image fallback is needed. A 10 MiB ASCII prose file therefore requires over 400 MiB for these tables alone, creating an avoidable OOM risk even when the document has no links. Build the resource index lazily after a lightweight scan finds a deep-image candidate.

🔧 Fix: Lazily build deep Markdown resource indexes
1 error still open:
- 🚨 `src/engine/markdown.ts:634` - The deep-image guard activates only for `](` resources. Valid nested reference images such as `&#34;![x &#34;.repeat(n) + &#34;x&#34; + &#34;][r]&#34;.repeat(n) + &#34;\n\n[r]: /u&#34;` never set `needsResourceIndex`, so line 841 sends them unchanged to micromark. Its label-end tokenizer searches backward for each closing label, producing O(n²) work that can stall allowlist CLI and host gates. Bound parser-valid full, collapsed, and shortcut reference images at `prepareMarkdownSource` before the final parse, and add performance coverage.

🔧 Fix: Bound nested Markdown reference image parsing
2 errors still open:
- 🚨 `src/engine/markdown.ts:920` - The criterion to &#34;flag every prose token absent from the list&#34; remains violated because `markdownEvents(opaqueInlineProbe(source))` classifies code spans before full-reference suffixes are resolved. In 33 nested images, a resolved suffix such as `[r`]`, followed by `Betaword` and a later unmatched backtick, causes the probe to pair the suffix backtick with the later backtick and skip the real suffix closer. The final parser then masks `Betaword` as code even though it is visible prose. Resolve reference suffixes before code-span opacity and add this regression.
- 🚨 `src/engine/markdown.ts:731` - Each deeply nested full-reference image normalizes `source.slice(frame.opening + 1, index)`, even though full references use the following label instead. For `&#34;![x &#34;.repeat(n) + &#34;x&#34; + &#34;][r]&#34;.repeat(n)`, these overlapping image-label slices total O(n²) time and retained string memory, so sufficiently deep input can stall or exhaust allowlist lint. Compute the image identifier lazily only for collapsed references, and bound collapsed-reference normalization without retaining overlapping strings.

🔧 Fix: Fix deep Markdown reference parsing and normalization
2 errors still open:
- 🚨 `src/engine/markdown.ts:727` - The fallback pops every raw `]` without excluding valid resource ranges. In `${&#34;![x &#34;.repeat(33)}[Alphaword](foo]bar)${&#34;](v)&#34;.repeat(33)}`, `]` is valid inside the inner destination, but the scanner pairs it with the deepest image opener and leaves the final `(v)` exposed as prose. This violates the required Markdown exclusions. Make valid resource contents opaque before fallback-stack matching.
- 🚨 `src/engine/markdown.ts:789` - `RAW_HTML_FLOW_START` includes `/`, so `&lt;script/&gt;\nBetaword` is treated as a raw-content block and blanked completely. CommonMark classifies the self-closing tag as ordinary HTML flow, so the visible absent `Betaword` is never flagged, contradicting the requirement to &#34;flag every prose token absent from the list.&#34; Restrict whole-block masking to actual raw-content starts and retain content after self-closing tags.

🔧 Fix: Fix deep resource and self-closing HTML masking
2 issues (1 error, 1 warning) still open:
- 🚨 `src/engine/markdown.ts:690` - The fallback only bounds deep images. For `&#34;[&#34;.repeat(n) + &#34;]&#34;.repeat(n)`, this branch sends every unresolved link label unchanged to `markdownEvents` at line 1041; micromark scans progressively farther backward for each closing bracket, causing O(n²) work that can stall allowlist CLI and host gates. Bound all deeply nested label forms before the final parser pass, including unresolved links and images.
- ⚠️ `src/engine/markdown.ts:677` - `imageOpenings` counts cumulative images rather than concurrent nesting, so 33 shallow `![x](u)` images activate fallback. The second pass then builds ten full-source Int32Array indexes for the first resource, meaning a large document with ordinary shallow images can allocate over 40 bytes per source character. Detect an actual fallback candidate before building the resource index.

🔧 Fix: Bound deep Markdown labels and preserve shallow parsing
3 errors still open:
- 🚨 `src/engine/markdown.ts:763` - The required &#34;flag every prose token absent from the list&#34; behavior still fails for deep labels containing a resolved shortcut link. In `${&#34;[x &#34;.repeat(33)}[word-form]](Betaword)${&#34;]&#34;.repeat(32)}\n\n[word-form]: /target`, the shortcut link invalidates the parent link, so `Betaword` is prose. The fallback does not advance `linkEpoch` for shortcut references and masks `(Betaword)`. Resolve valid shortcut links before deciding whether a deep parent resource is valid.
- 🚨 `src/engine/markdown.ts:745` - The required Markdown exclusions fail because the fallback bracket stack still crosses leaf-block boundaries. For `${&#34;[&#34;.repeat(33)}Alphaword\n\n[target]: /Betaword`, stale openers make the valid definition label appear deeper than 32, so lines 747-748 replace its delimiters and the final parser exposes `target` and `Betaword` as prose. Reset fallback delimiter state at parser-established inline-block boundaries before mutating labels.
- 🚨 `src/engine/markdown.ts:674` - The lazy resource-index fix still allocates ten document-sized Int32Arrays for a shallow valid link when its destination contains 33 `[` characters, such as `[Alphaword](path${&#34;[&#34;.repeat(33)})`. The preflight counts destination brackets as nested labels, then line 764 builds over 40 bytes of indexes per source character despite concurrent label depth being one. Skip parser-valid resource contents during the lightweight fallback check.

🔧 Fix: Harden deep Markdown fallback parsing
2 errors still open:
- 🚨 `src/engine/markdown.ts:882` - The required criterion to &#34;flag every prose token absent from the list&#34; remains violated for deep labels. In `${&#34;[x &#34;.repeat(33)}[word-form](not a link)](Betaword)${&#34;]&#34;.repeat(32)}\n\n[word-form]: /target`, CommonMark resolves `[word-form]` as a shortcut reference after the inline resource fails, which invalidates the parent link and leaves `Betaword` as prose. This branch records the failed resource but never advances `linkEpoch` for that shortcut, so the parent destination is masked. Resolve defined shortcuts after resource parsing fails before evaluating enclosing links.
- 🚨 `src/engine/markdown.ts:776` - The lightweight fallback scan records `](` as a potential resource even when `]` did not match an opening bracket. For `&#34;](&#34; + &#34;[&#34;.repeat(n) + &#34;]&#34;.repeat(n) + &#34;)&#34;`, `linearResourceEnd` accepts the unmatched construct and skips all deep labels, so the final micromark pass receives the quadratic nested-label input unchanged. Record potential resources only when the closing bracket popped an eligible matching frame.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `bunx vitest run test/engine/dictionary.test.ts test/engine/diff-lint.test.ts test/config/schema.test.ts test/config/merge.test.ts`
- `bunx vitest run test/cli/config.test.ts`
- `bunx vitest run test/cli/hook.test.ts -t 'reports approved-word list status with dictionary precedence|uses an approved-word list from the event directory|allows a hook event with a warning when the approved-word list is missing|resolves a custom dictionary from the event directory'`
- `bunx vitest run test/extension/extension.test.ts -t 'uses a configured approved-word list for extension gates|fails extension gates closed when the configured approved-word list is missing|reports the mode, rule severity counts, and dictionary state|reports a failed dictionary load'`
- <code>Manual CLI E2E from the evidence project: ran approved and absent Markdown through `simple-english --json` while `SIMPLE_ENGLISH_DICTIONARY` named a missing replacement, then exercised missing and invalid approved-word lists.</code>
- <code>Manual Hook E2E: piped Claude Code `PreToolUse` Write events into `simple-english hook` for an absent word and a missing configured list.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
