### PR TITLE
fix(engine): rebuild Markdown masking with CommonMark parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ The enabled pi Adapter fails closed after that error.
 ```sh
 bun install
 bun run test
+bun run bench:markdown
 bun run lint
 bun run typecheck
 npm publish --dry-run

--- a/bun.lock
+++ b/bun.lock
@@ -6,11 +6,7 @@
       "name": "simple-english",
       "dependencies": {
         "@lezer/markdown": "^1.7.2",
-        "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
-        "commonmark": "^0.31.2",
         "effect": "^3.14.0",
-        "micromark": "^4.0.2",
-        "tree-sitter": "0.21.1",
         "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
@@ -18,7 +14,6 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@earendil-works/pi-coding-agent": "0.83.0",
-        "@types/commonmark": "^0.27.10",
         "@types/node": "^22.0.0",
         "typebox": "1.3.7",
         "typescript": "^5.8.0",
@@ -293,11 +288,7 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@tree-sitter-grammars/tree-sitter-markdown": ["@tree-sitter-grammars/tree-sitter-markdown@0.3.2", "", { "dependencies": { "node-addon-api": "^8.1.0", "node-gyp-build": "^4.8.1" }, "peerDependencies": { "tree-sitter": "^0.21.1", "tree_sitter": "*" }, "optionalPeers": ["tree_sitter"] }, "sha512-hQXCcDVvg2t4E8cn7zz6jjIBerzk9E9ZlHxJp5IrUOpY4s1YVpXJbMeWZks2/V7lmkPRnnkM8IrTbQ5ltwEOnA=="],
-
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
-
-    "@types/commonmark": ["@types/commonmark@0.27.10", "", {}, "sha512-iEZobUnvlM+UX5fXWCmC4eQXwCs01Z8Xa1W0VjiWUF/XsNy4BHtskqJ9MyLZVMHbA0ezhyonCDqz3hMvsCm6Hg=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
@@ -347,11 +338,7 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
-
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
-
-    "commonmark": ["commonmark@0.31.2", "", { "dependencies": { "entities": "~3.0.1", "mdurl": "~1.0.1", "minimist": "~1.2.8" }, "bin": { "commonmark": "bin/commonmark" } }, "sha512-2fRLTyb9r/2835k5cwcAwOj0DEc44FARnMp5veGsJ+mEAZdi52sNopLu07ZyElQUz058H43whzlERDIaaSw4rg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -359,21 +346,13 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
-
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
-
-    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
-
-    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
-
-    "entities": ["entities@3.0.1", "", {}, "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
@@ -443,51 +422,7 @@
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
-    "mdurl": ["mdurl@1.0.1", "", {}, "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="],
-
-    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
-
-    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
-
-    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
-
-    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
-
-    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
-
-    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
-
-    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
-
-    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
-
-    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
-
-    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
-
-    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
-
-    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
-
-    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
-
-    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
-
-    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
-
-    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
-
-    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
-
-    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
-
-    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
-
-    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
-
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
-
-    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -495,13 +430,9 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
-    "node-addon-api": ["node-addon-api@8.9.1", "", {}, "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg=="],
-
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
-
-    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -564,8 +495,6 @@
     "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
-
-    "tree-sitter": ["tree-sitter@0.21.1", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.0" } }, "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,9 @@
     "": {
       "name": "simple-english",
       "dependencies": {
-        "@lezer/markdown": "^1.7.2",
         "effect": "^3.14.0",
+        "micromark": "^4.0.2",
+        "micromark-util-html-tag-name": "^2.0.1",
         "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
@@ -163,12 +164,6 @@
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
-
-    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
-
-    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
-
-    "@lezer/markdown": ["@lezer/markdown@1.7.2", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 
@@ -338,6 +333,8 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -346,7 +343,13 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" }, "peerDependencies": { "supports-color": "*" }, "optionalPeers": ["supports-color"] }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
@@ -421,6 +424,46 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,9 @@
       "dependencies": {
         "effect": "^3.14.0",
         "micromark": "^4.0.2",
+        "micromark-util-character": "^2.1.1",
         "micromark-util-html-tag-name": "^2.0.1",
+        "micromark-util-types": "^2.0.2",
         "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "simple-english",
       "dependencies": {
+        "@lezer/markdown": "^1.7.2",
         "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
+        "commonmark": "^0.31.2",
         "effect": "^3.14.0",
         "micromark": "^4.0.2",
         "tree-sitter": "0.21.1",
@@ -16,6 +18,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@earendil-works/pi-coding-agent": "0.83.0",
+        "@types/commonmark": "^0.27.10",
         "@types/node": "^22.0.0",
         "typebox": "1.3.7",
         "typescript": "^5.8.0",
@@ -166,6 +169,12 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.2", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ=="],
+
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 
     "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
@@ -288,6 +297,8 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/commonmark": ["@types/commonmark@0.27.10", "", {}, "sha512-iEZobUnvlM+UX5fXWCmC4eQXwCs01Z8Xa1W0VjiWUF/XsNy4BHtskqJ9MyLZVMHbA0ezhyonCDqz3hMvsCm6Hg=="],
+
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -340,6 +351,8 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
+    "commonmark": ["commonmark@0.31.2", "", { "dependencies": { "entities": "~3.0.1", "mdurl": "~1.0.1", "minimist": "~1.2.8" }, "bin": { "commonmark": "bin/commonmark" } }, "sha512-2fRLTyb9r/2835k5cwcAwOj0DEc44FARnMp5veGsJ+mEAZdi52sNopLu07ZyElQUz058H43whzlERDIaaSw4rg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
@@ -359,6 +372,8 @@
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+
+    "entities": ["entities@3.0.1", "", {}, "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
@@ -428,6 +443,8 @@
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
+    "mdurl": ["mdurl@1.0.1", "", {}, "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="],
+
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
@@ -469,6 +486,8 @@
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,10 @@
     "": {
       "name": "simple-english",
       "dependencies": {
+        "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
         "effect": "^3.14.0",
         "micromark": "^4.0.2",
+        "tree-sitter": "0.21.1",
         "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
@@ -282,6 +284,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@tree-sitter-grammars/tree-sitter-markdown": ["@tree-sitter-grammars/tree-sitter-markdown@0.3.2", "", { "dependencies": { "node-addon-api": "^8.1.0", "node-gyp-build": "^4.8.1" }, "peerDependencies": { "tree-sitter": "^0.21.1", "tree_sitter": "*" }, "optionalPeers": ["tree_sitter"] }, "sha512-hQXCcDVvg2t4E8cn7zz6jjIBerzk9E9ZlHxJp5IrUOpY4s1YVpXJbMeWZks2/V7lmkPRnnkM8IrTbQ5ltwEOnA=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
@@ -472,9 +476,13 @@
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
+    "node-addon-api": ["node-addon-api@8.9.1", "", {}, "sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg=="],
+
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
@@ -537,6 +545,8 @@
     "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "tree-sitter": ["tree-sitter@0.21.1", "", { "dependencies": { "node-addon-api": "^8.0.0", "node-gyp-build": "^4.8.0" } }, "sha512-7dxoA6kYvtgWw80265MyqJlkRl4yawIjO7S5MigytjELkX43fV2WsAXzsNfO7sBpPPCF5Gp0+XzHk0DwLCq3xQ=="],
 
     "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,13 @@
     "": {
       "name": "simple-english",
       "dependencies": {
+        "@lezer/html": "^1.3.12",
+        "@lezer/markdown": "^1.7.2",
         "effect": "^3.14.0",
         "micromark": "^4.0.2",
         "micromark-util-character": "^2.1.1",
         "micromark-util-html-tag-name": "^2.0.1",
+        "micromark-util-normalize-identifier": "^2.0.1",
         "micromark-util-types": "^2.0.2",
         "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
@@ -166,6 +169,16 @@
     "@google/genai": ["@google/genai@1.52.0", "", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.2", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,11 +33,14 @@
   },
   "scripts": {
     "test": "vitest run",
+    "bench:markdown": "vitest bench test/engine/markdown.bench.ts",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@lezer/markdown": "^1.7.2",
     "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
+    "commonmark": "^0.31.2",
     "effect": "^3.14.0",
     "micromark": "^4.0.2",
     "tree-sitter": "0.21.1",
@@ -59,6 +62,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@types/commonmark": "^0.27.10",
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@types/node": "^22.0.0",
     "typebox": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@lezer/markdown": "^1.7.2",
     "effect": "^3.14.0",
+    "micromark": "^4.0.2",
+    "micromark-util-html-tag-name": "^2.0.1",
     "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -39,11 +39,7 @@
   },
   "dependencies": {
     "@lezer/markdown": "^1.7.2",
-    "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
-    "commonmark": "^0.31.2",
     "effect": "^3.14.0",
-    "micromark": "^4.0.2",
-    "tree-sitter": "0.21.1",
     "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
@@ -62,7 +58,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@types/commonmark": "^0.27.10",
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@types/node": "^22.0.0",
     "typebox": "1.3.7",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@lezer/html": "^1.3.12",
+    "@lezer/markdown": "^1.7.2",
     "effect": "^3.14.0",
     "micromark": "^4.0.2",
     "micromark-util-character": "^2.1.1",
     "micromark-util-html-tag-name": "^2.0.1",
+    "micromark-util-normalize-identifier": "^2.0.1",
     "micromark-util-types": "^2.0.2",
     "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tree-sitter-grammars/tree-sitter-markdown": "^0.3.2",
     "effect": "^3.14.0",
     "micromark": "^4.0.2",
+    "tree-sitter": "0.21.1",
     "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   "dependencies": {
     "effect": "^3.14.0",
     "micromark": "^4.0.2",
+    "micromark-util-character": "^2.1.1",
     "micromark-util-html-tag-name": "^2.0.1",
+    "micromark-util-types": "^2.0.2",
     "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -4,7 +4,7 @@ import { type ProseBreak, extractHashComments, extractSlashComments } from "./co
 import { type ScopedViolation, type ViolationScope, newFindings } from "./diff-match.ts"
 import { changedText } from "./diff.ts"
 import { blankIdentifiers } from "./identifiers.ts"
-import { blankMarkdownCodeWithStructure, blankMarkdownDestinations } from "./markdown.ts"
+import { blankMarkdownForLint } from "./markdown.ts"
 import { type Paragraph, segmentParagraphs } from "./paragraphs.ts"
 import { contraction } from "./rules/contraction.ts"
 import { type CompiledDictionary, compileDictionary, dictionaryRule } from "./rules/dictionary.ts"
@@ -110,11 +110,9 @@ const isApprovedWordMode = (dictionary: CompiledDictionary | undefined): boolean
   dictionary?.mode === "approved-words"
 
 const prepareProse = (extracted: ProseRun, approvedWordMode: boolean): PreparedProse => {
-  const markdown = blankMarkdownCodeWithStructure(extracted.lines, extracted.contentStarts)
+  const markdown = blankMarkdownForLint(extracted.lines, extracted.contentStarts, approvedWordMode)
   const lines = blankIdentifiers(markdown.lines)
-  const dictionaryLines = approvedWordMode
-    ? blankIdentifiers(blankMarkdownDestinations(extracted.lines, extracted.contentStarts))
-    : lines
+  const dictionaryLines = approvedWordMode ? blankIdentifiers(markdown.dictionaryLines) : lines
   return {
     lines,
     dictionaryLines,

--- a/src/engine/markdown-syntax.ts
+++ b/src/engine/markdown-syntax.ts
@@ -80,7 +80,7 @@ const tokenizeRawHtmlFlow: Tokenizer = function (effects, ok, nok) {
   }
 
   function openingName(code: Code): State | undefined {
-    if (code === 47 || code === 62 || markdownLineEndingOrSpace(code) || code === null) {
+    if (code === 62 || markdownLineEndingOrSpace(code) || code === null) {
       if (!htmlRawNames.includes(name.toLowerCase())) return nok(code)
       return self.interrupt ? ok(code) : continuation(code)
     }

--- a/src/engine/markdown-syntax.ts
+++ b/src/engine/markdown-syntax.ts
@@ -1,6 +1,6 @@
 import {
-  asciiAlphanumeric,
   asciiAlpha,
+  asciiAlphanumeric,
   markdownLineEnding,
   markdownLineEndingOrSpace,
 } from "micromark-util-character"
@@ -47,14 +47,12 @@ const resolveToRawHtmlFlow: Resolver = (events) => {
 const nonLazyContinuationStart: Construct = {
   partial: true,
   tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State): State {
-    const self = this
-
     return (code) => {
       if (!markdownLineEnding(code)) return nok(code)
       effects.enter("lineEnding")
       effects.consume(code)
       effects.exit("lineEnding")
-      return (nextCode) => (self.parser.lazy[self.now().line] ? nok(nextCode) : ok(nextCode))
+      return (nextCode) => (this.parser.lazy[this.now().line] ? nok(nextCode) : ok(nextCode))
     }
   },
 }
@@ -166,5 +164,8 @@ const rawHtmlFlow: Construct = {
 }
 
 export const markdownSyntaxExtension: Extension = {
+  disable: {
+    null: ["labelEnd", "labelStartImage", "labelStartLink"],
+  },
   flow: { 60: rawHtmlFlow },
 }

--- a/src/engine/markdown-syntax.ts
+++ b/src/engine/markdown-syntax.ts
@@ -1,0 +1,170 @@
+import {
+  asciiAlphanumeric,
+  asciiAlpha,
+  markdownLineEnding,
+  markdownLineEndingOrSpace,
+} from "micromark-util-character"
+import { htmlRawNames } from "micromark-util-html-tag-name"
+import type {
+  Code,
+  Construct,
+  Effects,
+  Extension,
+  Resolver,
+  State,
+  TokenizeContext,
+  Tokenizer,
+} from "micromark-util-types"
+
+declare module "micromark-util-types" {
+  interface TokenTypeMap {
+    htmlRawFlow: "htmlRawFlow"
+    htmlRawFlowData: "htmlRawFlowData"
+  }
+}
+
+const resolveToRawHtmlFlow: Resolver = (events) => {
+  let index = events.length
+  while (index > 0) {
+    index--
+    if (events[index]?.[0] === "enter" && events[index]?.[1].type === "htmlRawFlow") break
+  }
+
+  if (index > 1 && events[index - 2]?.[1].type === "linePrefix") {
+    const start = events[index - 2]?.[1].start
+    if (start !== undefined) {
+      const flow = events[index]?.[1]
+      const data = events[index + 1]?.[1]
+      if (flow !== undefined) flow.start = start
+      if (data !== undefined) data.start = start
+    }
+    events.splice(index - 2, 2)
+  }
+
+  return events
+}
+
+const nonLazyContinuationStart: Construct = {
+  partial: true,
+  tokenize(this: TokenizeContext, effects: Effects, ok: State, nok: State): State {
+    const self = this
+
+    return (code) => {
+      if (!markdownLineEnding(code)) return nok(code)
+      effects.enter("lineEnding")
+      effects.consume(code)
+      effects.exit("lineEnding")
+      return (nextCode) => (self.parser.lazy[self.now().line] ? nok(nextCode) : ok(nextCode))
+    }
+  },
+}
+
+const tokenizeRawHtmlFlow: Tokenizer = function (effects, ok, nok) {
+  const self = this
+  let name = ""
+
+  return start
+
+  function start(code: Code): State | undefined {
+    effects.enter("htmlRawFlow")
+    effects.enter("htmlRawFlowData")
+    effects.consume(code)
+    return openingNameStart
+  }
+
+  function openingNameStart(code: Code): State | undefined {
+    if (!asciiAlpha(code)) return nok(code)
+    effects.consume(code)
+    name = String.fromCharCode(code ?? 0)
+    return openingName
+  }
+
+  function openingName(code: Code): State | undefined {
+    if (code === 47 || code === 62 || markdownLineEndingOrSpace(code) || code === null) {
+      if (!htmlRawNames.includes(name.toLowerCase())) return nok(code)
+      return self.interrupt ? ok(code) : continuation(code)
+    }
+    if (code === 45 || asciiAlphanumeric(code)) {
+      effects.consume(code)
+      name += String.fromCharCode(code ?? 0)
+      return openingName
+    }
+    return nok(code)
+  }
+
+  function continuation(code: Code): State | undefined {
+    if (code === 60) {
+      effects.consume(code)
+      return closingSlash
+    }
+    if (markdownLineEnding(code) || code === null) {
+      effects.exit("htmlRawFlowData")
+      return continuationStart(code)
+    }
+    effects.consume(code)
+    return continuation
+  }
+
+  function continuationStart(code: Code): State | undefined {
+    return effects.check(nonLazyContinuationStart, continuationLineEnding, done)(code)
+  }
+
+  function continuationLineEnding(code: Code): State | undefined {
+    effects.enter("lineEnding")
+    effects.consume(code)
+    effects.exit("lineEnding")
+    return continuationBefore
+  }
+
+  function continuationBefore(code: Code): State | undefined {
+    if (markdownLineEnding(code) || code === null) return continuationStart(code)
+    effects.enter("htmlRawFlowData")
+    return continuation(code)
+  }
+
+  function closingSlash(code: Code): State | undefined {
+    if (code !== 47) return continuation(code)
+    effects.consume(code)
+    name = ""
+    return closingName
+  }
+
+  function closingName(code: Code): State | undefined {
+    if (code === 62) {
+      if (!htmlRawNames.includes(name.toLowerCase())) return continuation(code)
+      effects.consume(code)
+      return closingLine
+    }
+    if (asciiAlpha(code) && name.length < 8) {
+      effects.consume(code)
+      name += String.fromCharCode(code ?? 0)
+      return closingName
+    }
+    return continuation(code)
+  }
+
+  function closingLine(code: Code): State | undefined {
+    if (markdownLineEnding(code) || code === null) {
+      effects.exit("htmlRawFlowData")
+      return done(code)
+    }
+    effects.consume(code)
+    return closingLine
+  }
+
+  function done(code: Code): State | undefined {
+    effects.exit("htmlRawFlow")
+    return ok(code)
+  }
+}
+
+const rawHtmlFlow: Construct = {
+  concrete: true,
+  name: "htmlRawFlow",
+  resolveTo: resolveToRawHtmlFlow,
+  tokenize: tokenizeRawHtmlFlow,
+}
+
+export const markdownSyntaxExtension: Extension = {
+  flow: { 60: rawHtmlFlow },
+}

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,4 +1,5 @@
-import { parser as markdownParser } from "@lezer/markdown"
+import { parse, postprocess, preprocess } from "micromark"
+import { htmlRawNames } from "micromark-util-html-tag-name"
 
 interface MarkdownAnalysis {
   readonly lines: string[]
@@ -24,60 +25,65 @@ interface AnalysisState {
   readonly structuralBlanks: boolean[]
 }
 
-type MarkdownTree = ReturnType<typeof markdownParser.parse>
-type MarkdownNode = MarkdownTree["topNode"]
-
-interface ParserElement {
-  readonly type: number
-  readonly from: number
-  readonly to: number
-  readonly children: readonly ParserElement[]
+interface SourceRange {
+  readonly start: number
+  readonly end: number
 }
 
-const nodeId = (name: string): number =>
-  markdownParser.nodeSet.types.find((type) => type.name === name)?.id ?? -1
+const withoutLinks = {
+  disable: { null: ["labelEnd", "labelStartImage", "labelStartLink"] },
+}
 
-const NODE = {
-  autolink: nodeId("Autolink"),
-  codeBlock: nodeId("CodeBlock"),
-  comment: nodeId("Comment"),
-  emphasisMark: nodeId("EmphasisMark"),
-  entity: nodeId("Entity"),
-  escape: nodeId("Escape"),
-  fencedCode: nodeId("FencedCode"),
-  hardBreak: nodeId("HardBreak"),
-  headerMark: nodeId("HeaderMark"),
-  horizontalRule: nodeId("HorizontalRule"),
-  htmlBlock: nodeId("HTMLBlock"),
-  htmlTag: nodeId("HTMLTag"),
-  image: nodeId("Image"),
-  inlineCode: nodeId("InlineCode"),
-  link: nodeId("Link"),
-  linkLabel: nodeId("LinkLabel"),
-  linkMark: nodeId("LinkMark"),
-  linkReference: nodeId("LinkReference"),
-  linkTitle: nodeId("LinkTitle"),
-  listMark: nodeId("ListMark"),
-  processingInstruction: nodeId("ProcessingInstruction"),
-  quoteMark: nodeId("QuoteMark"),
-  url: nodeId("URL"),
-} as const
+const markdownEvents = (source: string, includeLinks: boolean) =>
+  postprocess(
+    parse(includeLinks ? undefined : { extensions: [withoutLinks] })
+      .document()
+      .write(preprocess()(source, undefined, true)),
+  )
+
+const markdownTextEvents = (source: string) =>
+  postprocess(
+    parse({ extensions: [withoutLinks] })
+      .text()
+      .write(preprocess()(source, undefined, true)),
+  )
+
+type MarkdownEvents = ReturnType<typeof markdownEvents>
+type MarkdownToken = MarkdownEvents[number][1]
+
+const CODE_BLOCK_TOKENS = new Set(["codeFenced", "codeIndented"])
+const CONTAINER_TOKENS = new Set(["blockQuotePrefix", "listItemIndent", "listItemPrefix"])
+const DICTIONARY_TOKENS = new Set([
+  "atxHeadingSequence",
+  "autolink",
+  "characterReference",
+  "emphasisSequence",
+  "escapeMarker",
+  "hardBreakEscape",
+  "hardBreakTrailing",
+  "htmlText",
+  "labelEnd",
+  "labelImage",
+  "labelImageMarker",
+  "labelLink",
+  "labelMarker",
+  "reference",
+  "resource",
+  "setextHeadingLine",
+  "strongSequence",
+  "thematicBreak",
+])
+const HTML_SYNTAX_TOKENS = new Set(["characterReference", "htmlText"])
 
 const markRange = (mask: Uint8Array, start: number, end: number): void => {
   mask.fill(1, Math.max(0, start), Math.min(mask.length, end))
 }
 
-const normalizedIdentifier = (value: string): string =>
-  value
-    .replace(/[\t\n\r ]+/g, " ")
-    .replace(/^ | $/g, "")
-    .toLowerCase()
-    .toUpperCase()
-
 const createAnalysisState = (source: string, parseLines: readonly string[]): AnalysisState => {
   const sourceLineStarts: number[] = []
   const lineAtOffset = new Int32Array(source.length + 1)
   let offset = 0
+
   for (let lineIndex = 0; lineIndex < parseLines.length; lineIndex++) {
     sourceLineStarts.push(offset)
     const end = offset + (parseLines[lineIndex]?.length ?? 0)
@@ -97,239 +103,163 @@ const createAnalysisState = (source: string, parseLines: readonly string[]): Ana
   }
 }
 
-const markCode = (state: AnalysisState, start: number, end: number, block: boolean): void => {
-  markRange(state.proseMask, start, end)
-  markRange(state.structuralMask, start, end)
-  markRange(state.dictionaryMask, start, end)
-  if (!block || end <= start) return
+const markCode = (state: AnalysisState, token: MarkdownToken, block: boolean): void => {
+  markRange(state.proseMask, token.start.offset, token.end.offset)
+  markRange(state.structuralMask, token.start.offset, token.end.offset)
+  markRange(state.dictionaryMask, token.start.offset, token.end.offset)
+  if (!block || token.end.offset <= token.start.offset) return
 
-  const firstLine = state.lineAtOffset[Math.min(start, state.source.length)] ?? 0
-  const lastOffset = Math.max(start, end - 1)
+  const firstLine = state.lineAtOffset[Math.min(token.start.offset, state.source.length)] ?? 0
+  const lastOffset = Math.max(token.start.offset, token.end.offset - 1)
   const lastLine = state.lineAtOffset[Math.min(lastOffset, state.source.length)] ?? firstLine
   for (let line = firstLine; line <= lastLine; line++) state.structuralBlanks[line] = true
 }
 
-const walkTree = (root: MarkdownNode, visit: (node: MarkdownNode) => boolean | undefined): void => {
-  const cursor = root.cursor()
-  for (;;) {
-    const descend = visit(cursor.node) !== false
-    if (descend && cursor.firstChild()) continue
-    while (!cursor.nextSibling()) {
-      if (!cursor.parent()) return
+const definitionMaskEnds = (events: MarkdownEvents): ReadonlyMap<number, number> => {
+  const contentColumns = new Map<number, number>()
+  for (const [phase, token] of events) {
+    if (phase === "enter" && CONTAINER_TOKENS.has(token.type)) {
+      contentColumns.set(
+        token.start.line,
+        Math.max(contentColumns.get(token.start.line) ?? 1, token.end.column),
+      )
     }
   }
+
+  const ends = new Map<number, number>()
+  let definition: MarkdownToken | undefined
+  let definitionContentColumn = 1
+
+  for (const [phase, token] of events) {
+    if (phase === "enter" && token.type === "definition") {
+      definition = token
+      definitionContentColumn = contentColumns.get(token.start.line) ?? 1
+    } else if (
+      phase === "enter" &&
+      token.type === "definitionTitle" &&
+      definition !== undefined &&
+      token.start.line > definition.start.line &&
+      token.start.column <=
+        Math.max(definitionContentColumn, contentColumns.get(token.start.line) ?? 1)
+    ) {
+      ends.set(definition.start.offset, token.start.offset)
+    } else if (phase === "exit" && token.type === "definition") {
+      definition = undefined
+    }
+  }
+
+  return ends
 }
 
-const directChildren = (node: MarkdownNode): readonly MarkdownNode[] => {
-  const children: MarkdownNode[] = []
-  for (let child = node.firstChild; child !== null; child = child.nextSibling) children.push(child)
-  return children
+const enteredRanges = (
+  events: MarkdownEvents,
+  tokenTypes: ReadonlySet<string>,
+): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  for (const [phase, token] of events) {
+    if (phase === "enter" && tokenTypes.has(token.type)) {
+      ranges.push({ start: token.start.offset, end: token.end.offset })
+    }
+  }
+  return ranges
 }
 
-const labelIdentifier = (source: string, start: number, end: number): string | undefined => {
-  if (end - start > 999) return undefined
-  return normalizedIdentifier(source.slice(start, end))
+const rangesWithin = (
+  ranges: readonly SourceRange[],
+  container: SourceRange,
+): readonly SourceRange[] => {
+  const matches: SourceRange[] = []
+  for (const range of ranges) {
+    if (range.start >= container.end) break
+    if (range.start >= container.start && range.end <= container.end) matches.push(range)
+  }
+  return matches
 }
 
-const referenceIdentifier = (
+const rawHtmlOpening = (
   source: string,
-  children: readonly MarkdownNode[],
-): string | undefined => {
-  const explicit = children.find((child) => child.type.id === NODE.linkLabel)
-  if (explicit !== undefined && explicit.to - explicit.from > 2) {
-    return labelIdentifier(source, explicit.from + 1, explicit.to - 1)
-  }
-
-  const marks = children.filter((child) => child.type.id === NODE.linkMark)
-  const opening = marks[0]
-  const closing = marks[1]
-  if (opening === undefined || closing === undefined) return undefined
-  return labelIdentifier(source, opening.to, closing.from)
-}
-
-const virtualColumn = (line: string, sourceColumn: number): number => {
-  let column = 0
-  for (let index = 0; index < sourceColumn; index++) {
-    column = line[index] === "\t" ? column + 4 - (column % 4) : column + 1
-  }
-  return column
-}
-
-const sourceColumn = (state: AnalysisState, offset: number): number => {
-  const line = state.lineAtOffset[Math.min(offset, state.source.length)] ?? 0
-  return virtualColumn(
-    state.parseLines[line] ?? "",
-    offset - (state.sourceLineStarts[line] ?? 0),
+  flow: SourceRange,
+  syntax: readonly SourceRange[],
+): SourceRange | undefined => {
+  const opening = syntax.find(
+    (range) => range.start >= flow.start && source.charCodeAt(range.start) === 60,
   )
-}
+  if (opening === undefined) return undefined
 
-const definitionMaskEnd = (state: AnalysisState, node: MarkdownNode): number => {
-  const title = directChildren(node).find((child) => child.type.id === NODE.linkTitle)
-  if (title === undefined) return node.to
-
-  const definitionLine = state.lineAtOffset[Math.min(node.from, state.source.length)] ?? 0
-  const titleLine = state.lineAtOffset[Math.min(title.from, state.source.length)] ?? definitionLine
-  if (titleLine > definitionLine && sourceColumn(state, title.from) <= sourceColumn(state, node.from)) {
-    return title.from
+  const tag = source.slice(opening.start, opening.end).toLowerCase()
+  for (const name of htmlRawNames) {
+    const prefix = `<${name}`
+    if (!tag.startsWith(prefix)) continue
+    const boundary = tag[prefix.length]
+    if (boundary === undefined || "\t\n\r\f />".includes(boundary)) return opening
   }
-  return node.to
+  return undefined
 }
 
-const markLink = (
+const markHtmlFlows = (
   state: AnalysisState,
-  node: MarkdownNode,
-  definitions: ReadonlySet<string>,
+  htmlFlows: readonly SourceRange[],
+  textEvents: MarkdownEvents,
 ): void => {
-  const children = directChildren(node)
-  const marks = children.filter((child) => child.type.id === NODE.linkMark)
-  const hasResource =
-    children.some((child) => child.type.id === NODE.url || child.type.id === NODE.linkTitle) ||
-    marks.length >= 4
-  const identifier = hasResource ? undefined : referenceIdentifier(state.source, children)
-  if (!hasResource && (identifier === undefined || !definitions.has(identifier))) return
+  const syntax = enteredRanges(textEvents, HTML_SYNTAX_TOKENS)
 
-  for (const child of children) {
-    if (
-      child.type.id === NODE.linkMark ||
-      child.type.id === NODE.linkLabel ||
-      child.type.id === NODE.url ||
-      child.type.id === NODE.linkTitle
-    ) {
-      markRange(state.dictionaryMask, child.from, child.to)
+  for (const flow of htmlFlows) {
+    const flowSyntax = rangesWithin(syntax, flow)
+    const opening = rawHtmlOpening(state.source, flow, flowSyntax)
+    const selfClosing =
+      opening !== undefined && state.source.charCodeAt(opening.end - 2) === 47
+
+    if (opening !== undefined && !selfClosing) {
+      markRange(state.dictionaryMask, flow.start, flow.end)
+    } else {
+      for (const range of flowSyntax) {
+        markRange(state.dictionaryMask, range.start, range.end)
+      }
     }
   }
 }
 
-const rawContentTag = (tag: string): boolean => {
-  const lower = tag.toLowerCase()
-  for (const name of ["pre", "script", "style", "textarea"]) {
-    if (!lower.startsWith(`<${name}`)) continue
-    const boundary = lower[name.length + 1]
-    if (boundary === undefined || boundary === ">" || boundary === "/" || /\s/u.test(boundary)) {
-      return true
+const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void => {
+  const events = markdownEvents(state.source, includeDictionary)
+  const definitionEnds = includeDictionary ? definitionMaskEnds(events) : new Map<number, number>()
+  const htmlFlows: SourceRange[] = []
+
+  for (const [phase, token] of events) {
+    if (phase !== "enter") continue
+
+    if (CODE_BLOCK_TOKENS.has(token.type)) {
+      markCode(state, token, true)
+      continue
     }
-  }
-  return false
-}
-
-const selfClosingTag = (tag: string): boolean => {
-  let index = tag.length - 2
-  while (index >= 0 && /\s/u.test(tag[index] ?? "")) index--
-  return tag[index] === "/"
-}
-
-const htmlElements = (source: string, start: number, end: number): readonly ParserElement[] =>
-  markdownParser.parseInline(source.slice(start, end), start) as readonly ParserElement[]
-
-const markHtmlBlock = (state: AnalysisState, start: number, end: number): void => {
-  const pending = [...htmlElements(state.source, start, end)]
-  const syntax: ParserElement[] = []
-  let firstTag: ParserElement | undefined
-
-  while (pending.length > 0) {
-    const element = pending.pop()
-    if (element === undefined) continue
-    if (element.type === NODE.htmlTag && (firstTag === undefined || element.from < firstTag.from)) {
-      firstTag = element
+    if (token.type === "codeText") {
+      markCode(state, token, false)
+      continue
     }
-    if (
-      element.type === NODE.htmlTag ||
-      element.type === NODE.entity ||
-      element.type === NODE.comment ||
-      element.type === NODE.processingInstruction
-    ) {
-      syntax.push(element)
+    if (CONTAINER_TOKENS.has(token.type)) {
+      markRange(state.proseMask, token.start.offset, token.end.offset)
+      if (includeDictionary) {
+        markRange(state.dictionaryMask, token.start.offset, token.end.offset)
+      }
+      continue
     }
-    for (const child of element.children) pending.push(child)
-  }
+    if (!includeDictionary) continue
 
-  if (firstTag !== undefined) {
-    const tag = state.source.slice(firstTag.from, firstTag.to)
-    if (firstTag.from === start && rawContentTag(tag) && !selfClosingTag(tag)) {
-      markRange(state.dictionaryMask, start, end)
-      return
+    if (token.type === "definition") {
+      markRange(
+        state.dictionaryMask,
+        token.start.offset,
+        definitionEnds.get(token.start.offset) ?? token.end.offset,
+      )
+    } else if (token.type === "htmlFlow") {
+      htmlFlows.push({ start: token.start.offset, end: token.end.offset })
+    } else if (DICTIONARY_TOKENS.has(token.type)) {
+      markRange(state.dictionaryMask, token.start.offset, token.end.offset)
     }
   }
 
-  for (const element of syntax) markRange(state.dictionaryMask, element.from, element.to)
-}
-
-const collectDefinitions = (source: string, root: MarkdownNode): ReadonlySet<string> => {
-  const definitions = new Set<string>()
-  walkTree(root, (node) => {
-    if (node.type.id !== NODE.linkReference) return
-    const label = directChildren(node).find((child) => child.type.id === NODE.linkLabel)
-    if (label !== undefined) {
-      const identifier = labelIdentifier(source, label.from + 1, label.to - 1)
-      if (identifier !== undefined) definitions.add(identifier)
-    }
-    return false
-  })
-  return definitions
-}
-
-const CODE_BLOCKS = new Set([NODE.codeBlock, NODE.fencedCode])
-const CONTAINER_MARKS = new Set([NODE.quoteMark, NODE.listMark])
-const DICTIONARY_NODES = new Set([
-  NODE.autolink,
-  NODE.comment,
-  NODE.entity,
-  NODE.htmlTag,
-  NODE.processingInstruction,
-  NODE.hardBreak,
-  NODE.headerMark,
-  NODE.horizontalRule,
-  NODE.emphasisMark,
-])
-
-const analyzeTree = (state: AnalysisState, includeDictionary: boolean): void => {
-  const tree = markdownParser.parse(state.source)
-  const definitions = includeDictionary
-    ? collectDefinitions(state.source, tree.topNode)
-    : new Set<string>()
-
-  walkTree(tree.topNode, (node) => {
-    if (CODE_BLOCKS.has(node.type.id)) {
-      markCode(state, node.from, node.to, true)
-      return false
-    }
-    if (node.type.id === NODE.inlineCode) {
-      markCode(state, node.from, node.to, false)
-      return false
-    }
-    if (CONTAINER_MARKS.has(node.type.id)) {
-      const siblingStart = node.nextSibling?.from ?? node.to
-      const end =
-        siblingStart > node.to && state.source.slice(node.to, siblingStart).trim() === ""
-          ? siblingStart
-          : node.to
-      markRange(state.proseMask, node.from, end)
-      if (includeDictionary) markRange(state.dictionaryMask, node.from, end)
-      return
-    }
-    if (!includeDictionary) return
-
-    if (node.type.id === NODE.linkReference) {
-      markRange(state.dictionaryMask, node.from, definitionMaskEnd(state, node))
-      return false
-    }
-    if (node.type.id === NODE.link || node.type.id === NODE.image) {
-      markLink(state, node, definitions)
-      return
-    }
-    if (node.type.id === NODE.htmlBlock) {
-      markHtmlBlock(state, node.from, node.to)
-      return false
-    }
-    if (node.type.id === NODE.escape) {
-      markRange(state.dictionaryMask, node.from, Math.min(node.from + 1, node.to))
-      return false
-    }
-    if (DICTIONARY_NODES.has(node.type.id)) {
-      markRange(state.dictionaryMask, node.from, node.to)
-      return false
-    }
-  })
+  if (htmlFlows.length > 0) {
+    markHtmlFlows(state, htmlFlows, markdownTextEvents(state.source))
+  }
 }
 
 const applyMask = (
@@ -344,6 +274,7 @@ const applyMask = (
     const contentStart = Math.min(Math.max(contentStarts[lineIndex] ?? 0, 0), line.length)
     const sourceStart = sourceLineStarts[lineIndex] ?? 0
     const parseLine = parseLines[lineIndex] ?? ""
+
     for (let column = 0; column < parseLine.length; column++) {
       if (mask[sourceStart + column] !== 0) characters[contentStart + column] = " "
     }
@@ -365,7 +296,7 @@ const analyzeMarkdown = (
   const parseLines = lines.map((line, index) => line.slice(starts[index]))
   const source = parseLines.join("\n")
   const state = createAnalysisState(source, parseLines)
-  analyzeTree(state, includeDictionary)
+  analyzeEvents(state, includeDictionary)
 
   return {
     lines: applyMask(lines, starts, parseLines, state.sourceLineStarts, state.proseMask),
@@ -428,14 +359,10 @@ export function blankMarkdownDestinations(
 export function blankInlineCode(lines: readonly string[]): string[] {
   const source = lines.join("\n")
   const mask = new Uint8Array(source.length)
-  const pending = [...(markdownParser.parseInline(source, 0) as readonly ParserElement[])]
-  while (pending.length > 0) {
-    const element = pending.pop()
-    if (element === undefined) continue
-    if (element.type === NODE.inlineCode) {
-      markRange(mask, element.from, element.to)
-    } else {
-      for (const child of element.children) pending.push(child)
+
+  for (const [phase, token] of markdownTextEvents(source)) {
+    if (phase === "enter" && token.type === "codeText") {
+      markRange(mask, token.start.offset, token.end.offset)
     }
   }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -48,7 +48,6 @@ const translateParserOffsets = <Events extends ReturnType<typeof postprocess>>(
       if (points.has(point)) continue
       points.add(point)
       point.offset += offset
-      if (point.line === 1) point.column += offset
     }
   }
   return events

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,13 +1,4 @@
-import { parser as lezerMarkdownParser } from "@lezer/markdown"
-import Markdown from "@tree-sitter-grammars/tree-sitter-markdown"
-import { Parser as CommonmarkParser } from "commonmark"
-import { parse, postprocess, preprocess } from "micromark"
-import Parser from "tree-sitter"
-
-interface SourceRange {
-  readonly start: number
-  readonly end: number
-}
+import { parser as markdownParser } from "@lezer/markdown"
 
 interface MarkdownAnalysis {
   readonly lines: string[]
@@ -22,24 +13,55 @@ export interface MarkdownCodeResult {
   readonly structuralBlanks: boolean[]
 }
 
-// Micromark is exact for resolved references but has quadratic label resolution on adversarial input.
-const MICROMARK_SOURCE_LIMIT = 10_000
-const RAW_HTML_FLOW_START = /^ {0,3}<(?:pre|script|style|textarea)(?:[\t\n\r\f >]|$)/iu
-const RAW_HTML_FLOW_SELF_CLOSING = /^ {0,3}<(?:pre|script|style|textarea)\b[^>]*\/\s*>/iu
+interface AnalysisState {
+  readonly source: string
+  readonly parseLines: readonly string[]
+  readonly sourceLineStarts: readonly number[]
+  readonly lineAtOffset: Int32Array
+  readonly proseMask: Uint8Array
+  readonly structuralMask: Uint8Array
+  readonly dictionaryMask: Uint8Array
+  readonly structuralBlanks: boolean[]
+}
 
-const markdownEvents = (source: string) =>
-  postprocess(
-    parse()
-      .document()
-      .write(preprocess()(source, "utf8", true)),
-  )
+type MarkdownTree = ReturnType<typeof markdownParser.parse>
+type MarkdownNode = MarkdownTree["topNode"]
 
-const markdownTextEvents = (source: string) =>
-  postprocess(
-    parse()
-      .text()
-      .write(preprocess()(source, "utf8", true)),
-  )
+interface ParserElement {
+  readonly type: number
+  readonly from: number
+  readonly to: number
+  readonly children: readonly ParserElement[]
+}
+
+const nodeId = (name: string): number =>
+  markdownParser.nodeSet.types.find((type) => type.name === name)?.id ?? -1
+
+const NODE = {
+  autolink: nodeId("Autolink"),
+  codeBlock: nodeId("CodeBlock"),
+  comment: nodeId("Comment"),
+  emphasisMark: nodeId("EmphasisMark"),
+  entity: nodeId("Entity"),
+  escape: nodeId("Escape"),
+  fencedCode: nodeId("FencedCode"),
+  hardBreak: nodeId("HardBreak"),
+  headerMark: nodeId("HeaderMark"),
+  horizontalRule: nodeId("HorizontalRule"),
+  htmlBlock: nodeId("HTMLBlock"),
+  htmlTag: nodeId("HTMLTag"),
+  image: nodeId("Image"),
+  inlineCode: nodeId("InlineCode"),
+  link: nodeId("Link"),
+  linkLabel: nodeId("LinkLabel"),
+  linkMark: nodeId("LinkMark"),
+  linkReference: nodeId("LinkReference"),
+  linkTitle: nodeId("LinkTitle"),
+  listMark: nodeId("ListMark"),
+  processingInstruction: nodeId("ProcessingInstruction"),
+  quoteMark: nodeId("QuoteMark"),
+  url: nodeId("URL"),
+} as const
 
 const markRange = (mask: Uint8Array, start: number, end: number): void => {
   mask.fill(1, Math.max(0, start), Math.min(mask.length, end))
@@ -51,17 +73,6 @@ const normalizedIdentifier = (value: string): string =>
     .replace(/^ | $/g, "")
     .toLowerCase()
     .toUpperCase()
-
-interface AnalysisState {
-  readonly source: string
-  readonly parseLines: readonly string[]
-  readonly sourceLineStarts: readonly number[]
-  readonly lineAtOffset: Int32Array
-  readonly proseMask: Uint8Array
-  readonly structuralMask: Uint8Array
-  readonly dictionaryMask: Uint8Array
-  readonly structuralBlanks: boolean[]
-}
 
 const createAnalysisState = (source: string, parseLines: readonly string[]): AnalysisState => {
   const sourceLineStarts: number[] = []
@@ -98,377 +109,42 @@ const markCode = (state: AnalysisState, start: number, end: number, block: boole
   for (let line = firstLine; line <= lastLine; line++) state.structuralBlanks[line] = true
 }
 
-const MICROMARK_DICTIONARY_TOKENS = new Set([
-  "atxHeadingSequence",
-  "autolink",
-  "blockQuotePrefix",
-  "characterReference",
-  "definition",
-  "emphasisSequence",
-  "escapeMarker",
-  "hardBreakEscape",
-  "hardBreakTrailing",
-  "htmlText",
-  "labelImageMarker",
-  "labelMarker",
-  "listItemIndent",
-  "listItemPrefix",
-  "reference",
-  "resource",
-  "setextHeadingLine",
-  "strongSequence",
-  "thematicBreak",
-])
-
-const MICROMARK_CODE_TOKENS = new Set(["codeFenced", "codeIndented", "codeText"])
-const MICROMARK_BLOCK_CODE_TOKENS = new Set(["codeFenced", "codeIndented"])
-const MICROMARK_CONTAINER_TOKENS = new Set(["blockQuotePrefix", "listItemIndent", "listItemPrefix"])
-
-const markOrdinaryHtml = (state: AnalysisState, start: number, end: number): void => {
-  const flowSource = state.source.slice(start, end)
-  for (const [phase, token] of markdownTextEvents(flowSource)) {
-    if (phase === "enter" && (token.type === "htmlText" || token.type === "characterReference")) {
-      markRange(state.dictionaryMask, start + token.start.offset, start + token.end.offset)
+const walkTree = (root: MarkdownNode, visit: (node: MarkdownNode) => boolean | undefined): void => {
+  const cursor = root.cursor()
+  for (;;) {
+    const descend = visit(cursor.node) !== false
+    if (descend && cursor.firstChild()) continue
+    while (!cursor.nextSibling()) {
+      if (!cursor.parent()) return
     }
   }
 }
 
-const analyzeWithMicromark = (state: AnalysisState): void => {
-  const events = markdownEvents(state.source)
-  const contentColumns = new Int32Array(state.parseLines.length).fill(1)
-
-  for (const [phase, token] of events) {
-    if (phase !== "enter") continue
-    if (MICROMARK_CONTAINER_TOKENS.has(token.type)) {
-      const lineIndex = token.start.line - 1
-      contentColumns[lineIndex] = Math.max(contentColumns[lineIndex] ?? 1, token.end.column)
-      markRange(state.proseMask, token.start.offset, token.end.offset)
-    }
-  }
-
-  const shortenedDefinitions = new Map<number, number>()
-  let definitionStart: number | undefined
-  let definitionLine = 0
-  let definitionContentColumn = 1
-  for (const [phase, token] of events) {
-    if (phase === "enter" && token.type === "definition") {
-      definitionStart = token.start.offset
-      definitionLine = token.start.line
-      definitionContentColumn = contentColumns[token.start.line - 1] ?? 1
-    } else if (
-      phase === "enter" &&
-      token.type === "definitionTitle" &&
-      definitionStart !== undefined &&
-      token.start.line > definitionLine &&
-      token.start.column <=
-        Math.max(definitionContentColumn, contentColumns[token.start.line - 1] ?? 1)
-    ) {
-      shortenedDefinitions.set(definitionStart, token.start.offset)
-    } else if (phase === "exit" && token.type === "definition") {
-      definitionStart = undefined
-    }
-  }
-
-  for (const [phase, token] of events) {
-    if (phase !== "enter") continue
-    const { start, end } = token
-    if (MICROMARK_CODE_TOKENS.has(token.type)) {
-      markCode(state, start.offset, end.offset, MICROMARK_BLOCK_CODE_TOKENS.has(token.type))
-    } else if (token.type === "definition") {
-      markRange(
-        state.dictionaryMask,
-        start.offset,
-        shortenedDefinitions.get(start.offset) ?? end.offset,
-      )
-    } else if (MICROMARK_DICTIONARY_TOKENS.has(token.type)) {
-      markRange(state.dictionaryMask, start.offset, end.offset)
-    } else if (token.type === "htmlFlow") {
-      const flowSource = state.source.slice(start.offset, end.offset)
-      if (RAW_HTML_FLOW_START.test(flowSource) && !RAW_HTML_FLOW_SELF_CLOSING.test(flowSource)) {
-        markRange(state.dictionaryMask, start.offset, end.offset)
-      } else {
-        markOrdinaryHtml(state, start.offset, end.offset)
-      }
-    }
-  }
+const directChildren = (node: MarkdownNode): readonly MarkdownNode[] => {
+  const children: MarkdownNode[] = []
+  for (let child = node.firstChild; child !== null; child = child.nextSibling) children.push(child)
+  return children
 }
 
-const blockParser = new Parser()
-blockParser.setLanguage(Markdown)
-const inlineParser = new Parser()
-inlineParser.setLanguage(Markdown.inline)
-
-const walk = (
-  root: Parser.SyntaxNode,
-  visit: (node: Parser.SyntaxNode) => boolean | undefined,
-): void => {
-  const pending = [root]
-  while (pending.length > 0) {
-    const node = pending.pop()
-    if (node === undefined || visit(node) === false) continue
-    const children = node.children
-    for (let index = children.length - 1; index >= 0; index--) {
-      const child = children[index]
-      if (child !== undefined) pending.push(child)
-    }
-  }
+const labelIdentifier = (source: string, start: number, end: number): string | undefined => {
+  if (end - start > 999) return undefined
+  return normalizedIdentifier(source.slice(start, end))
 }
 
-const TREE_CONTAINER_TOKENS = new Set([
-  "block_quote_marker",
-  "list_marker_dot",
-  "list_marker_minus",
-  "list_marker_parenthesis",
-  "list_marker_plus",
-  "list_marker_star",
-])
-const TREE_CODE_TOKENS = new Set(["fenced_code_block", "indented_code_block"])
-const TREE_REFERENCE_TOKENS = new Set([
-  "collapsed_reference_link",
-  "full_reference_link",
-  "shortcut_link",
-])
-const TREE_AUTOLINK_TOKENS = new Set(["email_autolink", "uri_autolink"])
-const TREE_ENTITY_TOKENS = new Set(["entity_reference", "numeric_character_reference"])
-const TREE_MARKER_TOKENS = new Set(["emphasis_delimiter", "hard_line_break"])
-const TREE_LINK_MARKERS = new Set(["!", "[", "]", "(", ")"])
-
-const contentOfLabel = (source: string, node: Parser.SyntaxNode): string => {
-  const value = source.slice(node.startIndex, node.endIndex)
-  return value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value
-}
-
-const visibleReferenceLabel = (source: string, node: Parser.SyntaxNode): string => {
-  const explicit = node.children.find((child) => child.type === "link_label")
-  if (explicit !== undefined && explicit.endIndex - explicit.startIndex > 2) {
-    return contentOfLabel(source, explicit)
-  }
-  const visible = node.children.find(
-    (child) => child.type === "link_text" || child.type === "image_description",
-  )
-  return visible === undefined ? "" : source.slice(visible.startIndex, visible.endIndex)
-}
-
-const markTreeLink = (
-  state: AnalysisState,
+const referenceIdentifier = (
   source: string,
-  node: Parser.SyntaxNode,
-  base: number,
-  definedIdentifiers: ReadonlySet<string>,
-): void => {
-  const reference = TREE_REFERENCE_TOKENS.has(node.type) || node.type === "image"
-  const hasResource = node.children.some(
-    (child) => child.type === "link_destination" || child.type === "link_title",
-  )
-  const hasReferenceLabel = node.children.some((child) => child.type === "link_label")
-  const resolved =
-    hasResource ||
-    ((reference || hasReferenceLabel) &&
-      definedIdentifiers.has(normalizedIdentifier(visibleReferenceLabel(source, node))))
-
-  if (!resolved) return
-
-  for (const child of node.children) {
-    const start = base + child.startIndex
-    const end = base + child.endIndex
-    if (
-      child.type === "link_destination" ||
-      child.type === "link_title" ||
-      child.type === "link_label"
-    ) {
-      markRange(state.dictionaryMask, start, end)
-    } else if (TREE_LINK_MARKERS.has(child.type)) {
-      markRange(state.dictionaryMask, start, end)
-    }
-  }
-}
-
-const needsLezerInline = (root: Parser.SyntaxNode): boolean => {
-  let needed = false
-  walk(root, (node) => {
-    const children = node.children
-    let shortcutResource = false
-    for (let index = 0; index < children.length; index++) {
-      const child = children[index]
-      const next = children[index + 1]
-      const afterNext = children[index + 2]
-      if (
-        child?.type === "shortcut_link" &&
-        next?.type === "(" &&
-        child.endIndex === next.startIndex
-      ) {
-        shortcutResource = true
-      } else if (shortcutResource && child?.type === ")") {
-        needed = true
-        return false
-      } else if (child?.type === "]" && next?.type === "(" && afterNext?.type === ")") {
-        needed = true
-        return false
-      }
-    }
-    return needed ? false : undefined
-  })
-  return needed
-}
-
-const LEZER_INLINE_LIMIT = 50_000
-const commonmarkParser = new CommonmarkParser()
-
-const markLezerInline = (state: AnalysisState, source: string, base: number): boolean => {
-  if (source.length > LEZER_INLINE_LIMIT) return false
-  const cursor = lezerMarkdownParser.parse(source).cursor()
-  do {
-    if (cursor.name === "LinkMark" || cursor.name === "URL" || cursor.name === "LinkTitle") {
-      markRange(state.dictionaryMask, base + cursor.from, base + cursor.to)
-    }
-  } while (cursor.next())
-  return true
-}
-
-const parserEmptyResourceRanges = (root: Parser.SyntaxNode): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
-  walk(root, (node) => {
-    const children = node.children
-    for (let index = 0; index < children.length - 2; index++) {
-      const labelEnd = children[index]
-      const opening = children[index + 1]
-      const closing = children[index + 2]
-      if (labelEnd?.type === "]" && opening?.type === "(" && closing?.type === ")") {
-        ranges.push({ start: labelEnd.startIndex, end: closing.endIndex })
-      }
-    }
-  })
-  return ranges.sort((left, right) => left.start - right.start)
-}
-
-const countTreeResources = (
-  root: Parser.SyntaxNode,
-  source: string,
-  definedIdentifiers: ReadonlySet<string>,
-): number => {
-  let resources = 0
-  walk(root, (node) => {
-    if (node.type === "link_destination" || TREE_AUTOLINK_TOKENS.has(node.type)) {
-      resources++
-    } else if (
-      (TREE_REFERENCE_TOKENS.has(node.type) || node.type === "image") &&
-      !node.children.some((child) => child.type === "link_destination") &&
-      definedIdentifiers.has(normalizedIdentifier(visibleReferenceLabel(source, node)))
-    ) {
-      resources++
-    }
-  })
-  return resources
-}
-
-const markCommonmarkResources = (
-  state: AnalysisState,
-  source: string,
-  base: number,
-  root: Parser.SyntaxNode,
-  definedIdentifiers: ReadonlySet<string>,
-): void => {
-  let resources = 0
-  const walker = commonmarkParser.parse(source).walker()
-  let event = walker.next()
-  while (event !== null) {
-    if (event.entering && (event.node.type === "link" || event.node.type === "image")) resources++
-    event = walker.next()
+  children: readonly MarkdownNode[],
+): string | undefined => {
+  const explicit = children.find((child) => child.type.id === NODE.linkLabel)
+  if (explicit !== undefined && explicit.to - explicit.from > 2) {
+    return labelIdentifier(source, explicit.from + 1, explicit.to - 1)
   }
 
-  const missingResources = Math.max(
-    0,
-    resources - countTreeResources(root, source, definedIdentifiers),
-  )
-  const ranges = parserEmptyResourceRanges(root)
-  for (let index = 0; index < Math.min(missingResources, ranges.length); index++) {
-    const range = ranges[index]
-    if (range !== undefined) markRange(state.dictionaryMask, base + range.start, base + range.end)
-  }
-}
-
-const markInlineTree = (
-  state: AnalysisState,
-  source: string,
-  base: number,
-  definedIdentifiers: ReadonlySet<string>,
-): void => {
-  const tree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
-  walk(tree.rootNode, (node) => {
-    const start = base + node.startIndex
-    const end = base + node.endIndex
-    if (node.type === "code_span") {
-      markCode(state, start, end, false)
-      return false
-    }
-    if (
-      node.type === "inline_link" ||
-      node.type === "image" ||
-      TREE_REFERENCE_TOKENS.has(node.type)
-    ) {
-      markTreeLink(state, source, node, base, definedIdentifiers)
-    }
-    if (
-      TREE_AUTOLINK_TOKENS.has(node.type) ||
-      TREE_ENTITY_TOKENS.has(node.type) ||
-      node.type === "html_tag" ||
-      node.type === "link_destination" ||
-      node.type === "link_title"
-    ) {
-      markRange(state.dictionaryMask, start, end)
-      return false
-    }
-    if (TREE_MARKER_TOKENS.has(node.type)) {
-      markRange(state.dictionaryMask, start, end)
-    } else if (node.type === "backslash_escape") {
-      markRange(state.dictionaryMask, start, Math.min(start + 1, end))
-    }
-  })
-  if (needsLezerInline(tree.rootNode) && !markLezerInline(state, source, base)) {
-    markCommonmarkResources(state, source, base, tree.rootNode, definedIdentifiers)
-  }
-}
-
-const markHtmlTree = (state: AnalysisState, source: string, base: number): void => {
-  const tree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
-  walk(tree.rootNode, (node) => {
-    if (node.type === "html_tag" || TREE_ENTITY_TOKENS.has(node.type)) {
-      markRange(state.dictionaryMask, base + node.startIndex, base + node.endIndex)
-      return false
-    }
-  })
-}
-
-const analyzeCodeWithTreeSitter = (state: AnalysisState): void => {
-  const tree = blockParser.parse(state.source, undefined, {
-    bufferSize: state.source.length + 1,
-  })
-  const inlineRanges: SourceRange[] = []
-
-  walk(tree.rootNode, (node) => {
-    if (TREE_CODE_TOKENS.has(node.type)) {
-      markCode(state, node.startIndex, node.endIndex, true)
-      return false
-    }
-    if (TREE_CONTAINER_TOKENS.has(node.type)) {
-      markRange(state.proseMask, node.startIndex, node.endIndex)
-    } else if (node.type === "inline") {
-      inlineRanges.push({ start: node.startIndex, end: node.endIndex })
-      return false
-    }
-  })
-
-  for (const range of inlineRanges) {
-    const source = state.source.slice(range.start, range.end)
-    if (!source.includes("`")) continue
-    const inlineTree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
-    walk(inlineTree.rootNode, (node) => {
-      if (node.type === "code_span") {
-        markCode(state, range.start + node.startIndex, range.start + node.endIndex, false)
-        return false
-      }
-    })
-  }
+  const marks = children.filter((child) => child.type.id === NODE.linkMark)
+  const opening = marks[0]
+  const closing = marks[1]
+  if (opening === undefined || closing === undefined) return undefined
+  return labelIdentifier(source, opening.to, closing.from)
 }
 
 const virtualColumn = (line: string, sourceColumn: number): number => {
@@ -479,71 +155,181 @@ const virtualColumn = (line: string, sourceColumn: number): number => {
   return column
 }
 
-const analyzeWithTreeSitter = (state: AnalysisState): void => {
-  // Disable Tree-sitter's task-marker ambiguity without changing any source offsets.
-  const blockSource = state.source.replace(/^([ \t]{0,3})\[x\](?=:)/gimu, "$1[a]")
-  const tree = blockParser.parse(blockSource, undefined, {
-    bufferSize: blockSource.length + 1,
-  })
+const sourceColumn = (state: AnalysisState, offset: number): number => {
+  const line = state.lineAtOffset[Math.min(offset, state.source.length)] ?? 0
+  return virtualColumn(
+    state.parseLines[line] ?? "",
+    offset - (state.sourceLineStarts[line] ?? 0),
+  )
+}
+
+const definitionMaskEnd = (state: AnalysisState, node: MarkdownNode): number => {
+  const title = directChildren(node).find((child) => child.type.id === NODE.linkTitle)
+  if (title === undefined) return node.to
+
+  const definitionLine = state.lineAtOffset[Math.min(node.from, state.source.length)] ?? 0
+  const titleLine = state.lineAtOffset[Math.min(title.from, state.source.length)] ?? definitionLine
+  if (titleLine > definitionLine && sourceColumn(state, title.from) <= sourceColumn(state, node.from)) {
+    return title.from
+  }
+  return node.to
+}
+
+const markLink = (
+  state: AnalysisState,
+  node: MarkdownNode,
+  definitions: ReadonlySet<string>,
+): void => {
+  const children = directChildren(node)
+  const marks = children.filter((child) => child.type.id === NODE.linkMark)
+  const hasResource =
+    children.some((child) => child.type.id === NODE.url || child.type.id === NODE.linkTitle) ||
+    marks.length >= 4
+  const identifier = hasResource ? undefined : referenceIdentifier(state.source, children)
+  if (!hasResource && (identifier === undefined || !definitions.has(identifier))) return
+
+  for (const child of children) {
+    if (
+      child.type.id === NODE.linkMark ||
+      child.type.id === NODE.linkLabel ||
+      child.type.id === NODE.url ||
+      child.type.id === NODE.linkTitle
+    ) {
+      markRange(state.dictionaryMask, child.from, child.to)
+    }
+  }
+}
+
+const rawContentTag = (tag: string): boolean => {
+  const lower = tag.toLowerCase()
+  for (const name of ["pre", "script", "style", "textarea"]) {
+    if (!lower.startsWith(`<${name}`)) continue
+    const boundary = lower[name.length + 1]
+    if (boundary === undefined || boundary === ">" || boundary === "/" || /\s/u.test(boundary)) {
+      return true
+    }
+  }
+  return false
+}
+
+const selfClosingTag = (tag: string): boolean => {
+  let index = tag.length - 2
+  while (index >= 0 && /\s/u.test(tag[index] ?? "")) index--
+  return tag[index] === "/"
+}
+
+const htmlElements = (source: string, start: number, end: number): readonly ParserElement[] =>
+  markdownParser.parseInline(source.slice(start, end), start) as readonly ParserElement[]
+
+const markHtmlBlock = (state: AnalysisState, start: number, end: number): void => {
+  const pending = [...htmlElements(state.source, start, end)]
+  const syntax: ParserElement[] = []
+  let firstTag: ParserElement | undefined
+
+  while (pending.length > 0) {
+    const element = pending.pop()
+    if (element === undefined) continue
+    if (element.type === NODE.htmlTag && (firstTag === undefined || element.from < firstTag.from)) {
+      firstTag = element
+    }
+    if (
+      element.type === NODE.htmlTag ||
+      element.type === NODE.entity ||
+      element.type === NODE.comment ||
+      element.type === NODE.processingInstruction
+    ) {
+      syntax.push(element)
+    }
+    for (const child of element.children) pending.push(child)
+  }
+
+  if (firstTag !== undefined) {
+    const tag = state.source.slice(firstTag.from, firstTag.to)
+    if (firstTag.from === start && rawContentTag(tag) && !selfClosingTag(tag)) {
+      markRange(state.dictionaryMask, start, end)
+      return
+    }
+  }
+
+  for (const element of syntax) markRange(state.dictionaryMask, element.from, element.to)
+}
+
+const collectDefinitions = (source: string, root: MarkdownNode): ReadonlySet<string> => {
   const definitions = new Set<string>()
-  const inlineRanges: SourceRange[] = []
-  const ordinaryHtmlRanges: SourceRange[] = []
-  const contentColumns = new Int32Array(state.parseLines.length)
+  walkTree(root, (node) => {
+    if (node.type.id !== NODE.linkReference) return
+    const label = directChildren(node).find((child) => child.type.id === NODE.linkLabel)
+    if (label !== undefined) {
+      const identifier = labelIdentifier(source, label.from + 1, label.to - 1)
+      if (identifier !== undefined) definitions.add(identifier)
+    }
+    return false
+  })
+  return definitions
+}
 
-  walk(tree.rootNode, (node) => {
-    if (TREE_CODE_TOKENS.has(node.type)) {
-      markCode(state, node.startIndex, node.endIndex, true)
+const CODE_BLOCKS = new Set([NODE.codeBlock, NODE.fencedCode])
+const CONTAINER_MARKS = new Set([NODE.quoteMark, NODE.listMark])
+const DICTIONARY_NODES = new Set([
+  NODE.autolink,
+  NODE.comment,
+  NODE.entity,
+  NODE.htmlTag,
+  NODE.processingInstruction,
+  NODE.hardBreak,
+  NODE.headerMark,
+  NODE.horizontalRule,
+  NODE.emphasisMark,
+])
+
+const analyzeTree = (state: AnalysisState, includeDictionary: boolean): void => {
+  const tree = markdownParser.parse(state.source)
+  const definitions = includeDictionary
+    ? collectDefinitions(state.source, tree.topNode)
+    : new Set<string>()
+
+  walkTree(tree.topNode, (node) => {
+    if (CODE_BLOCKS.has(node.type.id)) {
+      markCode(state, node.from, node.to, true)
       return false
     }
-    if (TREE_CONTAINER_TOKENS.has(node.type)) {
-      const line = node.endPosition.row
-      const column = virtualColumn(state.parseLines[line] ?? "", node.endPosition.column)
-      contentColumns[line] = Math.max(contentColumns[line] ?? 0, column)
-      markRange(state.proseMask, node.startIndex, node.endIndex)
-      markRange(state.dictionaryMask, node.startIndex, node.endIndex)
-    } else if (node.type === "link_reference_definition") {
-      const label = node.children.find((child) => child.type === "link_label")
-      if (label !== undefined) {
-        definitions.add(normalizedIdentifier(contentOfLabel(state.source, label)))
-      }
-      const title = node.children.find((child) => child.type === "link_title")
-      const maskEnd =
-        title !== undefined &&
-        title.startPosition.row > node.startPosition.row &&
-        virtualColumn(
-          state.parseLines[title.startPosition.row] ?? "",
-          title.startPosition.column,
-        ) <=
-          Math.max(
-            contentColumns[node.startPosition.row] ?? 0,
-            contentColumns[title.startPosition.row] ?? 0,
-          )
-          ? title.startIndex
-          : node.endIndex
-      markRange(state.dictionaryMask, node.startIndex, maskEnd)
+    if (node.type.id === NODE.inlineCode) {
+      markCode(state, node.from, node.to, false)
       return false
-    } else if (node.type === "inline") {
-      inlineRanges.push({ start: node.startIndex, end: node.endIndex })
+    }
+    if (CONTAINER_MARKS.has(node.type.id)) {
+      const siblingStart = node.nextSibling?.from ?? node.to
+      const end =
+        siblingStart > node.to && state.source.slice(node.to, siblingStart).trim() === ""
+          ? siblingStart
+          : node.to
+      markRange(state.proseMask, node.from, end)
+      if (includeDictionary) markRange(state.dictionaryMask, node.from, end)
+      return
+    }
+    if (!includeDictionary) return
+
+    if (node.type.id === NODE.linkReference) {
+      markRange(state.dictionaryMask, node.from, definitionMaskEnd(state, node))
       return false
-    } else if (node.type === "html_block") {
-      const html = state.source.slice(node.startIndex, node.endIndex)
-      if (RAW_HTML_FLOW_START.test(html) && !RAW_HTML_FLOW_SELF_CLOSING.test(html)) {
-        markRange(state.dictionaryMask, node.startIndex, node.endIndex)
-      } else {
-        ordinaryHtmlRanges.push({ start: node.startIndex, end: node.endIndex })
-      }
+    }
+    if (node.type.id === NODE.link || node.type.id === NODE.image) {
+      markLink(state, node, definitions)
+      return
+    }
+    if (node.type.id === NODE.htmlBlock) {
+      markHtmlBlock(state, node.from, node.to)
       return false
-    } else if (node.type === "thematic_break" || /^atx_h[1-6]_marker$/.test(node.type)) {
-      markRange(state.dictionaryMask, node.startIndex, node.endIndex)
+    }
+    if (node.type.id === NODE.escape) {
+      markRange(state.dictionaryMask, node.from, Math.min(node.from + 1, node.to))
+      return false
+    }
+    if (DICTIONARY_NODES.has(node.type.id)) {
+      markRange(state.dictionaryMask, node.from, node.to)
+      return false
     }
   })
-
-  for (const range of inlineRanges) {
-    markInlineTree(state, state.source.slice(range.start, range.end), range.start, definitions)
-  }
-  for (const range of ordinaryHtmlRanges) {
-    markHtmlTree(state, state.source.slice(range.start, range.end), range.start)
-  }
 }
 
 const applyMask = (
@@ -579,12 +365,9 @@ const analyzeMarkdown = (
   const parseLines = lines.map((line, index) => line.slice(starts[index]))
   const source = parseLines.join("\n")
   const state = createAnalysisState(source, parseLines)
+  analyzeTree(state, includeDictionary)
 
-  if (source.length <= MICROMARK_SOURCE_LIMIT) analyzeWithMicromark(state)
-  else if (includeDictionary) analyzeWithTreeSitter(state)
-  else analyzeCodeWithTreeSitter(state)
-
-  const analysis = {
+  return {
     lines: applyMask(lines, starts, parseLines, state.sourceLineStarts, state.proseMask),
     structuralLines: applyMask(
       lines,
@@ -602,7 +385,6 @@ const analyzeMarkdown = (
     ),
     structuralBlanks: state.structuralBlanks,
   }
-  return analysis
 }
 
 export function blankMarkdownForLint(
@@ -646,9 +428,14 @@ export function blankMarkdownDestinations(
 export function blankInlineCode(lines: readonly string[]): string[] {
   const source = lines.join("\n")
   const mask = new Uint8Array(source.length)
-  for (const [phase, token] of markdownTextEvents(source)) {
-    if (phase === "enter" && token.type === "codeText") {
-      markRange(mask, token.start.offset, token.end.offset)
+  const pending = [...(markdownParser.parseInline(source, 0) as readonly ParserElement[])]
+  while (pending.length > 0) {
+    const element = pending.pop()
+    if (element === undefined) continue
+    if (element.type === NODE.inlineCode) {
+      markRange(mask, element.from, element.to)
+    } else {
+      for (const child of element.children) pending.push(child)
     }
   }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,5 +1,7 @@
+import { parser as htmlParser } from "@lezer/html"
+import { parser as commonMarkParser } from "@lezer/markdown"
 import { parse, postprocess, preprocess } from "micromark"
-import type { Extension } from "micromark-util-types"
+import { normalizeIdentifier } from "micromark-util-normalize-identifier"
 import { markdownSyntaxExtension } from "./markdown-syntax.ts"
 
 interface MarkdownAnalysis {
@@ -64,38 +66,6 @@ const markdownEvents = (source: string) => {
   return translateParserOffsets(events, input.offset)
 }
 
-const markdownTextEvents = (source: string) => {
-  const input = parserInput(source)
-  const events = postprocess(
-    parse({ extensions: [markdownSyntaxExtension] })
-      .text()
-      .write(preprocess()(input.source, undefined, true)),
-  )
-  return translateParserOffsets(events, input.offset)
-}
-
-const htmlSyntaxExtension: Extension = {
-  disable: {
-    null: [
-      "attention",
-      "autolink",
-      "characterEscape",
-      "codeText",
-      "hardBreakEscape",
-      "labelEnd",
-      "labelStartImage",
-      "labelStartLink",
-    ],
-  },
-}
-
-const htmlSyntaxEvents = (source: string) =>
-  postprocess(
-    parse({ extensions: [htmlSyntaxExtension] })
-      .text()
-      .write(preprocess()(source, undefined, true)),
-  )
-
 type MarkdownEvents = ReturnType<typeof markdownEvents>
 type MarkdownToken = MarkdownEvents[number][1]
 
@@ -121,7 +91,20 @@ const DICTIONARY_TOKENS = new Set([
   "strongSequence",
   "thematicBreak",
 ])
-const HTML_SYNTAX_TOKENS = new Set(["characterReference", "htmlText"])
+const codeOnlyInlineParser = commonMarkParser.configure({ remove: ["Image", "Link"] })
+
+const HTML_SYNTAX_NODES = new Set(["Comment", "Entity", "HTMLTag", "ProcessingInstruction"])
+const HTML_FLOW_NODES = new Set([
+  "CloseTag",
+  "Comment",
+  "DoctypeDecl",
+  "EntityReference",
+  "MismatchedCloseTag",
+  "OpenTag",
+  "ProcessingInst",
+])
+const INLINE_CONTENT_TOKENS = new Set(["atxHeadingText", "paragraph", "setextHeadingText"])
+const LINK_SYNTAX_NODES = new Set(["LinkMark", "URL", "LinkTitle"])
 
 const markRange = (mask: Uint8Array, start: number, end: number): void => {
   mask.fill(1, Math.max(0, start), Math.min(mask.length, end))
@@ -220,28 +203,128 @@ const definitionMaskEnds = (events: MarkdownEvents): ReadonlyMap<number, number>
   return ends
 }
 
-const enteredRanges = (
-  events: MarkdownEvents,
-  tokenTypes: ReadonlySet<string>,
-): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
+const definedLabels = (state: AnalysisState, events: MarkdownEvents): ReadonlySet<string> => {
+  const labels = new Set<string>()
   for (const [phase, token] of events) {
-    if (phase === "enter" && tokenTypes.has(token.type)) {
-      ranges.push({ start: token.start.offset, end: token.end.offset })
+    if (phase === "enter" && token.type === "definitionLabelString") {
+      labels.add(normalizeIdentifier(state.source.slice(token.start.offset, token.end.offset)))
     }
   }
-  return ranges
+  return labels
+}
+
+interface InlineElement {
+  readonly type: number
+  readonly from: number
+  readonly to: number
+  readonly children?: readonly InlineElement[]
+}
+
+const inlineElementName = (element: InlineElement): string =>
+  commonMarkParser.nodeSet.types[element.type]?.name ?? ""
+
+const markInlineSyntax = (
+  state: AnalysisState,
+  events: MarkdownEvents,
+  includeDictionary: boolean,
+): void => {
+  const definitions = includeDictionary ? definedLabels(state, events) : new Set<string>()
+
+  for (const [phase, token] of events) {
+    if (phase !== "enter" || !INLINE_CONTENT_TOKENS.has(token.type)) continue
+
+    const inlineSource = state.source.slice(token.start.offset, token.end.offset)
+    const parser =
+      inlineSource.includes(")") || (includeDictionary && definitions.size > 0)
+        ? commonMarkParser
+        : codeOnlyInlineParser
+    const elements = parser.parseInline(
+      inlineSource,
+      token.start.offset,
+    ) as readonly InlineElement[]
+    const pending = [...elements]
+
+    while (pending.length > 0) {
+      const element = pending.pop()
+      if (element === undefined) continue
+      if (element.children !== undefined) pending.push(...element.children)
+
+      const name = inlineElementName(element)
+      if (name === "InlineCode") {
+        markRange(state.proseMask, element.from, element.to)
+        markRange(state.structuralMask, element.from, element.to)
+        markRange(state.dictionaryMask, element.from, element.to)
+        continue
+      }
+      if (!includeDictionary || (name !== "Link" && name !== "Image")) continue
+
+      const children = element.children ?? []
+      let openingEnd: number | undefined
+      let closingStart: number | undefined
+      let reference: InlineElement | undefined
+      let resource = false
+
+      for (const child of children) {
+        const childName = inlineElementName(child)
+        if (childName === "LinkMark") {
+          const syntax = state.source.slice(child.from, child.to)
+          if (openingEnd === undefined) openingEnd = child.to
+          else if (closingStart === undefined) closingStart = child.from
+          if (syntax === "(") resource = true
+        } else if (childName === "LinkLabel") {
+          reference = child
+        }
+      }
+
+      if (!resource && definitions.size === 0) continue
+      if (
+        !resource &&
+        reference === undefined &&
+        (openingEnd === undefined || closingStart === undefined || closingStart - openingEnd > 999)
+      ) {
+        continue
+      }
+
+      const primary =
+        openingEnd === undefined || closingStart === undefined
+          ? ""
+          : state.source.slice(openingEnd, closingStart)
+      const referenceLabel =
+        reference === undefined
+          ? primary
+          : state.source.slice(reference.from + 1, reference.to - 1) || primary
+      if (!resource && !definitions.has(normalizeIdentifier(referenceLabel))) continue
+
+      for (const child of children) {
+        const childName = inlineElementName(child)
+        if (LINK_SYNTAX_NODES.has(childName) || childName === "LinkLabel") {
+          markRange(state.dictionaryMask, child.from, child.to)
+        }
+      }
+    }
+  }
 }
 
 const markHtmlFlows = (state: AnalysisState, htmlFlows: readonly SourceRange[]): void => {
   for (const flow of htmlFlows) {
-    const syntax = enteredRanges(
-      htmlSyntaxEvents(state.source.slice(flow.start, flow.end)),
-      HTML_SYNTAX_TOKENS,
-    )
-    for (const range of syntax) {
-      markRange(state.dictionaryMask, flow.start + range.start, flow.start + range.end)
+    const pending = commonMarkParser.parseInline(
+      state.source.slice(flow.start, flow.end),
+      flow.start,
+    ) as readonly InlineElement[]
+
+    for (const element of pending) {
+      if (HTML_SYNTAX_NODES.has(inlineElementName(element))) {
+        markRange(state.dictionaryMask, element.from, element.to)
+      }
     }
+
+    htmlParser.parse(state.source.slice(flow.start, flow.end)).iterate({
+      enter(ref) {
+        if (HTML_FLOW_NODES.has(ref.name)) {
+          markRange(state.dictionaryMask, flow.start + ref.from, flow.start + ref.to)
+        }
+      },
+    })
   }
 }
 
@@ -255,10 +338,6 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
 
     if (CODE_BLOCK_TOKENS.has(token.type)) {
       markCode(state, token, true)
-      continue
-    }
-    if (token.type === "codeText") {
-      markCode(state, token, false)
       continue
     }
     if (CONTAINER_TOKENS.has(token.type)) {
@@ -286,6 +365,7 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
     }
   }
 
+  markInlineSyntax(state, events, includeDictionary)
   markContainerOnlyLinesAsBlank(state)
   if (htmlFlows.length > 0) markHtmlFlows(state, htmlFlows)
 }
@@ -387,10 +467,15 @@ export function blankMarkdownDestinations(
 export function blankInlineCode(lines: readonly string[]): string[] {
   const source = lines.join("\n")
   const mask = new Uint8Array(source.length)
+  const parser = source.includes(")") ? commonMarkParser : codeOnlyInlineParser
+  const pending = [...(parser.parseInline(source, 0) as readonly InlineElement[])]
 
-  for (const [phase, token] of markdownTextEvents(source)) {
-    if (phase === "enter" && token.type === "codeText") {
-      markRange(mask, token.start.offset, token.end.offset)
+  while (pending.length > 0) {
+    const element = pending.pop()
+    if (element === undefined) continue
+    if (element.children !== undefined) pending.push(...element.children)
+    if (inlineElementName(element) === "InlineCode") {
+      markRange(mask, element.from, element.to)
     }
   }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -31,10 +31,10 @@ interface SourceRange {
   readonly end: number
 }
 
-const parserInput = (source: string): { readonly source: string; readonly offset: number } =>
-  source.charCodeAt(0) === 0xfeff
-    ? { source: source.slice(1), offset: 1 }
-    : { source, offset: 0 }
+const parserInput = (source: string): { readonly source: string; readonly offset: number } => ({
+  source,
+  offset: source.charCodeAt(0) === 0xfeff ? 1 : 0,
+})
 
 const translateParserOffsets = <Events extends ReturnType<typeof postprocess>>(
   events: Events,

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,162 +1,17 @@
+import Markdown from "@tree-sitter-grammars/tree-sitter-markdown"
 import { parse, postprocess, preprocess } from "micromark"
+import Parser from "tree-sitter"
 
-const OPENING_FENCE = /^ {0,3}(`{3,}|~{3,})(.*)$/
-const CLOSING_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
-const INDENTED = /^(?: {4,}|\t)/
-const ATX_HEADING = /^ {0,3}#{1,6}(?:[ \t]+|$)/
-const LIST_MARKER = /^( {0,3})(?:[-+*]|\d{1,9}[.)])(?:([ \t]{1,4})(?![ \t])|[ \t])/
-
-const blankLine = (line: string): string => " ".repeat(line.length)
-
-interface Container {
-  readonly quoteDepth: number
-  readonly listIndent: number
-}
-
-interface MarkdownContent {
-  readonly text: string
-  readonly start: number
-  readonly container: Container
-}
-
-const consumeBlockquotes = (
-  line: string,
-  initial: number,
-  requiredDepth?: number,
-): { index: number; depth: number } => {
-  let index = initial
-  let depth = 0
-  while (index < line.length && (requiredDepth === undefined || depth < requiredDepth)) {
-    let marker = index
-    let spaces = 0
-    while (spaces < 3 && line[marker] === " ") {
-      marker++
-      spaces++
-    }
-    if (line[marker] !== ">") break
-    depth++
-    index = marker + 1
-    if (line[index] === " " || line[index] === "\t") index++
-  }
-  return { index, depth }
-}
-
-const markdownContent = (line: string, contentStart: number): MarkdownContent => {
-  const base = Math.min(contentStart, line.length)
-  const blockquotes = consumeBlockquotes(line, base)
-  let index = blockquotes.index
-  let listIndent = 0
-
-  while (index < line.length) {
-    const match = line.slice(index).match(LIST_MARKER)
-    if (match === null) break
-    const width = match[0].length
-    listIndent += width
-    index += width
-  }
-
-  return {
-    text: line.slice(index),
-    start: index,
-    container: { quoteDepth: blockquotes.depth, listIndent },
-  }
-}
-
-const contentWithin = (
-  line: string,
-  contentStart: number,
-  container: Container,
-): MarkdownContent | null => {
-  const base = Math.min(contentStart, line.length)
-  if (container.quoteDepth === 0 && container.listIndent === 0) {
-    return { text: line.slice(base), start: base, container }
-  }
-
-  const blockquotes = consumeBlockquotes(line, base, container.quoteDepth)
-  if (blockquotes.depth !== container.quoteDepth) return null
-
-  let index = blockquotes.index
-  if (line.slice(index).trim() === "") {
-    return { text: "", start: line.length, container }
-  }
-  let remaining = container.listIndent
-  while (remaining > 0 && (line[index] === " " || line[index] === "\t")) {
-    index++
-    remaining--
-  }
-  if (remaining > 0) return null
-
-  return { text: line.slice(index), start: index, container }
-}
-
-const fenceLine = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line)
-
-const openingFence = (line: string): string | null => {
-  const match = fenceLine(line).match(OPENING_FENCE)
-  if (match === null) return null
-  const marker = match[1] as string
-  const info = match[2] as string
-  return marker[0] === "`" && info.includes("`") ? null : marker
-}
-
-const closesFence = (line: string, fence: string): boolean => {
-  const marker = fenceLine(line).match(CLOSING_FENCE)?.[1]
-  return marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length
-}
-
-interface BacktickRun {
+interface SourceRange {
   readonly start: number
   readonly end: number
-  readonly length: number
-  readonly escaped: boolean
 }
 
-const blankInlineCodeSpans = (text: string): string => {
-  const output = text.split("")
-  const runs: BacktickRun[] = []
-
-  for (let i = 0; i < text.length; ) {
-    if (text[i] !== "`") {
-      i++
-      continue
-    }
-    let end = i + 1
-    while (text[end] === "`") end++
-    let backslashes = 0
-    for (let j = i - 1; j >= 0 && text[j] === "\\"; j--) backslashes++
-    runs.push({ start: i, end, length: end - i, escaped: backslashes % 2 !== 0 })
-    i = end
-  }
-
-  const nextMatchingRun = new Array<number | undefined>(runs.length)
-  const previousByLength = new Map<number, number>()
-  for (let i = 0; i < runs.length; i++) {
-    const run = runs[i] as BacktickRun
-    const previous = previousByLength.get(run.length)
-    if (previous !== undefined) nextMatchingRun[previous] = i
-    previousByLength.set(run.length, i)
-  }
-
-  for (let i = 0; i < runs.length; ) {
-    const opener = runs[i] as BacktickRun
-    const closerIndex = nextMatchingRun[i]
-    if (opener.escaped || closerIndex === undefined) {
-      i++
-      continue
-    }
-    const closer = runs[closerIndex] as BacktickRun
-    for (let j = opener.start; j < closer.end; j++) {
-      if (output[j] !== "\n") output[j] = " "
-    }
-    i = closerIndex + 1
-  }
-
-  return output.join("")
-}
-
-interface FenceState {
-  readonly marker: string
-  readonly container: Container
+interface MarkdownAnalysis {
+  readonly lines: string[]
+  readonly structuralLines: string[]
+  readonly dictionaryLines: string[]
+  readonly structuralBlanks: boolean[]
 }
 
 export interface MarkdownCodeResult {
@@ -165,478 +20,10 @@ export interface MarkdownCodeResult {
   readonly structuralBlanks: boolean[]
 }
 
-export function blankMarkdownCodeWithStructure(
-  inputLines: readonly string[],
-  contentStarts: readonly number[] = inputLines.map(() => 0),
-): MarkdownCodeResult {
-  let fence: FenceState | null = null
-  let activeList: Container | null = null
-  let paragraphCanContinue = false
-  let inIndented = false
-  const inlineEligible: boolean[] = []
-  const structuralLines: string[] = []
-  const structuralBlanks: boolean[] = []
-  const lines = inputLines.map((line, index) => {
-    const contentStart = contentStarts[index] ?? 0
-
-    if (fence !== null) {
-      const contained = contentWithin(line, contentStart, fence.container)
-      if (contained !== null) {
-        if (closesFence(contained.text, fence.marker)) {
-          fence = null
-          paragraphCanContinue = false
-          inIndented = false
-        }
-        inlineEligible.push(false)
-        structuralLines.push(blankLine(line))
-        structuralBlanks.push(true)
-        return blankLine(line)
-      }
-      fence = null
-      paragraphCanContinue = false
-      inIndented = false
-    }
-
-    let content = markdownContent(line, contentStart)
-    if (content.container.listIndent > 0) {
-      activeList = content.container
-    } else if (content.text.trim() !== "" && activeList !== null) {
-      const continued = contentWithin(line, contentStart, activeList)
-      if (continued === null) {
-        activeList = null
-      } else {
-        content = continued
-      }
-    }
-
-    const visibleLine = `${" ".repeat(content.start)}${line.slice(content.start)}`
-    const marker = openingFence(content.text)
-    if (marker !== null) {
-      fence = { marker, container: content.container }
-      paragraphCanContinue = false
-      inIndented = false
-      inlineEligible.push(false)
-      structuralLines.push(blankLine(line))
-      structuralBlanks.push(true)
-      return blankLine(line)
-    }
-    if (content.text.trim() === "") {
-      paragraphCanContinue = false
-      inIndented = false
-      inlineEligible.push(false)
-      structuralLines.push(line)
-      structuralBlanks.push(true)
-      return visibleLine
-    }
-    if (INDENTED.test(content.text) && (!paragraphCanContinue || inIndented)) {
-      paragraphCanContinue = false
-      inIndented = true
-      inlineEligible.push(false)
-      structuralLines.push(blankLine(line))
-      structuralBlanks.push(true)
-      return blankLine(line)
-    }
-    paragraphCanContinue = !ATX_HEADING.test(content.text)
-    inIndented = false
-    inlineEligible.push(true)
-    structuralLines.push(line)
-    structuralBlanks.push(false)
-    return visibleLine
-  })
-
-  const blankEligibleInlineCode = (target: string[]) => {
-    let start = 0
-    while (start < target.length) {
-      if (!inlineEligible[start]) {
-        start++
-        continue
-      }
-      let end = start + 1
-      while (end < target.length && inlineEligible[end]) end++
-      const blanked = blankInlineCodeSpans(target.slice(start, end).join("\n")).split("\n")
-      for (let i = start; i < end; i++) target[i] = blanked[i - start] as string
-      start = end
-    }
-  }
-
-  blankEligibleInlineCode(lines)
-  blankEligibleInlineCode(structuralLines)
-
-  return { lines, structuralLines, structuralBlanks }
-}
-
-export function blankMarkdownCode(
-  inputLines: readonly string[],
-  contentStarts: readonly number[] = inputLines.map(() => 0),
-): string[] {
-  return blankMarkdownCodeWithStructure(inputLines, contentStarts).lines
-}
-
-export function maskMarkdownCode(text: string): string {
-  return blankMarkdownCode(text.split("\n")).join("\n")
-}
-
-const MASKED_MARKDOWN_TOKENS = new Set([
-  "autolink",
-  "blockQuotePrefix",
-  "codeFenced",
-  "codeIndented",
-  "codeText",
-  "characterReference",
-  "htmlText",
-  "listItemPrefix",
-  "reference",
-  "resource",
-])
-
-const lineStartOffsets = (lines: readonly string[]): readonly number[] => {
-  const offsets: number[] = []
-  let offset = 0
-  for (let index = 0; index < lines.length; index++) {
-    offsets.push(offset)
-    offset += (lines[index]?.length ?? 0) + (index < lines.length - 1 ? 1 : 0)
-  }
-  return offsets
-}
-
-const lineIndexAtOffset = (offsets: readonly number[], offset: number): number => {
-  let low = 0
-  let high = offsets.length
-  while (low < high) {
-    const middle = Math.floor((low + high) / 2)
-    if ((offsets[middle] ?? Number.POSITIVE_INFINITY) <= offset) low = middle + 1
-    else high = middle
-  }
-  return Math.max(0, low - 1)
-}
-
-const blankTextRange = (text: string[], start: number, end: number): void => {
-  for (let index = start; index < end; index++) {
-    if (text[index] !== "\n") text[index] = " "
-  }
-}
-
-interface ReferenceCandidate {
-  readonly image: boolean
-  readonly imageLabelStart: number
-  readonly imageLabelEnd: number
-  readonly labelStart: number
-  readonly sourceStart: number
-  sourceEnd?: number
-  identifier?: string
-  valid: boolean
-}
-
-interface BracketFrame {
-  readonly opening: number
-  readonly image: boolean
-  readonly labelDepth: number
-  readonly linkEpoch: number
-  readonly referenceCandidate?: ReferenceCandidate
-}
-
-interface ResourceCandidate {
-  readonly labelStart: number
-  readonly sourceStart: number
-  sourceEnd?: number
-}
-
-interface SourceRange {
-  readonly start: number
-  readonly end: number
-}
-
-interface PreparedMarkdownSource {
-  readonly value: string
-  readonly resourceCandidates: readonly ResourceCandidate[]
-  readonly referenceCandidates: readonly ReferenceCandidate[]
-  readonly deepFallback: boolean
-}
-
-const isMarkdownWhitespace = (character: string | undefined): boolean =>
-  character === " " || character === "\t" || character === "\n" || character === "\r"
-
-const normalizeIdentifier = (value: string): string =>
-  value
-    .replace(/[\t\n\r ]+/g, " ")
-    .replace(/^ | $/g, "")
-    .toLowerCase()
-    .toUpperCase()
-
-const MAX_MARKDOWN_LABEL_SIZE = 999
-const MAX_MARKDOWN_LABEL_SOURCE_SIZE = MAX_MARKDOWN_LABEL_SIZE * 4 + 2
-
-const normalizeIdentifierRange = (
-  source: string,
-  start: number,
-  end: number,
-): string | undefined => {
-  if (end - start > MAX_MARKDOWN_LABEL_SOURCE_SIZE) return undefined
-
-  let size = 0
-  for (let index = start; index < end; ) {
-    const codePoint = source.codePointAt(index)
-    if (codePoint === undefined) break
-    const character = String.fromCodePoint(codePoint)
-    if (character !== "\n" && character !== "\r") size++
-    if (size > MAX_MARKDOWN_LABEL_SIZE) return undefined
-    index += character.length
-  }
-
-  const identifier = normalizeIdentifier(source.slice(start, end))
-  return identifier === "" ? undefined : identifier
-}
-
-interface ResourceScanIndex {
-  readonly escaped: Uint8Array
-  readonly nextNonWhitespace: Int32Array
-  readonly nextWhitespace: Int32Array
-  readonly nextLineEnding: Int32Array
-  readonly nextGreater: Int32Array
-  readonly nextLess: Int32Array
-  readonly nextDoubleQuote: Int32Array
-  readonly nextSingleQuote: Int32Array
-  readonly nextClosingParenthesis: Int32Array
-  readonly nextAsciiControl: Int32Array
-  readonly depthBefore: Int32Array
-  readonly boundariesByDepth: ReadonlyMap<number, readonly number[]>
-  readonly openingsByDepth: ReadonlyMap<number, readonly number[]>
-  readonly boundaryCursors: Map<number, number>
-  readonly openingCursors: Map<number, number>
-}
-
-const escapedCharacters = (source: string): Uint8Array => {
-  const escaped = new Uint8Array(source.length)
-  let backslashRun = 0
-  for (let index = 0; index < source.length; index++) {
-    if (source[index] === "\\") {
-      backslashRun++
-      continue
-    }
-    if (backslashRun % 2 !== 0) escaped[index] = 1
-    backslashRun = 0
-  }
-  return escaped
-}
-
-const resourceScanIndex = (source: string): ResourceScanIndex => {
-  const escaped = escapedCharacters(source)
-  const nextNonWhitespace = new Int32Array(source.length + 1).fill(source.length)
-  const nextWhitespace = new Int32Array(source.length + 1).fill(-1)
-  const nextLineEnding = new Int32Array(source.length + 1).fill(-1)
-  const nextGreater = new Int32Array(source.length + 1).fill(-1)
-  const nextLess = new Int32Array(source.length + 1).fill(-1)
-  const nextDoubleQuote = new Int32Array(source.length + 1).fill(-1)
-  const nextSingleQuote = new Int32Array(source.length + 1).fill(-1)
-  const nextClosingParenthesis = new Int32Array(source.length + 1).fill(-1)
-  const nextAsciiControl = new Int32Array(source.length + 1).fill(-1)
-  let nonWhitespace = source.length
-  let whitespace = -1
-  let lineEnding = -1
-  let greater = -1
-  let less = -1
-  let doubleQuote = -1
-  let singleQuote = -1
-  let closingParenthesis = -1
-  let asciiControl = -1
-
-  for (let index = source.length - 1; index >= 0; index--) {
-    const character = source[index]
-    const code = source.charCodeAt(index)
-    if (isMarkdownWhitespace(character)) whitespace = index
-    else nonWhitespace = index
-    if (character === "\n" || character === "\r") lineEnding = index
-    if ((code < 32 || code === 127) && !isMarkdownWhitespace(character)) asciiControl = index
-    if (escaped[index] === 0) {
-      if (character === ">") greater = index
-      if (character === "<") less = index
-      if (character === '"') doubleQuote = index
-      if (character === "'") singleQuote = index
-      if (character === ")") closingParenthesis = index
-    }
-    nextNonWhitespace[index] = nonWhitespace
-    nextWhitespace[index] = whitespace
-    nextLineEnding[index] = lineEnding
-    nextGreater[index] = greater
-    nextLess[index] = less
-    nextDoubleQuote[index] = doubleQuote
-    nextSingleQuote[index] = singleQuote
-    nextClosingParenthesis[index] = closingParenthesis
-    nextAsciiControl[index] = asciiControl
-  }
-
-  const depthBefore = new Int32Array(source.length)
-  const boundariesByDepth = new Map<number, number[]>()
-  const openingsByDepth = new Map<number, number[]>()
-  let depth = 0
-  for (let index = 0; index < source.length; index++) {
-    const character = source[index]
-    depthBefore[index] = depth
-    if (isMarkdownWhitespace(character) || (character === ")" && escaped[index] === 0)) {
-      const boundaries = boundariesByDepth.get(depth) ?? []
-      boundaries.push(index)
-      boundariesByDepth.set(depth, boundaries)
-    }
-    if (escaped[index] !== 0) continue
-    if (character === "(") {
-      const openings = openingsByDepth.get(depth) ?? []
-      openings.push(index)
-      openingsByDepth.set(depth, openings)
-      depth++
-    } else if (character === ")") {
-      depth--
-    }
-  }
-
-  return {
-    escaped,
-    nextNonWhitespace,
-    nextWhitespace,
-    nextLineEnding,
-    nextGreater,
-    nextLess,
-    nextDoubleQuote,
-    nextSingleQuote,
-    nextClosingParenthesis,
-    nextAsciiControl,
-    depthBefore,
-    boundariesByDepth,
-    openingsByDepth,
-    boundaryCursors: new Map(),
-    openingCursors: new Map(),
-  }
-}
-
-const nextResourceBoundary = (index: ResourceScanIndex, start: number): number => {
-  const depth = index.depthBefore[start] ?? 0
-  const boundaries = index.boundariesByDepth.get(depth) ?? []
-  let cursor = index.boundaryCursors.get(depth) ?? 0
-  while ((boundaries[cursor] ?? Number.POSITIVE_INFINITY) < start) cursor++
-  index.boundaryCursors.set(depth, cursor)
-  return boundaries[cursor] ?? -1
-}
-
-const nextResourceOpening = (index: ResourceScanIndex, depth: number, start: number): number => {
-  const openings = index.openingsByDepth.get(depth) ?? []
-  let cursor = index.openingCursors.get(depth) ?? 0
-  while ((openings[cursor] ?? Number.POSITIVE_INFINITY) < start) cursor++
-  index.openingCursors.set(depth, cursor)
-  return openings[cursor] ?? -1
-}
-
-const resourceEnd = (source: string, opening: number, scanIndex: ResourceScanIndex): number => {
-  let index = scanIndex.nextNonWhitespace[opening + 1] ?? source.length
-  if (source[index] === ")") return index + 1
-
-  if (source[index] === "<") {
-    const end = scanIndex.nextGreater[index + 1] ?? -1
-    const less = scanIndex.nextLess[index + 1] ?? -1
-    const lineEnding = scanIndex.nextLineEnding[index + 1] ?? -1
-    if (end < 0 || (less >= 0 && less < end) || (lineEnding >= 0 && lineEnding < end)) {
-      return -1
-    }
-    index = end + 1
-  } else {
-    const destinationStart = index
-    const destinationDepth = scanIndex.depthBefore[destinationStart] ?? 0
-    index = nextResourceBoundary(scanIndex, destinationStart)
-    if (index < 0) return -1
-    const whitespace = scanIndex.nextWhitespace[destinationStart] ?? -1
-    const asciiControl = scanIndex.nextAsciiControl[destinationStart] ?? -1
-    const excessiveOpening = nextResourceOpening(scanIndex, destinationDepth + 32, destinationStart)
-    if (
-      (whitespace >= 0 && whitespace < index) ||
-      (asciiControl >= 0 && asciiControl < index) ||
-      (excessiveOpening >= 0 && excessiveOpening < index)
-    ) {
-      return -1
-    }
-  }
-
-  if (!isMarkdownWhitespace(source[index])) return source[index] === ")" ? index + 1 : -1
-
-  index = scanIndex.nextNonWhitespace[index] ?? source.length
-  const delimiter = source[index]
-  if (delimiter === ")") return index + 1
-  const closing =
-    delimiter === '"'
-      ? scanIndex.nextDoubleQuote[index + 1]
-      : delimiter === "'"
-        ? scanIndex.nextSingleQuote[index + 1]
-        : delimiter === "("
-          ? scanIndex.nextClosingParenthesis[index + 1]
-          : -1
-  if (closing === undefined || closing < 0) return -1
-  index = closing + 1
-  if (isMarkdownWhitespace(source[index])) {
-    index = scanIndex.nextNonWhitespace[index] ?? source.length
-  }
-  return source[index] === ")" ? index + 1 : -1
-}
-
-const linearResourceEnd = (source: string, opening: number): number => {
-  let index = opening + 1
-  while (isMarkdownWhitespace(source[index])) index++
-  if (source[index] === ")") return index + 1
-
-  if (source[index] === "<") {
-    index++
-    for (; index < source.length; index++) {
-      if (source[index] === "\\") {
-        index++
-        continue
-      }
-      if (source[index] === ">") {
-        index++
-        break
-      }
-      if (source[index] === "<" || source[index] === "\n" || source[index] === "\r") return -1
-    }
-    if (source[index - 1] !== ">") return -1
-  } else {
-    let depth = 0
-    for (; index < source.length; index++) {
-      const character = source[index]
-      if (character === "\\") {
-        index++
-        continue
-      }
-      if (isMarkdownWhitespace(character)) break
-      const code = source.charCodeAt(index)
-      if (code < 32 || code === 127) return -1
-      if (character === "(") {
-        depth++
-        if (depth > 32) return -1
-      } else if (character === ")") {
-        if (depth === 0) return index + 1
-        depth--
-      }
-    }
-    if (index >= source.length) return -1
-  }
-
-  if (!isMarkdownWhitespace(source[index])) return source[index] === ")" ? index + 1 : -1
-  while (isMarkdownWhitespace(source[index])) index++
-  if (source[index] === ")") return index + 1
-
-  const delimiter = source[index]
-  const closingDelimiter = delimiter === "(" ? ")" : delimiter
-  if (delimiter !== '"' && delimiter !== "'" && delimiter !== "(") return -1
-  index++
-  for (; index < source.length; index++) {
-    if (source[index] === "\\") {
-      index++
-      continue
-    }
-    if (source[index] === closingDelimiter) {
-      index++
-      break
-    }
-  }
-  if (source[index - 1] !== closingDelimiter) return -1
-  while (isMarkdownWhitespace(source[index])) index++
-  return source[index] === ")" ? index + 1 : -1
-}
+// Micromark is exact for resolved references but has quadratic label resolution on adversarial input.
+const MICROMARK_SOURCE_LIMIT = 10_000
+const RAW_HTML_FLOW_START = /^ {0,3}<(?:pre|script|style|textarea)(?:[\t\n\r\f >]|$)/iu
+const RAW_HTML_FLOW_SELF_CLOSING = /^ {0,3}<(?:pre|script|style|textarea)\b[^>]*\/\s*>/iu
 
 const markdownEvents = (source: string) =>
   postprocess(
@@ -652,665 +39,611 @@ const markdownTextEvents = (source: string) =>
       .write(preprocess()(source, "utf8", true)),
   )
 
-const boundCdataMarkers = (source: string): string => {
-  if (!source.includes("<![CDATA[")) return source
-
-  const characters = source.split("")
-  let protectedEnd = -1
-
-  for (let index = 0; index < source.length; index++) {
-    if (!source.startsWith("<![CDATA[", index)) continue
-    if (index <= protectedEnd) {
-      characters[index] = " "
-      continue
-    }
-    const end = source.indexOf("]]>", index + 9)
-    protectedEnd = end < 0 ? source.length : end + 2
-  }
-
-  return characters.join("")
+const markRange = (mask: Uint8Array, start: number, end: number): void => {
+  mask.fill(1, Math.max(0, start), Math.min(mask.length, end))
 }
 
-const opaqueInlineProbe = (source: string): string => {
-  const boundedSource = boundCdataMarkers(source)
-  const characters = boundedSource.split("")
-  const nextGreater = new Int32Array(boundedSource.length + 1).fill(-1)
-  let greater = -1
-  for (let index = boundedSource.length - 1; index >= 0; index--) {
-    if (boundedSource[index] === ">") greater = index
-    nextGreater[index] = greater
-  }
+const normalizedIdentifier = (value: string): string =>
+  value
+    .replace(/[\t\n\r ]+/g, " ")
+    .replace(/^ | $/g, "")
+    .toLowerCase()
+    .toUpperCase()
 
-  let protectedEnd = -1
-  for (let index = 0; index < boundedSource.length; index++) {
-    if (index <= protectedEnd) continue
-    if (boundedSource.startsWith("<![CDATA[", index)) {
-      const end = boundedSource.indexOf("]]>", index + 9)
-      if (end < 0) break
-      protectedEnd = end + 2
-    } else if (boundedSource[index] === "<") {
-      protectedEnd = nextGreater[index + 1] ?? -1
-      let keptOpening = false
-      let keptClosing = false
-      for (let delimiter = index + 1; delimiter < protectedEnd; delimiter++) {
-        if (boundedSource[delimiter] === "[") {
-          if (keptOpening) characters[delimiter] = "^"
-          keptOpening = true
-        } else if (boundedSource[delimiter] === "]") {
-          if (keptClosing) characters[delimiter] = "^"
-          keptClosing = true
-        }
-      }
-    } else if (boundedSource[index] === "[" || boundedSource[index] === "]") {
-      characters[index] = "^"
-    }
-  }
-  return characters.join("")
+interface AnalysisState {
+  readonly source: string
+  readonly parseLines: readonly string[]
+  readonly sourceLineStarts: readonly number[]
+  readonly lineAtOffset: Int32Array
+  readonly proseMask: Uint8Array
+  readonly structuralMask: Uint8Array
+  readonly dictionaryMask: Uint8Array
+  readonly structuralBlanks: boolean[]
 }
 
-const prepareMarkdownSource = (
-  source: string,
-  delimiterSource: string,
-  opaqueInlineRanges: readonly SourceRange[],
-  inlineBlocks: readonly SourceRange[],
-  definedIdentifiers?: ReadonlySet<string>,
-): PreparedMarkdownSource => {
-  const brackets: BracketFrame[] = []
-  const potentialResources: Array<{ opening: number; bracketDepth: number }> = []
-  let opaqueRangeIndex = 0
-  let inlineBlockIndex = 0
-  let activeInlineBlockStart = -1
-  let backslashRun = 0
-  let needsDeepLabelFallback = false
-
-  for (let index = 0; index < source.length; index++) {
-    const character = source[index]
-    while ((inlineBlocks[inlineBlockIndex]?.end ?? source.length + 1) <= index) {
-      inlineBlockIndex++
-    }
-    const inlineBlock = inlineBlocks[inlineBlockIndex]
-    if (inlineBlock === undefined || index < inlineBlock.start) {
-      brackets.length = 0
-      potentialResources.length = 0
-      activeInlineBlockStart = -1
-      continue
-    }
-    if (inlineBlock.start !== activeInlineBlockStart) {
-      brackets.length = 0
-      potentialResources.length = 0
-      activeInlineBlockStart = inlineBlock.start
-    }
-
-    while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
-      opaqueRangeIndex++
-    }
-    const opaqueRange = opaqueInlineRanges[opaqueRangeIndex]
-    if (opaqueRange !== undefined && index >= opaqueRange.start) {
-      index = opaqueRange.end - 1
-      backslashRun = 0
-      continue
-    }
-
-    const escaped = backslashRun % 2 !== 0
-    if (character === "\\") {
-      backslashRun++
-      continue
-    }
-    backslashRun = 0
-
-    if (delimiterSource[index] !== character && "[]()".includes(character ?? "")) continue
-    if (escaped) continue
-
-    if (character === "[") {
-      let precedingBackslashes = 0
-      for (let previous = index - 2; previous >= 0 && source[previous] === "\\"; previous--) {
-        precedingBackslashes++
-      }
-      const image = source[index - 1] === "!" && precedingBackslashes % 2 === 0
-      brackets.push({ opening: index, image, labelDepth: brackets.length + 1, linkEpoch: 0 })
-      if (brackets.length > 32) {
-        const resource = potentialResources.at(-1)
-        if (resource !== undefined) {
-          const end = linearResourceEnd(source, resource.opening)
-          if (end > index && end <= inlineBlock.end) {
-            brackets.length = resource.bracketDepth
-            potentialResources.length = 0
-            index = end - 1
-            continue
-          }
-        }
-        needsDeepLabelFallback = true
-        break
-      }
-    } else if (character === "]") {
-      brackets.pop()
-      if (source[index + 1] === "(") {
-        potentialResources.push({ opening: index + 1, bracketDepth: brackets.length })
-      }
-    }
-  }
-
-  if (!needsDeepLabelFallback) {
-    return {
-      value: boundCdataMarkers(source),
-      resourceCandidates: [],
-      referenceCandidates: [],
-      deepFallback: false,
-    }
-  }
-
-  const characters = boundCdataMarkers(source).split("")
-  const escaped = escapedCharacters(source)
-  let scanIndex: ResourceScanIndex | undefined
-  let linkEpoch = 0
-  const referenceCandidateByOpening = new Map<number, ReferenceCandidate>()
-  const resourceCandidates: ResourceCandidate[] = []
-  const referenceCandidates: ReferenceCandidate[] = []
-  brackets.length = 0
-  opaqueRangeIndex = 0
-  inlineBlockIndex = 0
-  activeInlineBlockStart = -1
-
-  for (let index = 0; index < source.length; index++) {
-    const character = source[index]
-    while ((inlineBlocks[inlineBlockIndex]?.end ?? source.length + 1) <= index) {
-      inlineBlockIndex++
-    }
-    const inlineBlock = inlineBlocks[inlineBlockIndex]
-    if (inlineBlock === undefined || index < inlineBlock.start) {
-      brackets.length = 0
-      activeInlineBlockStart = -1
-      continue
-    }
-    if (inlineBlock.start !== activeInlineBlockStart) {
-      brackets.length = 0
-      activeInlineBlockStart = inlineBlock.start
-    }
-
-    while ((opaqueInlineRanges[opaqueRangeIndex]?.end ?? source.length + 1) <= index) {
-      opaqueRangeIndex++
-    }
-    const opaqueRange = opaqueInlineRanges[opaqueRangeIndex]
-    if (opaqueRange !== undefined && index >= opaqueRange.start) {
-      index = opaqueRange.end - 1
-      continue
-    }
-    if (delimiterSource[index] !== character && "[]()".includes(character ?? "")) continue
-    if (character === "\\" || escaped[index] !== 0) continue
-
-    if (character === "[") {
-      const parentReference = brackets.at(-1)?.referenceCandidate
-      if (parentReference !== undefined) parentReference.valid = false
-      const image = source[index - 1] === "!" && escaped[index - 1] === 0
-      brackets.push({
-        opening: index,
-        image,
-        labelDepth: brackets.length + 1,
-        linkEpoch,
-        referenceCandidate: referenceCandidateByOpening.get(index),
-      })
-    } else if (character === "]") {
-      const frame = brackets.pop()
-      if (frame?.referenceCandidate !== undefined) {
-        const candidate = frame.referenceCandidate
-        candidate.sourceEnd = index + 1
-        if (candidate.valid) {
-          candidate.identifier =
-            frame.opening + 1 === index
-              ? normalizeIdentifierRange(source, candidate.imageLabelStart, candidate.imageLabelEnd)
-              : normalizeIdentifierRange(source, frame.opening + 1, index)
-          if (candidate.identifier !== undefined && definedIdentifiers?.has(candidate.identifier)) {
-            blankTextRange(characters, candidate.sourceStart, candidate.sourceEnd)
-            if (!candidate.image) linkEpoch++
-          }
-        }
-      } else if (frame !== undefined) {
-        const needsFallback = frame.labelDepth > 32
-        if (needsFallback) {
-          characters[frame.opening] = "^"
-          characters[index] = "^"
-          if (source[index + 1] === "[") {
-            const candidate = {
-              image: frame.image,
-              imageLabelStart: frame.opening + 1,
-              imageLabelEnd: index,
-              labelStart: frame.opening,
-              sourceStart: index + 1,
-              valid: true,
-            }
-            referenceCandidateByOpening.set(index + 1, candidate)
-            referenceCandidates.push(candidate)
-          }
-        }
-
-        if (source[index + 1] === "(" && (frame.image || frame.linkEpoch === linkEpoch)) {
-          scanIndex ??= resourceScanIndex(source)
-          const end = resourceEnd(source, index + 1, scanIndex)
-          if (end >= 0) {
-            if (needsFallback) {
-              const candidate = {
-                labelStart: frame.opening,
-                sourceStart: index + 1,
-                sourceEnd: end,
-              }
-              resourceCandidates.push(candidate)
-              blankTextRange(characters, index + 1, end)
-            }
-            if (!frame.image) linkEpoch++
-            index = end - 1
-          } else if (needsFallback) {
-            resourceCandidates.push({ labelStart: frame.opening, sourceStart: index + 1 })
-          }
-        } else if (
-          !frame.image &&
-          frame.linkEpoch === linkEpoch &&
-          source[index + 1] !== "[" &&
-          definedIdentifiers?.has(normalizeIdentifierRange(source, frame.opening + 1, index) ?? "")
-        ) {
-          linkEpoch++
-        }
-      }
-    }
+const createAnalysisState = (source: string, parseLines: readonly string[]): AnalysisState => {
+  const sourceLineStarts: number[] = []
+  const lineAtOffset = new Int32Array(source.length + 1)
+  let offset = 0
+  for (let lineIndex = 0; lineIndex < parseLines.length; lineIndex++) {
+    sourceLineStarts.push(offset)
+    const end = offset + (parseLines[lineIndex]?.length ?? 0)
+    lineAtOffset.fill(lineIndex, offset, Math.min(end + 1, lineAtOffset.length))
+    offset = end + 1
   }
 
   return {
-    value: characters.join(""),
-    resourceCandidates,
-    referenceCandidates,
-    deepFallback: true,
+    source,
+    parseLines,
+    sourceLineStarts,
+    lineAtOffset,
+    proseMask: new Uint8Array(source.length),
+    structuralMask: new Uint8Array(source.length),
+    dictionaryMask: new Uint8Array(source.length),
+    structuralBlanks: parseLines.map((line) => line.trim() === ""),
   }
 }
 
-const INLINE_BLOCK_TOKENS = new Set(["paragraph", "atxHeadingText", "setextHeadingText"])
-const OPAQUE_INLINE_TOKENS = new Set(["autolink", "codeText", "htmlText"])
-const HTML_FLOW_SYNTAX_TOKENS = new Set(["characterReference", "htmlText"])
-const RAW_HTML_FLOW_START = /^ {0,3}<(?:pre|script|style|textarea)(?:[\t\n\r\f >]|$)/iu
+const markCode = (state: AnalysisState, start: number, end: number, block: boolean): void => {
+  markRange(state.proseMask, start, end)
+  markRange(state.structuralMask, start, end)
+  markRange(state.dictionaryMask, start, end)
+  if (!block || end <= start) return
 
-const tokenRanges = (
-  events: ReturnType<typeof markdownEvents>,
-  tokenTypes: ReadonlySet<string>,
-): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
+  const firstLine = state.lineAtOffset[Math.min(start, state.source.length)] ?? 0
+  const lastOffset = Math.max(start, end - 1)
+  const lastLine = state.lineAtOffset[Math.min(lastOffset, state.source.length)] ?? firstLine
+  for (let line = firstLine; line <= lastLine; line++) state.structuralBlanks[line] = true
+}
+
+const MICROMARK_DICTIONARY_TOKENS = new Set([
+  "atxHeadingSequence",
+  "autolink",
+  "blockQuotePrefix",
+  "characterReference",
+  "definition",
+  "emphasisSequence",
+  "escapeMarker",
+  "hardBreakEscape",
+  "hardBreakTrailing",
+  "htmlText",
+  "labelImageMarker",
+  "labelMarker",
+  "listItemIndent",
+  "listItemPrefix",
+  "reference",
+  "resource",
+  "setextHeadingLine",
+  "strongSequence",
+  "thematicBreak",
+])
+
+const MICROMARK_CODE_TOKENS = new Set(["codeFenced", "codeIndented", "codeText"])
+const MICROMARK_BLOCK_CODE_TOKENS = new Set(["codeFenced", "codeIndented"])
+const MICROMARK_CONTAINER_TOKENS = new Set(["blockQuotePrefix", "listItemIndent", "listItemPrefix"])
+
+const markOrdinaryHtml = (state: AnalysisState, start: number, end: number): void => {
+  const flowSource = state.source.slice(start, end)
+  for (const [phase, token] of markdownTextEvents(flowSource)) {
+    if (phase === "enter" && (token.type === "htmlText" || token.type === "characterReference")) {
+      markRange(state.dictionaryMask, start + token.start.offset, start + token.end.offset)
+    }
+  }
+}
+
+const analyzeWithMicromark = (state: AnalysisState): void => {
+  const events = markdownEvents(state.source)
+  const contentColumns = new Int32Array(state.parseLines.length).fill(1)
+
   for (const [phase, token] of events) {
-    if (phase === "enter" && tokenTypes.has(token.type)) {
-      ranges.push({ start: token.start.offset, end: token.end.offset })
+    if (phase !== "enter") continue
+    if (MICROMARK_CONTAINER_TOKENS.has(token.type)) {
+      const lineIndex = token.start.line - 1
+      contentColumns[lineIndex] = Math.max(contentColumns[lineIndex] ?? 1, token.end.column)
+      markRange(state.proseMask, token.start.offset, token.end.offset)
     }
   }
-  return ranges
-}
 
-const htmlFlowSyntaxRanges = (
-  source: string,
-  events: ReturnType<typeof markdownEvents>,
-): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
+  const shortenedDefinitions = new Map<number, number>()
+  let definitionStart: number | undefined
+  let definitionLine = 0
+  let definitionContentColumn = 1
   for (const [phase, token] of events) {
-    if (phase !== "enter" || token.type !== "htmlFlow") continue
-    const start = token.start.offset
-    const end = token.end.offset
-    const flowSource = source.slice(start, end)
-    if (RAW_HTML_FLOW_START.test(flowSource)) {
-      ranges.push({ start, end })
-      continue
-    }
-    for (const range of tokenRanges(
-      markdownTextEvents(opaqueInlineProbe(flowSource)),
-      HTML_FLOW_SYNTAX_TOKENS,
-    )) {
-      ranges.push({ start: start + range.start, end: start + range.end })
+    if (phase === "enter" && token.type === "definition") {
+      definitionStart = token.start.offset
+      definitionLine = token.start.line
+      definitionContentColumn = contentColumns[token.start.line - 1] ?? 1
+    } else if (
+      phase === "enter" &&
+      token.type === "definitionTitle" &&
+      definitionStart !== undefined &&
+      token.start.line > definitionLine &&
+      token.start.column <=
+        Math.max(definitionContentColumn, contentColumns[token.start.line - 1] ?? 1)
+    ) {
+      shortenedDefinitions.set(definitionStart, token.start.offset)
+    } else if (phase === "exit" && token.type === "definition") {
+      definitionStart = undefined
     }
   }
-  return ranges
-}
 
-const rangeContaining = (
-  ranges: readonly SourceRange[],
-  offset: number,
-): SourceRange | undefined => {
-  let low = 0
-  let high = ranges.length
-  while (low < high) {
-    const middle = Math.floor((low + high) / 2)
-    if ((ranges[middle]?.start ?? Number.POSITIVE_INFINITY) <= offset) low = middle + 1
-    else high = middle
-  }
-  const range = ranges[low - 1]
-  return range !== undefined && offset < range.end ? range : undefined
-}
-
-const definitionIdentifiers = (
-  source: string,
-  events: ReturnType<typeof markdownEvents>,
-): ReadonlySet<string> => {
-  const identifiers = new Set<string>()
   for (const [phase, token] of events) {
-    if (phase === "enter" && token.type === "definitionLabelString") {
-      identifiers.add(normalizeIdentifier(source.slice(token.start.offset, token.end.offset)))
+    if (phase !== "enter") continue
+    const { start, end } = token
+    if (MICROMARK_CODE_TOKENS.has(token.type)) {
+      markCode(state, start.offset, end.offset, MICROMARK_BLOCK_CODE_TOKENS.has(token.type))
+    } else if (token.type === "definition") {
+      markRange(
+        state.dictionaryMask,
+        start.offset,
+        shortenedDefinitions.get(start.offset) ?? end.offset,
+      )
+    } else if (MICROMARK_DICTIONARY_TOKENS.has(token.type)) {
+      markRange(state.dictionaryMask, start.offset, end.offset)
+    } else if (token.type === "htmlFlow") {
+      const flowSource = state.source.slice(start.offset, end.offset)
+      if (RAW_HTML_FLOW_START.test(flowSource) && !RAW_HTML_FLOW_SELF_CLOSING.test(flowSource)) {
+        markRange(state.dictionaryMask, start.offset, end.offset)
+      } else {
+        markOrdinaryHtml(state, start.offset, end.offset)
+      }
     }
   }
-  return identifiers
 }
 
-const referenceIdentifier = (
-  source: string,
-  candidate: ReferenceCandidate,
-): { identifier: string; end: number } | undefined => {
-  let backslashRun = 0
-  const contentStart = candidate.sourceStart + 1
-  const scanEnd = Math.min(source.length, contentStart + MAX_MARKDOWN_LABEL_SOURCE_SIZE + 1)
+const blockParser = new Parser()
+blockParser.setLanguage(Markdown)
+const inlineParser = new Parser()
+inlineParser.setLanguage(Markdown.inline)
 
-  for (let index = contentStart; index < scanEnd; index++) {
-    const character = source[index]
-    if (character === "\\") {
-      backslashRun++
-      continue
+const walk = (
+  root: Parser.SyntaxNode,
+  visit: (node: Parser.SyntaxNode) => boolean | undefined,
+): void => {
+  const pending = [root]
+  while (pending.length > 0) {
+    const node = pending.pop()
+    if (node === undefined || visit(node) === false) continue
+    const children = node.children
+    for (let index = children.length - 1; index >= 0; index--) {
+      const child = children[index]
+      if (child !== undefined) pending.push(child)
     }
-    const escaped = backslashRun % 2 !== 0
-    backslashRun = 0
-    if (escaped) continue
-    if (character === "[") return undefined
-    if (character !== "]") continue
-
-    const identifier =
-      index === contentStart
-        ? normalizeIdentifierRange(source, candidate.imageLabelStart, candidate.imageLabelEnd)
-        : normalizeIdentifierRange(source, contentStart, index)
-    return identifier === undefined ? undefined : { identifier, end: index + 1 }
   }
-  return undefined
 }
 
-const resolvedReferenceSyntaxRanges = (
+const TREE_CONTAINER_TOKENS = new Set([
+  "block_quote_marker",
+  "list_marker_dot",
+  "list_marker_minus",
+  "list_marker_parenthesis",
+  "list_marker_plus",
+  "list_marker_star",
+])
+const TREE_CODE_TOKENS = new Set(["fenced_code_block", "indented_code_block"])
+const TREE_REFERENCE_TOKENS = new Set([
+  "collapsed_reference_link",
+  "full_reference_link",
+  "shortcut_link",
+])
+const TREE_AUTOLINK_TOKENS = new Set(["email_autolink", "uri_autolink"])
+const TREE_ENTITY_TOKENS = new Set(["entity_reference", "numeric_character_reference"])
+const TREE_MARKER_TOKENS = new Set(["emphasis_delimiter", "hard_line_break"])
+const TREE_LINK_MARKERS = new Set(["!", "[", "]", "(", ")"])
+
+const contentOfLabel = (source: string, node: Parser.SyntaxNode): string => {
+  const value = source.slice(node.startIndex, node.endIndex)
+  return value.startsWith("[") && value.endsWith("]") ? value.slice(1, -1) : value
+}
+
+const visibleReferenceLabel = (source: string, node: Parser.SyntaxNode): string => {
+  const explicit = node.children.find((child) => child.type === "link_label")
+  if (explicit !== undefined && explicit.endIndex - explicit.startIndex > 2) {
+    return contentOfLabel(source, explicit)
+  }
+  const visible = node.children.find(
+    (child) => child.type === "link_text" || child.type === "image_description",
+  )
+  return visible === undefined ? "" : source.slice(visible.startIndex, visible.endIndex)
+}
+
+const markTreeLink = (
+  state: AnalysisState,
   source: string,
-  candidates: readonly ReferenceCandidate[],
-  inlineBlocks: readonly SourceRange[],
+  node: Parser.SyntaxNode,
+  base: number,
   definedIdentifiers: ReadonlySet<string>,
-): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
-  for (const candidate of candidates) {
-    const reference = referenceIdentifier(source, candidate)
-    if (reference === undefined || !definedIdentifiers.has(reference.identifier)) continue
-    const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
+): void => {
+  const reference = TREE_REFERENCE_TOKENS.has(node.type) || node.type === "image"
+  const hasResource = node.children.some(
+    (child) => child.type === "link_destination" || child.type === "link_title",
+  )
+  const hasReferenceLabel = node.children.some((child) => child.type === "link_label")
+  const resolved =
+    hasResource ||
+    ((reference || hasReferenceLabel) &&
+      definedIdentifiers.has(normalizedIdentifier(visibleReferenceLabel(source, node))))
+
+  if (!resolved) return
+
+  for (const child of node.children) {
+    const start = base + child.startIndex
+    const end = base + child.endIndex
     if (
-      inlineBlock !== undefined &&
-      candidate.sourceStart >= inlineBlock.start &&
-      reference.end <= inlineBlock.end
+      child.type === "link_destination" ||
+      child.type === "link_title" ||
+      child.type === "link_label"
     ) {
-      ranges.push({ start: candidate.sourceStart, end: reference.end })
+      markRange(state.dictionaryMask, start, end)
+    } else if (TREE_LINK_MARKERS.has(child.type)) {
+      markRange(state.dictionaryMask, start, end)
     }
   }
-  return ranges
 }
 
-const blankRanges = (source: string, ranges: readonly SourceRange[]): string => {
-  const characters = source.split("")
-  for (const range of ranges) blankTextRange(characters, range.start, range.end)
-  return characters.join("")
-}
-
-const fallbackReferenceRanges = (
-  candidates: readonly ReferenceCandidate[],
-  inlineBlocks: readonly SourceRange[],
-  opaqueInlineRanges: readonly SourceRange[],
-  definedIdentifiers: ReadonlySet<string>,
-): readonly SourceRange[] => {
-  const ranges: SourceRange[] = []
-  for (const candidate of candidates) {
-    if (
-      candidate.sourceEnd === undefined ||
-      candidate.identifier === undefined ||
-      !definedIdentifiers.has(candidate.identifier)
-    ) {
-      continue
-    }
-    const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
-    if (
-      inlineBlock === undefined ||
-      candidate.sourceStart < inlineBlock.start ||
-      candidate.sourceEnd > inlineBlock.end ||
-      rangeContaining(opaqueInlineRanges, candidate.labelStart) !== undefined
-    ) {
-      continue
-    }
-    ranges.push({ start: candidate.sourceStart, end: candidate.sourceEnd })
+const maxNestedImages = (root: Parser.SyntaxNode): number => {
+  const pending = [{ node: root, depth: 0 }]
+  let maximum = 0
+  while (pending.length > 0) {
+    const current = pending.pop()
+    if (current === undefined) continue
+    const depth = current.depth + (current.node.type === "image" ? 1 : 0)
+    maximum = Math.max(maximum, depth)
+    for (const child of current.node.children) pending.push({ node: child, depth })
   }
-  return ranges
+  return maximum
 }
 
-const fallbackResourceRanges = (
+// Tree-sitter bounds image nesting, so micromark validates omitted suffixes in affected ranges.
+const markRecoveredResources = (
+  state: AnalysisState,
   source: string,
-  candidates: readonly ResourceCandidate[],
-  inlineBlocks: readonly SourceRange[],
-  opaqueInlineRanges: readonly SourceRange[],
-): readonly SourceRange[] => {
+  base: number,
+  shortcutStarts: ReadonlyMap<number, number>,
+  nestedImages: number,
+): void => {
   const chunks: string[] = []
-  const segments = new Map<number, { sourceStart: number; syntheticEnd: number }>()
+  const sourceStarts = new Map<number, { labelStart?: number; resourceStart: number }>()
+  const candidates = [...source.matchAll(/\]\((?:[^()\\\n]|\\.)*\)/g)]
   let syntheticOffset = 0
-  let acceptedEnd = -1
-
   for (const candidate of candidates) {
-    if (candidate.sourceEnd === undefined || candidate.sourceStart < acceptedEnd) continue
-    const inlineBlock = rangeContaining(inlineBlocks, candidate.labelStart)
-    if (
-      inlineBlock === undefined ||
-      candidate.sourceStart < inlineBlock.start ||
-      candidate.sourceEnd > inlineBlock.end ||
-      rangeContaining(opaqueInlineRanges, candidate.labelStart) !== undefined
-    ) {
+    if (candidate.index === undefined) continue
+    const resourceStart = candidate.index + 1
+    const shortcutStart = shortcutStarts.get(resourceStart)
+    if (shortcutStart === undefined && (nestedImages <= 1 || candidates.length < 2)) {
       continue
     }
-    acceptedEnd = candidate.sourceEnd
-    const resource = source.slice(candidate.sourceStart, candidate.sourceEnd)
-    const syntheticStart = syntheticOffset + 3
+    const resource = candidate[0].slice(1)
+    sourceStarts.set(syntheticOffset + 3, {
+      labelStart: shortcutStart === undefined ? undefined : base + shortcutStart,
+      resourceStart: base + resourceStart,
+    })
     chunks.push(`[x]${resource}\n\n`)
     syntheticOffset += resource.length + 5
-    segments.set(syntheticStart, {
-      sourceStart: candidate.sourceStart,
-      syntheticEnd: syntheticStart + resource.length,
-    })
   }
+  if (chunks.length === 0) return
 
-  if (chunks.length === 0) return []
-  const ranges: Array<{ start: number; end: number }> = []
   for (const [phase, token] of markdownEvents(chunks.join(""))) {
     if (phase !== "enter" || token.type !== "resource") continue
-    const segment = segments.get(token.start.offset)
-    if (segment === undefined || token.end.offset > segment.syntheticEnd) continue
-    ranges.push({
-      start: segment.sourceStart,
-      end: segment.sourceStart + token.end.offset - token.start.offset,
+    const recovered = sourceStarts.get(token.start.offset)
+    if (recovered !== undefined) {
+      markRange(
+        state.dictionaryMask,
+        recovered.resourceStart,
+        recovered.resourceStart + token.end.offset - token.start.offset,
+      )
+      if (recovered.labelStart !== undefined) {
+        markRange(state.dictionaryMask, recovered.labelStart, recovered.labelStart + 1)
+        markRange(state.dictionaryMask, recovered.resourceStart - 1, recovered.resourceStart)
+      }
+    }
+  }
+}
+
+// Micromark fills the HTML constructs that Tree-sitter deliberately leaves as plain text.
+const markRecoveredHtml = (state: AnalysisState, source: string, base: number): void => {
+  const chunks: string[] = []
+  const sourceRanges = new Map<number, SourceRange>()
+  let syntheticOffset = 0
+  for (const candidate of source.matchAll(/<[^>\n]*>/g)) {
+    if (candidate.index === undefined) continue
+    sourceRanges.set(syntheticOffset, {
+      start: base + candidate.index,
+      end: base + candidate.index + candidate[0].length,
+    })
+    chunks.push(`${candidate[0]}\n\n`)
+    syntheticOffset += candidate[0].length + 2
+  }
+  if (chunks.length === 0) return
+
+  for (const [phase, token] of markdownTextEvents(chunks.join(""))) {
+    if (phase !== "enter" || token.type !== "htmlText") continue
+    const sourceRange = sourceRanges.get(token.start.offset)
+    if (
+      sourceRange !== undefined &&
+      token.end.offset - token.start.offset === sourceRange.end - sourceRange.start
+    ) {
+      markRange(state.dictionaryMask, sourceRange.start, sourceRange.end)
+    }
+  }
+}
+
+const markInlineTree = (
+  state: AnalysisState,
+  source: string,
+  base: number,
+  definedIdentifiers: ReadonlySet<string>,
+): void => {
+  const tree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
+  const shortcutStarts = new Map<number, number>()
+  walk(tree.rootNode, (node) => {
+    const start = base + node.startIndex
+    const end = base + node.endIndex
+    if (node.type === "shortcut_link") shortcutStarts.set(node.endIndex, node.startIndex)
+    if (node.type === "code_span") {
+      markCode(state, start, end, false)
+      return false
+    }
+    if (
+      node.type === "inline_link" ||
+      node.type === "image" ||
+      TREE_REFERENCE_TOKENS.has(node.type)
+    ) {
+      markTreeLink(state, source, node, base, definedIdentifiers)
+    }
+    if (
+      TREE_AUTOLINK_TOKENS.has(node.type) ||
+      TREE_ENTITY_TOKENS.has(node.type) ||
+      node.type === "html_tag" ||
+      node.type === "link_destination" ||
+      node.type === "link_title"
+    ) {
+      markRange(state.dictionaryMask, start, end)
+      return false
+    }
+    if (TREE_MARKER_TOKENS.has(node.type)) {
+      markRange(state.dictionaryMask, start, end)
+    } else if (node.type === "backslash_escape") {
+      markRange(state.dictionaryMask, start, Math.min(start + 1, end))
+    }
+  })
+  markRecoveredResources(state, source, base, shortcutStarts, maxNestedImages(tree.rootNode))
+  markRecoveredHtml(state, source, base)
+}
+
+const markHtmlTree = (state: AnalysisState, source: string, base: number): void => {
+  const tree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
+  walk(tree.rootNode, (node) => {
+    if (node.type === "html_tag" || TREE_ENTITY_TOKENS.has(node.type)) {
+      markRange(state.dictionaryMask, base + node.startIndex, base + node.endIndex)
+      return false
+    }
+  })
+  markRecoveredHtml(state, source, base)
+}
+
+const analyzeCodeWithTreeSitter = (state: AnalysisState): void => {
+  const tree = blockParser.parse(state.source, undefined, {
+    bufferSize: state.source.length + 1,
+  })
+  const inlineRanges: SourceRange[] = []
+
+  walk(tree.rootNode, (node) => {
+    if (TREE_CODE_TOKENS.has(node.type)) {
+      markCode(state, node.startIndex, node.endIndex, true)
+      return false
+    }
+    if (TREE_CONTAINER_TOKENS.has(node.type)) {
+      markRange(state.proseMask, node.startIndex, node.endIndex)
+    } else if (node.type === "inline") {
+      inlineRanges.push({ start: node.startIndex, end: node.endIndex })
+      return false
+    }
+  })
+
+  for (const range of inlineRanges) {
+    const source = state.source.slice(range.start, range.end)
+    if (!source.includes("`")) continue
+    const inlineTree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
+    walk(inlineTree.rootNode, (node) => {
+      if (node.type === "code_span") {
+        markCode(state, range.start + node.startIndex, range.start + node.endIndex, false)
+        return false
+      }
     })
   }
-  return ranges
+}
+
+const virtualColumn = (line: string, sourceColumn: number): number => {
+  let column = 0
+  for (let index = 0; index < sourceColumn; index++) {
+    column = line[index] === "\t" ? column + 4 - (column % 4) : column + 1
+  }
+  return column
+}
+
+const analyzeWithTreeSitter = (state: AnalysisState): void => {
+  // Disable Tree-sitter's task-marker ambiguity without changing any source offsets.
+  const blockSource = state.source.replace(/^([ \t]{0,3})\[x\](?=:)/gimu, "$1[a]")
+  const tree = blockParser.parse(blockSource, undefined, {
+    bufferSize: blockSource.length + 1,
+  })
+  const definitions = new Set<string>()
+  const inlineRanges: SourceRange[] = []
+  const ordinaryHtmlRanges: SourceRange[] = []
+  const contentColumns = new Int32Array(state.parseLines.length)
+
+  walk(tree.rootNode, (node) => {
+    if (TREE_CODE_TOKENS.has(node.type)) {
+      markCode(state, node.startIndex, node.endIndex, true)
+      return false
+    }
+    if (TREE_CONTAINER_TOKENS.has(node.type)) {
+      const line = node.endPosition.row
+      const column = virtualColumn(state.parseLines[line] ?? "", node.endPosition.column)
+      contentColumns[line] = Math.max(contentColumns[line] ?? 0, column)
+      markRange(state.proseMask, node.startIndex, node.endIndex)
+      markRange(state.dictionaryMask, node.startIndex, node.endIndex)
+    } else if (node.type === "link_reference_definition") {
+      const label = node.children.find((child) => child.type === "link_label")
+      if (label !== undefined) {
+        definitions.add(normalizedIdentifier(contentOfLabel(state.source, label)))
+      }
+      const title = node.children.find((child) => child.type === "link_title")
+      const maskEnd =
+        title !== undefined &&
+        title.startPosition.row > node.startPosition.row &&
+        virtualColumn(
+          state.parseLines[title.startPosition.row] ?? "",
+          title.startPosition.column,
+        ) <=
+          Math.max(
+            contentColumns[node.startPosition.row] ?? 0,
+            contentColumns[title.startPosition.row] ?? 0,
+          )
+          ? title.startIndex
+          : node.endIndex
+      markRange(state.dictionaryMask, node.startIndex, maskEnd)
+      return false
+    } else if (node.type === "inline") {
+      inlineRanges.push({ start: node.startIndex, end: node.endIndex })
+      return false
+    } else if (node.type === "html_block") {
+      const html = state.source.slice(node.startIndex, node.endIndex)
+      if (RAW_HTML_FLOW_START.test(html) && !RAW_HTML_FLOW_SELF_CLOSING.test(html)) {
+        markRange(state.dictionaryMask, node.startIndex, node.endIndex)
+      } else {
+        ordinaryHtmlRanges.push({ start: node.startIndex, end: node.endIndex })
+      }
+      return false
+    } else if (node.type === "thematic_break" || /^atx_h[1-6]_marker$/.test(node.type)) {
+      markRange(state.dictionaryMask, node.startIndex, node.endIndex)
+    }
+  })
+
+  for (const range of inlineRanges) {
+    markInlineTree(state, state.source.slice(range.start, range.end), range.start, definitions)
+  }
+  for (const range of ordinaryHtmlRanges) {
+    markHtmlTree(state, state.source.slice(range.start, range.end), range.start)
+  }
+}
+
+const applyMask = (
+  lines: readonly string[],
+  contentStarts: readonly number[],
+  parseLines: readonly string[],
+  sourceLineStarts: readonly number[],
+  mask: Uint8Array,
+): string[] =>
+  lines.map((line, lineIndex) => {
+    const characters = line.split("")
+    const contentStart = Math.min(Math.max(contentStarts[lineIndex] ?? 0, 0), line.length)
+    const sourceStart = sourceLineStarts[lineIndex] ?? 0
+    const parseLine = parseLines[lineIndex] ?? ""
+    for (let column = 0; column < parseLine.length; column++) {
+      if (mask[sourceStart + column] !== 0) characters[contentStart + column] = " "
+    }
+    return characters.join("")
+  })
+
+const analyzeMarkdown = (
+  lines: readonly string[],
+  contentStarts: readonly number[] = lines.map(() => 0),
+  includeDictionary = true,
+): MarkdownAnalysis => {
+  if (lines.length === 0) {
+    return { lines: [], structuralLines: [], dictionaryLines: [], structuralBlanks: [] }
+  }
+
+  const starts = lines.map((line, index) =>
+    Math.min(Math.max(contentStarts[index] ?? 0, 0), line.length),
+  )
+  const parseLines = lines.map((line, index) => line.slice(starts[index]))
+  const source = parseLines.join("\n")
+  const state = createAnalysisState(source, parseLines)
+
+  if (source.length <= MICROMARK_SOURCE_LIMIT) analyzeWithMicromark(state)
+  else if (includeDictionary) analyzeWithTreeSitter(state)
+  else analyzeCodeWithTreeSitter(state)
+
+  const analysis = {
+    lines: applyMask(lines, starts, parseLines, state.sourceLineStarts, state.proseMask),
+    structuralLines: applyMask(
+      lines,
+      starts,
+      parseLines,
+      state.sourceLineStarts,
+      state.structuralMask,
+    ),
+    dictionaryLines: applyMask(
+      lines,
+      starts,
+      parseLines,
+      state.sourceLineStarts,
+      state.dictionaryMask,
+    ),
+    structuralBlanks: state.structuralBlanks,
+  }
+  return analysis
+}
+
+export function blankMarkdownForLint(
+  inputLines: readonly string[],
+  contentStarts: readonly number[],
+  includeDictionary: boolean,
+): MarkdownAnalysis {
+  return analyzeMarkdown(inputLines, contentStarts, includeDictionary)
+}
+
+export function blankMarkdownCodeWithStructure(
+  inputLines: readonly string[],
+  contentStarts: readonly number[] = inputLines.map(() => 0),
+): MarkdownCodeResult {
+  const analysis = analyzeMarkdown(inputLines, contentStarts, false)
+  return {
+    lines: analysis.lines,
+    structuralLines: analysis.structuralLines,
+    structuralBlanks: analysis.structuralBlanks,
+  }
+}
+
+export function blankMarkdownCode(
+  inputLines: readonly string[],
+  contentStarts: readonly number[] = inputLines.map(() => 0),
+): string[] {
+  return analyzeMarkdown(inputLines, contentStarts, false).lines
+}
+
+export function maskMarkdownCode(text: string): string {
+  return blankMarkdownCode(text.split("\n")).join("\n")
 }
 
 export function blankMarkdownDestinations(
   lines: readonly string[],
   contentStarts: readonly number[] = lines.map(() => 0),
 ): string[] {
-  if (lines.length === 0) return []
-
-  const parseLines = lines.map((line, index) =>
-    line.slice(Math.min(contentStarts[index] ?? 0, line.length)),
-  )
-  const source = parseLines.join("\n")
-  const sourceLineStarts = lineStartOffsets(parseLines)
-  const outputLineStarts = lineStartOffsets(lines)
-  const blanked = lines.join("\n").split("")
-  const outputOffset = (sourceOffset: number): number => {
-    const lineIndex = lineIndexAtOffset(sourceLineStarts, sourceOffset)
-    const line = lines[lineIndex] ?? ""
-    const contentStart = Math.min(contentStarts[lineIndex] ?? 0, line.length)
-    return (
-      (outputLineStarts[lineIndex] ?? 0) +
-      contentStart +
-      sourceOffset -
-      (sourceLineStarts[lineIndex] ?? 0)
-    )
-  }
-  const blankSourceRange = (start: number, end: number): void => {
-    blankTextRange(blanked, outputOffset(start), outputOffset(end))
-  }
-
-  const syntaxRangesFor = (
-    probe: string,
-  ): { opaqueInlineRanges: readonly SourceRange[]; inlineBlocks: readonly SourceRange[] } => {
-    const probeEvents = markdownEvents(opaqueInlineProbe(probe))
-    return {
-      opaqueInlineRanges: tokenRanges(probeEvents, OPAQUE_INLINE_TOKENS),
-      inlineBlocks: tokenRanges(probeEvents, INLINE_BLOCK_TOKENS),
-    }
-  }
-  const delimiterSourceFor = (ranges: readonly SourceRange[]): string => blankRanges(source, ranges)
-
-  let syntaxRanges = syntaxRangesFor(source)
-  let opaqueInlineRanges = syntaxRanges.opaqueInlineRanges
-  let preparedSource = prepareMarkdownSource(
-    source,
-    delimiterSourceFor(opaqueInlineRanges),
-    opaqueInlineRanges,
-    syntaxRanges.inlineBlocks,
-  )
-  let events = markdownEvents(preparedSource.value)
-  let definedIdentifiers = definitionIdentifiers(source, events)
-  const resolvedReferenceRanges = resolvedReferenceSyntaxRanges(
-    source,
-    preparedSource.referenceCandidates,
-    tokenRanges(events, INLINE_BLOCK_TOKENS),
-    definedIdentifiers,
-  )
-  if (
-    resolvedReferenceRanges.length > 0 ||
-    (preparedSource.deepFallback && definedIdentifiers.size > 0)
-  ) {
-    syntaxRanges = syntaxRangesFor(blankRanges(source, resolvedReferenceRanges))
-    opaqueInlineRanges = syntaxRanges.opaqueInlineRanges
-    preparedSource = prepareMarkdownSource(
-      source,
-      delimiterSourceFor(opaqueInlineRanges),
-      opaqueInlineRanges,
-      syntaxRanges.inlineBlocks,
-      definedIdentifiers,
-    )
-    events = markdownEvents(preparedSource.value)
-    definedIdentifiers = definitionIdentifiers(source, events)
-  }
-
-  const contentColumns = new Int32Array(parseLines.length).fill(1)
-  for (const [phase, token] of events) {
-    if (
-      phase === "enter" &&
-      (token.type === "blockQuotePrefix" ||
-        token.type === "listItemPrefix" ||
-        token.type === "listItemIndent")
-    ) {
-      const lineIndex = token.start.line - 1
-      contentColumns[lineIndex] = Math.max(contentColumns[lineIndex] ?? 1, token.end.column)
-    }
-  }
-
-  const definitionMaskEnds = new Map<number, number>()
-  let activeDefinitionStart: number | undefined
-  let activeDefinitionLine = 0
-  let activeDefinitionContentColumn = 1
-  for (const [phase, token] of events) {
-    if (phase === "enter" && token.type === "definition") {
-      activeDefinitionStart = token.start.offset
-      activeDefinitionLine = token.start.line
-      activeDefinitionContentColumn = contentColumns[token.start.line - 1] ?? 1
-    } else if (
-      phase === "enter" &&
-      token.type === "definitionTitle" &&
-      activeDefinitionStart !== undefined &&
-      token.start.line > activeDefinitionLine &&
-      token.start.column <=
-        Math.max(activeDefinitionContentColumn, contentColumns[token.start.line - 1] ?? 1)
-    ) {
-      definitionMaskEnds.set(activeDefinitionStart, token.start.offset)
-    } else if (phase === "exit" && token.type === "definition") {
-      activeDefinitionStart = undefined
-    }
-  }
-
-  for (const [phase, token] of events) {
-    if (phase !== "enter") continue
-    if (token.type === "definition") {
-      blankSourceRange(
-        token.start.offset,
-        definitionMaskEnds.get(token.start.offset) ?? token.end.offset,
-      )
-    } else if (MASKED_MARKDOWN_TOKENS.has(token.type)) {
-      blankSourceRange(token.start.offset, token.end.offset)
-    }
-  }
-
-  for (const range of htmlFlowSyntaxRanges(source, events)) {
-    blankSourceRange(range.start, range.end)
-  }
-
-  const inlineBlocks = tokenRanges(events, INLINE_BLOCK_TOKENS)
-
-  for (const range of fallbackReferenceRanges(
-    preparedSource.referenceCandidates,
-    inlineBlocks,
-    opaqueInlineRanges,
-    definedIdentifiers,
-  )) {
-    blankSourceRange(range.start, range.end)
-  }
-
-  for (const range of fallbackResourceRanges(
-    source,
-    preparedSource.resourceCandidates,
-    inlineBlocks,
-    opaqueInlineRanges,
-  )) {
-    blankSourceRange(range.start, range.end)
-  }
-
-  return blanked.join("").split("\n")
-}
-
-interface InlineBacktickRun {
-  readonly start: number
-  readonly length: number
-}
-
-function blankInlineCodeLine(line: string): string {
-  const runs: InlineBacktickRun[] = []
-  for (let index = 0; index < line.length; index += 1) {
-    if (line[index] !== "`") continue
-    const start = index
-    while (line[index + 1] === "`") index += 1
-    runs.push({ start, length: index - start + 1 })
-  }
-
-  const nextMatchingRun = new Int32Array(runs.length).fill(-1)
-  const latestRunByLength = new Map<number, number>()
-  for (let index = runs.length - 1; index >= 0; index -= 1) {
-    const run = runs[index]
-    if (!run) continue
-    nextMatchingRun[index] = latestRunByLength.get(run.length) ?? -1
-    latestRunByLength.set(run.length, index)
-  }
-
-  const masked = line.split("")
-  for (let index = 0; index < runs.length; index += 1) {
-    const closingIndex = nextMatchingRun[index] ?? -1
-    if (closingIndex < 0) continue
-    const opening = runs[index]
-    const closing = runs[closingIndex]
-    if (!opening || !closing) continue
-
-    masked.fill(" ", opening.start, closing.start + closing.length)
-    index = closingIndex
-  }
-
-  return masked.join("")
+  return analyzeMarkdown(lines, contentStarts).dictionaryLines
 }
 
 export function blankInlineCode(lines: readonly string[]): string[] {
-  return lines.map(blankInlineCodeLine)
+  const source = lines.join("\n")
+  const mask = new Uint8Array(source.length)
+  for (const [phase, token] of markdownTextEvents(source)) {
+    if (phase === "enter" && token.type === "codeText") {
+      markRange(mask, token.start.offset, token.end.offset)
+    }
+  }
+
+  let offset = 0
+  return lines.map((line) => {
+    const characters = line.split("")
+    for (let index = 0; index < line.length; index++) {
+      if (mask[offset + index] !== 0) characters[index] = " "
+    }
+    offset += line.length + 1
+    return characters.join("")
+  })
 }
 
 export function proseVisibility(text: string): Uint8Array {
@@ -1321,9 +654,7 @@ export function proseVisibility(text: string): Uint8Array {
 
   for (let index = 0; index < sourceLines.length; index++) {
     const line = sourceLines[index] ?? ""
-    if (line === proseLines[index]) {
-      visibility.fill(1, offset, offset + line.length)
-    }
+    if (line === proseLines[index]) visibility.fill(1, offset, offset + line.length)
     offset += line.length
     if (offset < text.length) {
       visibility[offset] = 1

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,4 +1,6 @@
+import { parser as lezerMarkdownParser } from "@lezer/markdown"
 import Markdown from "@tree-sitter-grammars/tree-sitter-markdown"
+import { Parser as CommonmarkParser } from "commonmark"
 import { parse, postprocess, preprocess } from "micromark"
 import Parser from "tree-sitter"
 
@@ -281,90 +283,107 @@ const markTreeLink = (
   }
 }
 
-const maxNestedImages = (root: Parser.SyntaxNode): number => {
-  const pending = [{ node: root, depth: 0 }]
-  let maximum = 0
-  while (pending.length > 0) {
-    const current = pending.pop()
-    if (current === undefined) continue
-    const depth = current.depth + (current.node.type === "image" ? 1 : 0)
-    maximum = Math.max(maximum, depth)
-    for (const child of current.node.children) pending.push({ node: child, depth })
-  }
-  return maximum
+const needsLezerInline = (root: Parser.SyntaxNode): boolean => {
+  let needed = false
+  walk(root, (node) => {
+    const children = node.children
+    let shortcutResource = false
+    for (let index = 0; index < children.length; index++) {
+      const child = children[index]
+      const next = children[index + 1]
+      const afterNext = children[index + 2]
+      if (
+        child?.type === "shortcut_link" &&
+        next?.type === "(" &&
+        child.endIndex === next.startIndex
+      ) {
+        shortcutResource = true
+      } else if (shortcutResource && child?.type === ")") {
+        needed = true
+        return false
+      } else if (child?.type === "]" && next?.type === "(" && afterNext?.type === ")") {
+        needed = true
+        return false
+      }
+    }
+    return needed ? false : undefined
+  })
+  return needed
 }
 
-// Tree-sitter bounds image nesting, so micromark validates omitted suffixes in affected ranges.
-const markRecoveredResources = (
+const LEZER_INLINE_LIMIT = 50_000
+const commonmarkParser = new CommonmarkParser()
+
+const markLezerInline = (state: AnalysisState, source: string, base: number): boolean => {
+  if (source.length > LEZER_INLINE_LIMIT) return false
+  const cursor = lezerMarkdownParser.parse(source).cursor()
+  do {
+    if (cursor.name === "LinkMark" || cursor.name === "URL" || cursor.name === "LinkTitle") {
+      markRange(state.dictionaryMask, base + cursor.from, base + cursor.to)
+    }
+  } while (cursor.next())
+  return true
+}
+
+const parserEmptyResourceRanges = (root: Parser.SyntaxNode): readonly SourceRange[] => {
+  const ranges: SourceRange[] = []
+  walk(root, (node) => {
+    const children = node.children
+    for (let index = 0; index < children.length - 2; index++) {
+      const labelEnd = children[index]
+      const opening = children[index + 1]
+      const closing = children[index + 2]
+      if (labelEnd?.type === "]" && opening?.type === "(" && closing?.type === ")") {
+        ranges.push({ start: labelEnd.startIndex, end: closing.endIndex })
+      }
+    }
+  })
+  return ranges.sort((left, right) => left.start - right.start)
+}
+
+const countTreeResources = (
+  root: Parser.SyntaxNode,
+  source: string,
+  definedIdentifiers: ReadonlySet<string>,
+): number => {
+  let resources = 0
+  walk(root, (node) => {
+    if (node.type === "link_destination" || TREE_AUTOLINK_TOKENS.has(node.type)) {
+      resources++
+    } else if (
+      (TREE_REFERENCE_TOKENS.has(node.type) || node.type === "image") &&
+      !node.children.some((child) => child.type === "link_destination") &&
+      definedIdentifiers.has(normalizedIdentifier(visibleReferenceLabel(source, node)))
+    ) {
+      resources++
+    }
+  })
+  return resources
+}
+
+const markCommonmarkResources = (
   state: AnalysisState,
   source: string,
   base: number,
-  shortcutStarts: ReadonlyMap<number, number>,
-  nestedImages: number,
+  root: Parser.SyntaxNode,
+  definedIdentifiers: ReadonlySet<string>,
 ): void => {
-  const chunks: string[] = []
-  const sourceStarts = new Map<number, { labelStart?: number; resourceStart: number }>()
-  const candidates = [...source.matchAll(/\]\((?:[^()\\\n]|\\.)*\)/g)]
-  let syntheticOffset = 0
-  for (const candidate of candidates) {
-    if (candidate.index === undefined) continue
-    const resourceStart = candidate.index + 1
-    const shortcutStart = shortcutStarts.get(resourceStart)
-    if (shortcutStart === undefined && (nestedImages <= 1 || candidates.length < 2)) {
-      continue
-    }
-    const resource = candidate[0].slice(1)
-    sourceStarts.set(syntheticOffset + 3, {
-      labelStart: shortcutStart === undefined ? undefined : base + shortcutStart,
-      resourceStart: base + resourceStart,
-    })
-    chunks.push(`[x]${resource}\n\n`)
-    syntheticOffset += resource.length + 5
+  let resources = 0
+  const walker = commonmarkParser.parse(source).walker()
+  let event = walker.next()
+  while (event !== null) {
+    if (event.entering && (event.node.type === "link" || event.node.type === "image")) resources++
+    event = walker.next()
   }
-  if (chunks.length === 0) return
 
-  for (const [phase, token] of markdownEvents(chunks.join(""))) {
-    if (phase !== "enter" || token.type !== "resource") continue
-    const recovered = sourceStarts.get(token.start.offset)
-    if (recovered !== undefined) {
-      markRange(
-        state.dictionaryMask,
-        recovered.resourceStart,
-        recovered.resourceStart + token.end.offset - token.start.offset,
-      )
-      if (recovered.labelStart !== undefined) {
-        markRange(state.dictionaryMask, recovered.labelStart, recovered.labelStart + 1)
-        markRange(state.dictionaryMask, recovered.resourceStart - 1, recovered.resourceStart)
-      }
-    }
-  }
-}
-
-// Micromark fills the HTML constructs that Tree-sitter deliberately leaves as plain text.
-const markRecoveredHtml = (state: AnalysisState, source: string, base: number): void => {
-  const chunks: string[] = []
-  const sourceRanges = new Map<number, SourceRange>()
-  let syntheticOffset = 0
-  for (const candidate of source.matchAll(/<[^>\n]*>/g)) {
-    if (candidate.index === undefined) continue
-    sourceRanges.set(syntheticOffset, {
-      start: base + candidate.index,
-      end: base + candidate.index + candidate[0].length,
-    })
-    chunks.push(`${candidate[0]}\n\n`)
-    syntheticOffset += candidate[0].length + 2
-  }
-  if (chunks.length === 0) return
-
-  for (const [phase, token] of markdownTextEvents(chunks.join(""))) {
-    if (phase !== "enter" || token.type !== "htmlText") continue
-    const sourceRange = sourceRanges.get(token.start.offset)
-    if (
-      sourceRange !== undefined &&
-      token.end.offset - token.start.offset === sourceRange.end - sourceRange.start
-    ) {
-      markRange(state.dictionaryMask, sourceRange.start, sourceRange.end)
-    }
+  const missingResources = Math.max(
+    0,
+    resources - countTreeResources(root, source, definedIdentifiers),
+  )
+  const ranges = parserEmptyResourceRanges(root)
+  for (let index = 0; index < Math.min(missingResources, ranges.length); index++) {
+    const range = ranges[index]
+    if (range !== undefined) markRange(state.dictionaryMask, base + range.start, base + range.end)
   }
 }
 
@@ -375,11 +394,9 @@ const markInlineTree = (
   definedIdentifiers: ReadonlySet<string>,
 ): void => {
   const tree = inlineParser.parse(source, undefined, { bufferSize: source.length + 1 })
-  const shortcutStarts = new Map<number, number>()
   walk(tree.rootNode, (node) => {
     const start = base + node.startIndex
     const end = base + node.endIndex
-    if (node.type === "shortcut_link") shortcutStarts.set(node.endIndex, node.startIndex)
     if (node.type === "code_span") {
       markCode(state, start, end, false)
       return false
@@ -407,8 +424,9 @@ const markInlineTree = (
       markRange(state.dictionaryMask, start, Math.min(start + 1, end))
     }
   })
-  markRecoveredResources(state, source, base, shortcutStarts, maxNestedImages(tree.rootNode))
-  markRecoveredHtml(state, source, base)
+  if (needsLezerInline(tree.rootNode) && !markLezerInline(state, source, base)) {
+    markCommonmarkResources(state, source, base, tree.rootNode, definedIdentifiers)
+  }
 }
 
 const markHtmlTree = (state: AnalysisState, source: string, base: number): void => {
@@ -419,7 +437,6 @@ const markHtmlTree = (state: AnalysisState, source: string, base: number): void 
       return false
     }
   })
-  markRecoveredHtml(state, source, base)
 }
 
 const analyzeCodeWithTreeSitter = (state: AnalysisState): void => {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,4 +1,5 @@
 import { parse, postprocess, preprocess } from "micromark"
+import type { Extension } from "micromark-util-types"
 import { markdownSyntaxExtension } from "./markdown-syntax.ts"
 
 interface MarkdownAnalysis {
@@ -72,6 +73,28 @@ const markdownTextEvents = (source: string) => {
   )
   return translateParserOffsets(events, input.offset)
 }
+
+const htmlSyntaxExtension: Extension = {
+  disable: {
+    null: [
+      "attention",
+      "autolink",
+      "characterEscape",
+      "codeText",
+      "hardBreakEscape",
+      "labelEnd",
+      "labelStartImage",
+      "labelStartLink",
+    ],
+  },
+}
+
+const htmlSyntaxEvents = (source: string) =>
+  postprocess(
+    parse({ extensions: [htmlSyntaxExtension] })
+      .text()
+      .write(preprocess()(source, undefined, true)),
+  )
 
 type MarkdownEvents = ReturnType<typeof markdownEvents>
 type MarkdownToken = MarkdownEvents[number][1]
@@ -189,22 +212,14 @@ const enteredRanges = (
   return ranges
 }
 
-const markHtmlFlows = (
-  state: AnalysisState,
-  htmlFlows: readonly SourceRange[],
-  textEvents: MarkdownEvents,
-): void => {
-  const syntax = enteredRanges(textEvents, HTML_SYNTAX_TOKENS)
-  let syntaxIndex = 0
-
+const markHtmlFlows = (state: AnalysisState, htmlFlows: readonly SourceRange[]): void => {
   for (const flow of htmlFlows) {
-    while ((syntax[syntaxIndex]?.end ?? Number.POSITIVE_INFINITY) <= flow.start) syntaxIndex++
-    for (let index = syntaxIndex; index < syntax.length; index++) {
-      const range = syntax[index]
-      if (range === undefined || range.start >= flow.end) break
-      if (range.start >= flow.start && range.end <= flow.end) {
-        markRange(state.dictionaryMask, range.start, range.end)
-      }
+    const syntax = enteredRanges(
+      htmlSyntaxEvents(state.source.slice(flow.start, flow.end)),
+      HTML_SYNTAX_TOKENS,
+    )
+    for (const range of syntax) {
+      markRange(state.dictionaryMask, flow.start + range.start, flow.start + range.end)
     }
   }
 }
@@ -249,9 +264,7 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
     }
   }
 
-  if (htmlFlows.length > 0) {
-    markHtmlFlows(state, htmlFlows, markdownTextEvents(state.source))
-  }
+  if (htmlFlows.length > 0) markHtmlFlows(state, htmlFlows)
 }
 
 const applyMask = (

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,5 +1,5 @@
 import { parse, postprocess, preprocess } from "micromark"
-import { htmlRawNames } from "micromark-util-html-tag-name"
+import { markdownSyntaxExtension } from "./markdown-syntax.ts"
 
 interface MarkdownAnalysis {
   readonly lines: string[]
@@ -30,23 +30,48 @@ interface SourceRange {
   readonly end: number
 }
 
-const withoutLinks = {
-  disable: { null: ["labelEnd", "labelStartImage", "labelStartLink"] },
+const parserInput = (source: string): { readonly source: string; readonly offset: number } =>
+  source.charCodeAt(0) === 0xfeff
+    ? { source: source.slice(1), offset: 1 }
+    : { source, offset: 0 }
+
+const translateParserOffsets = <Events extends ReturnType<typeof postprocess>>(
+  events: Events,
+  offset: number,
+): Events => {
+  if (offset === 0) return events
+
+  const points = new Set<object>()
+  for (const [, token] of events) {
+    for (const point of [token.start, token.end]) {
+      if (points.has(point)) continue
+      points.add(point)
+      point.offset += offset
+      if (point.line === 1) point.column += offset
+    }
+  }
+  return events
 }
 
-const markdownEvents = (source: string, includeLinks: boolean) =>
-  postprocess(
-    parse(includeLinks ? undefined : { extensions: [withoutLinks] })
+const markdownEvents = (source: string) => {
+  const input = parserInput(source)
+  const events = postprocess(
+    parse({ extensions: [markdownSyntaxExtension] })
       .document()
-      .write(preprocess()(source, undefined, true)),
+      .write(preprocess()(input.source, undefined, true)),
   )
+  return translateParserOffsets(events, input.offset)
+}
 
-const markdownTextEvents = (source: string) =>
-  postprocess(
-    parse({ extensions: [withoutLinks] })
+const markdownTextEvents = (source: string) => {
+  const input = parserInput(source)
+  const events = postprocess(
+    parse({ extensions: [markdownSyntaxExtension] })
       .text()
-      .write(preprocess()(source, undefined, true)),
+      .write(preprocess()(input.source, undefined, true)),
   )
+  return translateParserOffsets(events, input.offset)
+}
 
 type MarkdownEvents = ReturnType<typeof markdownEvents>
 type MarkdownToken = MarkdownEvents[number][1]
@@ -164,55 +189,20 @@ const enteredRanges = (
   return ranges
 }
 
-const rangesWithin = (
-  ranges: readonly SourceRange[],
-  container: SourceRange,
-): readonly SourceRange[] => {
-  const matches: SourceRange[] = []
-  for (const range of ranges) {
-    if (range.start >= container.end) break
-    if (range.start >= container.start && range.end <= container.end) matches.push(range)
-  }
-  return matches
-}
-
-const rawHtmlOpening = (
-  source: string,
-  flow: SourceRange,
-  syntax: readonly SourceRange[],
-): SourceRange | undefined => {
-  const opening = syntax.find(
-    (range) => range.start >= flow.start && source.charCodeAt(range.start) === 60,
-  )
-  if (opening === undefined) return undefined
-
-  const tag = source.slice(opening.start, opening.end).toLowerCase()
-  for (const name of htmlRawNames) {
-    const prefix = `<${name}`
-    if (!tag.startsWith(prefix)) continue
-    const boundary = tag[prefix.length]
-    if (boundary === undefined || "\t\n\r\f />".includes(boundary)) return opening
-  }
-  return undefined
-}
-
 const markHtmlFlows = (
   state: AnalysisState,
   htmlFlows: readonly SourceRange[],
   textEvents: MarkdownEvents,
 ): void => {
   const syntax = enteredRanges(textEvents, HTML_SYNTAX_TOKENS)
+  let syntaxIndex = 0
 
   for (const flow of htmlFlows) {
-    const flowSyntax = rangesWithin(syntax, flow)
-    const opening = rawHtmlOpening(state.source, flow, flowSyntax)
-    const selfClosing =
-      opening !== undefined && state.source.charCodeAt(opening.end - 2) === 47
-
-    if (opening !== undefined && !selfClosing) {
-      markRange(state.dictionaryMask, flow.start, flow.end)
-    } else {
-      for (const range of flowSyntax) {
+    while ((syntax[syntaxIndex]?.end ?? Number.POSITIVE_INFINITY) <= flow.start) syntaxIndex++
+    for (let index = syntaxIndex; index < syntax.length; index++) {
+      const range = syntax[index]
+      if (range === undefined || range.start >= flow.end) break
+      if (range.start >= flow.start && range.end <= flow.end) {
         markRange(state.dictionaryMask, range.start, range.end)
       }
     }
@@ -220,7 +210,7 @@ const markHtmlFlows = (
 }
 
 const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void => {
-  const events = markdownEvents(state.source, includeDictionary)
+  const events = markdownEvents(state.source)
   const definitionEnds = includeDictionary ? definitionMaskEnds(events) : new Map<number, number>()
   const htmlFlows: SourceRange[] = []
 
@@ -250,6 +240,8 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
         token.start.offset,
         definitionEnds.get(token.start.offset) ?? token.end.offset,
       )
+    } else if (token.type === "htmlRawFlow") {
+      markRange(state.dictionaryMask, token.start.offset, token.end.offset)
     } else if (token.type === "htmlFlow") {
       htmlFlows.push({ start: token.start.offset, end: token.end.offset })
     } else if (DICTIONARY_TOKENS.has(token.type)) {

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -23,6 +23,7 @@ interface AnalysisState {
   readonly proseMask: Uint8Array
   readonly structuralMask: Uint8Array
   readonly dictionaryMask: Uint8Array
+  readonly containerMask: Uint8Array
   readonly structuralBlanks: boolean[]
 }
 
@@ -146,7 +147,28 @@ const createAnalysisState = (source: string, parseLines: readonly string[]): Ana
     proseMask: new Uint8Array(source.length),
     structuralMask: new Uint8Array(source.length),
     dictionaryMask: new Uint8Array(source.length),
+    containerMask: new Uint8Array(source.length),
     structuralBlanks: parseLines.map((line) => line.trim() === ""),
+  }
+}
+
+const markContainerOnlyLinesAsBlank = (state: AnalysisState): void => {
+  for (let line = 0; line < state.parseLines.length; line++) {
+    const start = state.sourceLineStarts[line] ?? 0
+    const end = start + (state.parseLines[line]?.length ?? 0)
+    let hasContainer = false
+    let hasOtherContent = false
+
+    for (let offset = start; offset < end; offset++) {
+      if (state.containerMask[offset] !== 0) {
+        hasContainer = true
+      } else if (state.source[offset]?.trim() !== "") {
+        hasOtherContent = true
+        break
+      }
+    }
+
+    if (hasContainer && !hasOtherContent) state.structuralBlanks[line] = true
   }
 }
 
@@ -241,6 +263,7 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
     }
     if (CONTAINER_TOKENS.has(token.type)) {
       markRange(state.proseMask, token.start.offset, token.end.offset)
+      markRange(state.containerMask, token.start.offset, token.end.offset)
       if (includeDictionary) {
         markRange(state.dictionaryMask, token.start.offset, token.end.offset)
       }
@@ -263,6 +286,7 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
     }
   }
 
+  markContainerOnlyLinesAsBlank(state)
   if (htmlFlows.length > 0) markHtmlFlows(state, htmlFlows)
 }
 

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -401,6 +401,12 @@ describe("lint prose-file: hardened markdown stripping", () => {
     expect(report.violations[0]).toMatchObject({ line: 1, column: 1 })
   })
 
+  test("empty blockquote container lines split prose sentences", () => {
+    const text = [words(20), ">", `${words(10)}.`].join("\n")
+
+    expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+
   test("a tilde fence is not closed by a backtick fence", () => {
     const text = ["~~~", "```", `${words(40)}.`, "~~~"].join("\n")
 

--- a/test/engine/markdown.bench.ts
+++ b/test/engine/markdown.bench.ts
@@ -1,0 +1,37 @@
+import { bench, describe } from "vitest"
+import { blankMarkdownDestinations } from "../../src/engine/markdown.ts"
+
+const sizes = [4_000, 8_000, 16_000] as const
+const benchmarkOptions = {
+  iterations: 1,
+  time: 0,
+  warmupIterations: 1,
+  warmupTime: 0,
+}
+
+const nestedImages = new Map(
+  sizes.map((size) => [size, `${"![x ".repeat(size)}x${"](target)".repeat(size)}`]),
+)
+const unbalancedResources = new Map(sizes.map((size) => [size, "[a](".repeat(size)]))
+
+describe("Markdown parser scaling", () => {
+  for (const size of sizes) {
+    bench(
+      `deep image nesting at ${size} levels`,
+      () => {
+        blankMarkdownDestinations([nestedImages.get(size) ?? ""])
+      },
+      benchmarkOptions,
+    )
+  }
+
+  for (const size of sizes) {
+    bench(
+      `long unbalanced resource sequence at ${size} units`,
+      () => {
+        blankMarkdownDestinations([unbalancedResources.get(size) ?? ""])
+      },
+      benchmarkOptions,
+    )
+  }
+})

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest"
+import { blankMarkdownDestinations } from "../../src/engine/markdown.ts"
+
+const parserThresholdPrefix = `${"Alphaword ".repeat(1_100)}\n\n`
+
+const maskAfterThreshold = (markdown: string): string => {
+  const source = `${parserThresholdPrefix}${markdown}`
+  const masked = blankMarkdownDestinations(source.split("\n")).join("\n")
+  expect(masked).toHaveLength(source.length)
+  return masked.slice(parserThresholdPrefix.length)
+}
+
+describe("Markdown parser masking", () => {
+  test("keeps heading prose while masking its syntax", () => {
+    expect(maskAfterThreshold("# Betaword")).toBe("  Betaword")
+  })
+
+  test("retains invalid next-line definition titles", () => {
+    expect(maskAfterThreshold('[target]: /path\n"Betaword"')).toBe('               \n"Betaword"')
+    expect(maskAfterThreshold('- [target]: /path\n "Betaword"')).toBe(
+      '                 \n "Betaword"',
+    )
+  })
+
+  test("does not parse Markdown syntax inside HTML flow content", () => {
+    expect(maskAfterThreshold("<div>\n[Alphaword](Betaword)\n</div>")).toBe(
+      "     \n[Alphaword](Betaword)\n      ",
+    )
+  })
+
+  test("masks definitions and angle-bracket resources consistently", () => {
+    expect(maskAfterThreshold("[x]: /Betaword")).toBe("              ")
+    expect(maskAfterThreshold('[a](<Destword> "Titleword")')).toBe(" a                         ")
+  })
+
+  test("uses virtual columns for definition titles after tabs", () => {
+    const text = '-\t[target]: /path\n    "Betaword"'
+    expect(maskAfterThreshold(text)).toBe('                 \n    "Betaword"')
+  })
+
+  test("retains link-like text that the parser does not classify as links", () => {
+    const text = "Alphaword ](Betaword) and ](Gammaword)"
+    expect(maskAfterThreshold(text)).toBe(text)
+  })
+
+  test("does not let shallow images make link-like prose into syntax", () => {
+    const text = `${"![x](u) ".repeat(40)}\n\nAlphaword ](Betaword) and ](Gammaword)`
+    expect(maskAfterThreshold(text).endsWith("Alphaword ](Betaword) and ](Gammaword)")).toBe(true)
+  })
+})

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -168,6 +168,15 @@ describe("Markdown parser masking", () => {
     ])
   })
 
+  test("uses parser-relative columns for definitions after a byte order mark", () => {
+    const input = '\ufeff- [target]: /path\n   "Betaword"'
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      `\ufeff${" ".repeat(17)}`,
+      " ".repeat(13),
+    ])
+  })
+
   test("masks self-closing syntax in a parser-classified raw-content block", () => {
     const input = '<script data=">"/>\nBetaword'
 

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest"
-import { blankMarkdownDestinations } from "../../src/engine/markdown.ts"
+import {
+  blankMarkdownCode,
+  blankMarkdownDestinations,
+} from "../../src/engine/markdown.ts"
 
 const parserThresholdPrefix = `${"Alphaword ".repeat(1_100)}\n\n`
 
@@ -120,12 +123,32 @@ describe("Markdown parser masking", () => {
     ])
   })
 
-  test("retains prose after a parser-classified self-closing raw tag", () => {
+  test("uses the complete grammar when link destinations contain backticks", () => {
+    const input = "[Alpha](target`) Betaword `"
+
+    expect(blankMarkdownCode([input])).toEqual([input])
+  })
+
+  test("masks parser-classified malformed raw-content blocks", () => {
+    const input = "<script =bad>\nBetaword\n</script>"
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      " ".repeat(13),
+      " ".repeat(8),
+      " ".repeat(9),
+    ])
+  })
+
+  test("keeps parser offsets aligned after a byte order mark", () => {
+    expect(blankMarkdownCode(["\ufeff`Betaword`"])).toEqual([`\ufeff${" ".repeat(10)}`])
+  })
+
+  test("masks self-closing syntax in a parser-classified raw-content block", () => {
     const input = '<script data=">"/>\nBetaword'
 
     expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
       " ".repeat(18),
-      "Betaword",
+      " ".repeat(8),
     ])
   })
 })

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -47,4 +47,14 @@ describe("Markdown parser masking", () => {
     const text = `${"![x](u) ".repeat(40)}\n\nAlphaword ](Betaword) and ](Gammaword)`
     expect(maskAfterThreshold(text).endsWith("Alphaword ](Betaword) and ](Gammaword)")).toBe(true)
   })
+
+  test("does not let nested images make link-like prose into syntax", () => {
+    expect(maskAfterThreshold("![![x](u)](v) Alphaword ](Betaword)")).toBe(
+      "    x         Alphaword ](Betaword)",
+    )
+  })
+
+  test("retains escaped angle-bracket prose", () => {
+    expect(maskAfterThreshold(String.raw`\<Betaword>`)).toBe(" <Betaword>")
+  })
 })

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest"
 import {
+  blankInlineCode,
   blankMarkdownCode,
   blankMarkdownDestinations,
 } from "../../src/engine/markdown.ts"
@@ -127,6 +128,7 @@ describe("Markdown parser masking", () => {
     const input = "[Alpha](target`) Betaword `"
 
     expect(blankMarkdownCode([input])).toEqual([input])
+    expect(blankInlineCode([input])).toEqual([input])
   })
 
   test("masks parser-classified malformed raw-content blocks", () => {
@@ -142,10 +144,7 @@ describe("Markdown parser masking", () => {
   test("retains prose after a self-closing raw-content tag name", () => {
     const input = "<script/>\nBetaword"
 
-    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
-      " ".repeat(9),
-      "Betaword",
-    ])
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([" ".repeat(9), "Betaword"])
   })
 
   test("masks HTML tags inside code-like HTML flow content", () => {
@@ -163,9 +162,7 @@ describe("Markdown parser masking", () => {
   })
 
   test("keeps parser offsets aligned after consecutive byte order marks", () => {
-    expect(blankMarkdownCode(["\ufeff\ufeff`Betaword`"])).toEqual([
-      `\ufeff\ufeff${" ".repeat(10)}`,
-    ])
+    expect(blankMarkdownCode(["\ufeff\ufeff`Betaword`"])).toEqual([`\ufeff\ufeff${" ".repeat(10)}`])
   })
 
   test("uses parser-relative columns for definitions after a byte order mark", () => {
@@ -180,9 +177,6 @@ describe("Markdown parser masking", () => {
   test("masks self-closing syntax in a parser-classified raw-content block", () => {
     const input = '<script data=">"/>\nBetaword'
 
-    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
-      " ".repeat(18),
-      " ".repeat(8),
-    ])
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([" ".repeat(18), " ".repeat(8)])
   })
 })

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -75,11 +75,39 @@ describe("Markdown parser masking", () => {
     },
   )
 
+  test("accepts labels at the CommonMark size limit", () => {
+    const text = `[${"x".repeat(999)}]: /Betaword`
+
+    expect(maskAfterThreshold(text)).toBe(" ".repeat(text.length))
+  })
+
   test("retains labels beyond the CommonMark size limit", () => {
     const label = "x".repeat(1_000)
     const text = `[${label}]: /Betaword`
 
     expect(maskAfterThreshold(text)).toBe(text)
+  })
+
+  test("retains unknown character references as prose", () => {
+    expect(maskAfterThreshold("Alphaword &Betaword;")).toBe("Alphaword &Betaword;")
+  })
+
+  test.each([
+    ["comment", "<!--\nBetaword\n-->", ["    ", "        ", "   "]],
+    ["processing instruction", "<?target\nBetaword\n?>", ["        ", "        ", "  "]],
+  ])("masks multiline HTML %s blocks", (_name, input, expected) => {
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual(expected)
+  })
+
+  test("retains prose after a closed raw-content block", () => {
+    const input = "<textarea>\nBetaword\n</textarea>\nAlphaword"
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      " ".repeat(10),
+      " ".repeat(8),
+      " ".repeat(11),
+      "Alphaword",
+    ])
   })
 
   test("does not mistake a slash in a quoted attribute for a self-closing tag", () => {

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -57,4 +57,47 @@ describe("Markdown parser masking", () => {
   test("retains escaped angle-bracket prose", () => {
     expect(maskAfterThreshold(String.raw`\<Betaword>`)).toBe(" <Betaword>")
   })
+
+  test("masks the parser-classified empty resource after link-like prose", () => {
+    const prefix = "Alphaword ".repeat(6_000)
+    const text = `${prefix}Alphaword ]() before [x]()`
+    const masked = blankMarkdownDestinations([text])[0]
+
+    expect(masked).toBe(`${prefix}Alphaword ]() before  x   `)
+  })
+
+  test.each(["> [x]: /private", "- [x]: /private"])(
+    "resolves definitions in Markdown containers: %s",
+    (definition) => {
+      expect(maskAfterThreshold(`${definition}\n\n[text][x]`)).toBe(
+        `${" ".repeat(definition.length)}\n\n text    `,
+      )
+    },
+  )
+
+  test("retains labels beyond the CommonMark size limit", () => {
+    const label = "x".repeat(1_000)
+    const text = `[${label}]: /Betaword`
+
+    expect(maskAfterThreshold(text)).toBe(text)
+  })
+
+  test("does not mistake a slash in a quoted attribute for a self-closing tag", () => {
+    const input = '<script data="/>">\nBetaword\n</script>'
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      " ".repeat(18),
+      " ".repeat(8),
+      " ".repeat(9),
+    ])
+  })
+
+  test("retains prose after a parser-classified self-closing raw tag", () => {
+    const input = '<script data=">"/>\nBetaword'
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      " ".repeat(18),
+      "Betaword",
+    ])
+  })
 })

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -139,6 +139,25 @@ describe("Markdown parser masking", () => {
     ])
   })
 
+  test("retains prose after a self-closing raw-content tag name", () => {
+    const input = "<script/>\nBetaword"
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      " ".repeat(9),
+      "Betaword",
+    ])
+  })
+
+  test("masks HTML tags inside code-like HTML flow content", () => {
+    const input = "<div>\n`<span>`\n</div>"
+
+    expect(blankMarkdownDestinations(input.split("\n"))).toEqual([
+      " ".repeat(5),
+      `\`${" ".repeat(6)}\``,
+      " ".repeat(6),
+    ])
+  })
+
   test("keeps parser offsets aligned after a byte order mark", () => {
     expect(blankMarkdownCode(["\ufeff`Betaword`"])).toEqual([`\ufeff${" ".repeat(10)}`])
   })

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -162,6 +162,12 @@ describe("Markdown parser masking", () => {
     expect(blankMarkdownCode(["\ufeff`Betaword`"])).toEqual([`\ufeff${" ".repeat(10)}`])
   })
 
+  test("keeps parser offsets aligned after consecutive byte order marks", () => {
+    expect(blankMarkdownCode(["\ufeff\ufeff`Betaword`"])).toEqual([
+      `\ufeff\ufeff${" ".repeat(10)}`,
+    ])
+  })
+
   test("masks self-closing syntax in a parser-classified raw-content block", () => {
     const input = '<script data=">"/>\nBetaword'
 


### PR DESCRIPTION
## Intent

Implement Linear HUF-160 for simple-english: rebuild Markdown masking wholesale on a real CommonMark parser with source-position tracking instead of the bespoke hand-written CommonMark inline layer. Preserve the extractor contract exactly by replacing non-prose with spaces without deleting source units, so every finding line and column maps to the original source. Mask parser-classified destinations, titles, definitions, autolinks, HTML tags, raw-content blocks, and code while retaining visible prose including link text and image descriptions. Remove the hand-written inline scanning, fallback bracket stack, and opaque-inline probe. Keep every HUF-158 Markdown regression test passing, preserve position fidelity, and benchmark pathological deep nesting and long unbalanced sequences to confirm linear-time behavior. All existing Markdown extractor tests, the full suite, Biome, and TypeScript must remain clean.

## What Changed

- Replaced bespoke Markdown scanning with parser-derived CommonMark source ranges for code, links, definitions, autolinks, and HTML.
- Preserved original source offsets while masking non-prose and retaining visible link text and image descriptions.
- Added Markdown regression coverage and scaling benchmarks for deeply nested and long unbalanced input.

## Risk Assessment

✅ Low: The parser rewrite is well-bounded, extensively regression-covered, and no material source-verifiable defects remain.

## Testing

The initial targeted run exposed quadratic malformed-suffix and nesting behavior plus a benchmark timeout; I fixed the parser integration, reran all Markdown-related engine tests successfully, confirmed near-linear scaling across 4,000 to 16,000 units, and captured a CLI transcript showing that visible link, image, HTML, and reference prose is reported at original columns while destinations, titles, autolinks, tags, raw blocks, code, and definitions are hidden. Full-suite, lint, and type checks were intentionally left to their separate gate phases.

<details>
<summary>Evidence: End-to-end Markdown masking CLI transcript</summary>

```text
$ nl -ba markdown-e2e.md
     1	[Linkword](/Destinationword "Titleword")
     2	![Imageword](/Destinationword "Titleword")
     3	<https://Destinationword.example>
     4	<span title="Attributeword">Htmlword</span>
     5	<script>
     6	Rawword
     7	</script>
     8	`Codeword`
     9	
    10	`` `text
    11	Codeword
    12	`` `
    13	
    14	[Referenceword][private]
    15	
    16	[private]: /Definitionword "Definitiontitleword"

$ simple-english --json --config markdown-e2e-config.json markdown-e2e.md
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Linkword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 1,
      "column": 2
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Imageword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 2,
      "column": 3
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Htmlword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 4,
      "column": 29
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Referenceword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 14,
      "column": 2
    }
  ],
  "summary": {
    "total": 4,
    "hard": 4
  }
}

exit code: 1
```
</details>
<details>
<summary>Evidence: Pathological Markdown scaling benchmark</summary>

```text
$ vitest bench test/engine/markdown.bench.ts
Benchmarking is an experimental feature.
Breaking changes might not follow SemVer, please pin Vitest's version when using it.

 RUN  v3.2.7 /home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KZ2V2WTQ04H9BE9ZYD0KCWD8


 ✓ test/engine/markdown.bench.ts > Markdown parser scaling 995ms
     name                                                   hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · deep image nesting at 4000 levels                 36.5067  27.3923  27.3923  27.3923  27.3923  27.3923  27.3923  27.3923  ±0.00%        1
   · deep image nesting at 8000 levels                 22.3089  44.8252  44.8252  44.8252  44.8252  44.8252  44.8252  44.8252  ±0.00%        1
   · deep image nesting at 16000 levels                 9.0751   110.19   110.19   110.19   110.19   110.19   110.19   110.19  ±0.00%        1
   · long unbalanced resource sequence at 4000 units    113.07   8.8441   8.8441   8.8441   8.8441   8.8441   8.8441   8.8441  ±0.00%        1
   · long unbalanced resource sequence at 8000 units   60.5103  16.5261  16.5261  16.5261  16.5261  16.5261  16.5261  16.5261  ±0.00%        1
   · long unbalanced resource sequence at 16000 units  30.0978  33.2250  33.2250  33.2250  33.2250  33.2250  33.2250  33.2250  ±0.00%        1

 BENCH  Summary

  long unbalanced resource sequence at 4000 units - test/engine/markdown.bench.ts > Markdown parser scaling
    1.87x faster than long unbalanced resource sequence at 8000 units
    3.10x faster than deep image nesting at 4000 levels
    3.76x faster than long unbalanced resource sequence at 16000 units
    5.07x faster than deep image nesting at 8000 levels
    12.46x faster than deep image nesting at 16000 levels
```
</details>
<details>
<summary>Evidence: CLI JSON report</summary>

```text
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Linkword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 1,
      "column": 2
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Imageword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 2,
      "column": 3
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Htmlword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 4,
      "column": 29
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "\"Referenceword\" is not in the approved-word list.",
      "suggestions": [],
      "line": 14,
      "column": 2
    }
  ],
  "summary": {
    "total": 4,
    "hard": 4
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (8) ✅</summary>

- 🚨 `src/engine/markdown.ts:307` - Intent requires &#34;Remove the hand-written inline scanning&#34;, but this path and line 348 scan inline source with regexes and reparse synthetic fragments. This also overmasks visible prose in documents over 10,000 units: after a nested image, `](Betaword)` is treated as a resource solely because `nestedImages &gt; 1`, while escaped `\&lt;Betaword&gt;` is isolated and treated as HTML. Replace these recovery scans at the parser boundary with context-aware parser source ranges.
- 🚨 `test/engine/markdown.test.ts:13` - The required benchmark of pathological deep nesting and long unbalanced sequences is absent. The new suite only adds functional threshold cases, while existing single-size timeout tests cannot confirm linear-time scaling. Add reproducible scaling benchmarks or provide the required benchmark evidence.

🔧 Fix: Fix parser-range masking and add scaling benchmarks
3 errors still open:
- 🚨 `src/engine/markdown.ts:383` - This fallback pairs a CommonMark link count with unrelated sorted Tree-sitter token triples rather than parser source ranges. In an inline range over 50,000 units containing plain `Alphaword ]()` before `[x]()`, `missingResources` is 1, so the visible `]()` is masked while the actual link syntax remains unmasked. This contradicts &#34;Preserve the extractor contract exactly&#34;. Obtain ranges directly from the parser that classified each link instead of correlating counts.
- 🚨 `src/engine/markdown.ts:484` - Documents over 10,000 units use a Tree-sitter fallback that is not CommonMark-equivalent for definitions. The rewrite only handles `[x]:` at a physical line start, so `&gt; [x]: /private` and `- [x]: /private` remain paragraphs, exposing the definition and leaving `[text][x]` unresolved. Conversely, Tree-sitter accepts 1,000-unit labels that CommonMark rejects, causing visible prose to be masked at line 504. This violates the required real CommonMark classification and definition masking. Enforce classification at one CommonMark-accurate parser boundary rather than adding more rewrites.
- 🚨 `src/engine/markdown.ts:28` - The self-closing regex is not quote-aware. A valid raw block such as `&lt;script data=&#34;/&gt;&#34;&gt;\nBetaword\n&lt;/script&gt;` matches this regex and is sent to ordinary-HTML masking, exposing `Betaword` even though the intent requires raw-content blocks to be masked. It also misses genuine self-closing tags containing `&gt;` inside a quoted attribute. Use parser-classified tag boundaries for the self-closing decision.

🔧 Fix: Unify Markdown masking on parser source ranges
3 errors still open:
- 🚨 `src/engine/markdown.ts:203` - The required &#34;Remove the hand-written inline scanning&#34; criterion remains unmet: rawContentTag and selfClosingTag manually classify tag text, while markHtmlBlock reparses sliced blocks. This also remains incorrect for `&lt;textarea&gt;...&lt;/textarea&gt;\nBetaword`: Lezer treats textarea as a generic blank-terminated HTML block, so line 249 masks Betaword through EOF. Use a CommonMark parser boundary that supplies accurate HTML subtype, closing, and source ranges.
- 🚨 `src/engine/markdown.ts:320` - The tree visitor handles HTMLBlock but omits Lezer&#39;s distinct CommentBlock and ProcessingInstructionBlock nodes. Consequently, multiline `&lt;!-- ... --&gt;` and `&lt;? ... ?&gt;` content receives no dictionary mask and is linted as prose, contradicting the requirement to replace non-prose with spaces. Handle these parser-classified block ranges at the same tree boundary.
- 🚨 `src/engine/markdown.ts:276` - The selected parser is not sufficiently CommonMark-accurate for the required contract. Its Entity scanner accepts any `&amp;word;`, so this generic mask hides visible `&amp;Betaword;` even though CommonMark treats unknown entities literally. Its label scanner also rejects a valid definition containing exactly 999 label characters, exposing the definition destination. Replace or configure the parser boundary to preserve CommonMark classification rather than masking every emitted Entity and inheriting its label boundary error.

🔧 Fix: Use micromark ranges for CommonMark masking
3 errors still open:
- 🚨 `src/engine/markdown.ts:39` - The required &#34;real CommonMark parser&#34; classification is disabled for normal linting via `withoutLinks`. For `[Alpha](target`) Betaword ``, real CommonMark consumes the first backtick inside the destination and leaves the second unmatched, but this configuration pairs them as code and hides visible prose. Always parse the complete grammar and choose masks from its events instead of disabling link constructs.
- 🚨 `src/engine/markdown.ts:184` - The requirement to mask parser-classified raw-content blocks remains violated because `rawHtmlOpening` manually reclassifies an `htmlFlow` through a second inline parse. Micromark classifies `&lt;script =bad&gt;\nBetaword\n&lt;/script&gt;` as a raw HTML flow based on its tag name, but the inline parser rejects the malformed opening, so `Betaword` remains exposed. Obtain the HTML-flow subtype from the document parser boundary and mask its range directly.
- 🚨 `src/engine/markdown.ts:41` - The required exact source-position fidelity fails for input beginning with U+FEFF. Micromark&#39;s preprocessor removes the BOM without advancing token offsets, while this code applies those offsets directly to the original source. For example, ranges in `﻿`Betaword`` are shifted left by one source unit. Translate parser offsets back to original offsets at the shared parser boundary.

🔧 Fix: Fix CommonMark classification and BOM offset fidelity
2 errors still open:
- 🚨 `src/engine/markdown-syntax.ts:83` - The required &#34;real CommonMark parser&#34; classification is changed here by accepting `/` after a raw-content tag name. `&lt;script/&gt;\nBetaword` is therefore labeled `htmlRawFlow` and masks Betaword through EOF, while standard micromark does not classify `&lt;script/&gt;` as a type-1 raw-content block. Match CommonMark&#39;s raw-block start condition and let the normal parser handle this case.
- 🚨 `src/engine/markdown.ts:197` - The required &#34;Mask parser-classified ... HTML tags&#34; behavior remains bypassable because HTML-flow tags are recovered through a full Markdown text parse. In `&lt;div&gt;\n`&lt;span&gt;`\n&lt;/div&gt;`, that parse classifies `&lt;span&gt;` as code content, so `span` remains exposed even though Markdown constructs are not interpreted inside an HTML flow. Tokenize HTML syntax within each parser-classified ordinary HTML flow without allowing inline Markdown constructs to suppress tags.

🔧 Fix: Fix CommonMark raw flow and HTML tag masking
1 error still open:
- 🚨 `src/engine/markdown.ts:34` - The required &#34;Preserve the extractor contract exactly ... without deleting source units&#34; invariant still fails when a BOM is followed by U+FEFF content. `parserInput` removes the first U+FEFF, then micromark&#39;s preprocessor removes the newly leading second one, but offsets are translated by only one unit. For `\ufeff\ufeff`Betaword``, the code mask shifts left, blanks the second U+FEFF, and exposes the closing backtick. Let micromark consume the original leading BOM and translate its offsets at this shared parser boundary without exposing the next source unit as another BOM.

🔧 Fix: Preserve masking offsets across consecutive BOM characters
1 error still open:
- 🚨 `src/engine/markdown.ts:51` - Adding the BOM offset to first-line columns makes them incomparable with later-line parser columns. For `\ufeff- [target]: /path\n   &#34;Betaword&#34;`, the first-line list content column shifts from 3 to 4 while the valid title remains at column 4, so `definitionMaskEnds` treats the title as unindented and exposes it. This violates the required &#34;Mask parser-classified ... definitions&#34; contract. Translate source offsets, but keep definition indentation comparisons in parser-relative columns or account for the BOM separately.

🔧 Fix: Preserve BOM-relative definition indentation
1 error still open:
- 🚨 `src/engine/markdown.ts:149` - The required &#34;Preserve the extractor contract exactly&#34; behavior regresses for container-only lines. `structuralBlanks` is computed before parser-classified blockquote or list markers are masked, so `&gt;` becomes an empty prose line but remains structurally nonblank. A sentence before `&gt;` therefore joins a sentence after it, potentially producing a false sentence-length violation. Preserve the prior invariant by marking parser-classified empty container lines as structural blanks at the shared parser boundary, without treating inline-code-only lines as boundaries.

🔧 Fix: Preserve sentence boundaries around empty Markdown containers
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial targeted Markdown engine run: `bunx vitest run test/engine/markdown.test.ts test/engine/dictionary.test.ts test/engine/kinds.test.ts test/engine/lint.test.ts test/engine/paragraph-length.test.ts test/engine/contraction.test.ts test/engine/semicolon.test.ts test/engine/verb-form.test.ts test/engine/diff-lint.test.ts`</code>
- <code>Performance isolation with `bun -e` timing harnesses for malformed `](&lt;`, deep image nesting, unbalanced resources, and malformed CDATA</code>
- <code>Focused regression check: `bunx vitest run test/engine/dictionary.test.ts -t &#39;bounds malformed CDATA probes&#39;`</code>
- <code>Final targeted engine validation: `bunx vitest run test/engine/markdown.test.ts test/engine/dictionary.test.ts test/engine/kinds.test.ts test/engine/lint.test.ts test/engine/paragraph-length.test.ts test/engine/contraction.test.ts test/engine/semicolon.test.ts test/engine/verb-form.test.ts test/engine/diff-lint.test.ts`</code>
- <code>Scaling evidence: `bun run bench:markdown`</code>
- <code>End-to-end CLI check using `bun src/cli/main.ts --json --config /tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e-config.json /tmp/no-mistakes-evidence/01KZ2V2WTQ04H9BE9ZYD0KCWD8/markdown-e2e.md`, asserting exactly four visible-prose findings and original source positions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
