### PR TITLE
fix(engine): allow adjectival participles in verb-form checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ The enabled pi Adapter gates fail closed after this error.
 Claude Code Hook mode reports a warning and allows the event, as it does for other load errors.
 Unknown keys, unknown rule IDs, and invalid values cause a config error.
 
-`ruleDataExtensions` maps each list-backed rule to more JSON data files.
+`ruleDataExtensions` maps each list-backed data set to more JSON data files.
 The loader adds entries from these files after the bundled entries.
 The loader resolves relative paths from the current working directory.
 Each file must use the [package dictionary data format](src/dictionary/README.md).
-An `adjectival-participle` extension adds exact forms that the verb-form rules allow after a form of `be`.
+An `adjectival-participle` extension adds exact tagged-token forms that the progressive and passive rules allow after a form of `be`.
 A lint command reports an extension load error and continues with the bundled rule data.
 The enabled pi Adapter fails closed after that error, while Claude Code Hook mode allows the event and adds a warning.
 
@@ -367,13 +367,14 @@ The default maximum is 25 words.
 
 Default: hard.
 Reports a form of `be` followed by an `-ing` verb, with optional adverbs or `not` between them.
-Forms in the adjectival-participle allowlist are exempt.
 
 #### `verb-passive`
 
 Default: soft.
 Reports a form of `be` followed by a past participle, with optional adverbs or `not` between them.
-Forms in the adjectival-participle allowlist are exempt.
+
+Before either rule reports a finding, it checks the exact tagged token against the [bundled adjectival-participle allowlist](src/dictionary/data/adjectival-participles.json).
+The `ruleDataExtensions.adjectival-participle` configuration extends that allowlist.
 
 #### `verb-perfect`
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ This example contains every config key and every rule:
   "ruleDataExtensions": {
     "phrasal-verb": ["config/phrasal-verbs.json"],
     "hedging": ["config/hedging.json"],
-    "marketing": ["config/marketing.json"]
+    "marketing": ["config/marketing.json"],
+    "adjectival-participle": ["config/adjectival-participles.json"]
   },
   "rules": {
     "contraction": "hard",
@@ -313,6 +314,7 @@ Unknown keys, unknown rule IDs, and invalid values cause a config error.
 The loader adds entries from these files after the bundled entries.
 The loader resolves relative paths from the current working directory.
 Each file must use the [package dictionary data format](src/dictionary/README.md).
+An `adjectival-participle` extension adds exact forms that the verb-form rules allow after a form of `be`.
 A lint command reports an extension load error and continues with the bundled rule data.
 The enabled pi Adapter fails closed after that error, while Claude Code Hook mode allows the event and adds a warning.
 
@@ -365,11 +367,13 @@ The default maximum is 25 words.
 
 Default: hard.
 Reports a form of `be` followed by an `-ing` verb, with optional adverbs or `not` between them.
+Forms in the adjectival-participle allowlist are exempt.
 
 #### `verb-passive`
 
 Default: soft.
 Reports a form of `be` followed by a past participle, with optional adverbs or `not` between them.
+Forms in the adjectival-participle allowlist are exempt.
 
 #### `verb-perfect`
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -33,6 +33,7 @@ const RuleDataExtensionsSchema = Schema.partial(
     "phrasal-verb": Schema.Array(Schema.NonEmptyTrimmedString),
     hedging: Schema.Array(Schema.NonEmptyTrimmedString),
     marketing: Schema.Array(Schema.NonEmptyTrimmedString),
+    "adjectival-participle": Schema.Array(Schema.NonEmptyTrimmedString),
   }),
 )
 

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -20,13 +20,12 @@ Unknown properties cause validation to fail.
 - `entries[].unapproved` lists exact case-insensitive word forms or phrases.
   Forms can contain letters, numbers, internal apostrophes, internal hyphens, and horizontal whitespace between words.
 - `entries[].suggestions` is a required list of rule responses.
-  The dictionary rule reports all values as approved alternatives, the phrasal-verb rule uses the first value, and the hedging and marketing rules ignore this field.
+  The dictionary rule reports all values as approved alternatives, the phrasal-verb rule uses the first value, and the hedging, marketing, and adjectival-participle checks ignore this field.
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
   Only the `dictionary-not-approved-word` rule uses this field.
 
-For `adjectival-participle` rule data, each `entries[].unapproved` value is one allowed surface form.
+For `adjectival-participle` rule data, each `entries[].unapproved` value represents one allowed tagged-token surface form.
 Matching is exact and case-insensitive.
-The verb-form rules ignore `suggestions` and `partsOfSpeech` in this data.
 
 For the `dictionary-not-approved-word` rule, matching is token based.
 A hyphenated form matches only that exact hyphenated token.
@@ -34,7 +33,7 @@ A phrase can span horizontal whitespace or a soft line break in the same Markdow
 Fenced and indented Markdown code is excluded from matching.
 The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags for the form's first token.
 The rule checks an entry without `partsOfSpeech` by word or phrase alone.
-The root [README](../../README.md) documents match details for the three list-backed rules and their config extension paths.
+The root [README](../../README.md) owns user-facing matching behavior and configuration.
 
 ## Approved-word list
 
@@ -70,4 +69,4 @@ It also excludes raw content in `pre`, `script`, `style`, and `textarea` HTML fl
 See the root [Configuration](../../README.md#configuration) section for list selection, precedence, and load errors.
 The pure engine receives validated dictionary data and does not read this file.
 
-See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the bundled data source, conversion scope, and license details.
+See [`THIRD_PARTY_NOTICES.md`](../../THIRD_PARTY_NOTICES.md) for the third-party bundled dictionary source, conversion scope, and license details.

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -3,6 +3,7 @@
 The JSON files in `data/` use the package-owned format that `schema.ts` defines and Effect Schema validates.
 The CLI and Adapters load all bundled data through `load.ts`.
 The bundled dictionary and rule-data files use the not-approved form.
+The adjectival-participle rule data interprets its forms as allowed exceptions.
 A user-owned approved-word list uses the approved form.
 
 ## Shared fields
@@ -22,6 +23,10 @@ Unknown properties cause validation to fail.
   The dictionary rule reports all values as approved alternatives, the phrasal-verb rule uses the first value, and the hedging and marketing rules ignore this field.
 - `entries[].partsOfSpeech`, when present, lists the POS tags for which the forms are unapproved.
   Only the `dictionary-not-approved-word` rule uses this field.
+
+For `adjectival-participle` rule data, each `entries[].unapproved` value is one allowed surface form.
+Matching is exact and case-insensitive.
+The verb-form rules ignore `suggestions` and `partsOfSpeech` in this data.
 
 For the `dictionary-not-approved-word` rule, matching is token based.
 A hyphenated form matches only that exact hyphenated token.

--- a/src/dictionary/bundled-rule-data.ts
+++ b/src/dictionary/bundled-rule-data.ts
@@ -1,3 +1,4 @@
+import adjectivalParticiples from "./data/adjectival-participles.json" with { type: "json" }
 import hedging from "./data/hedging.json" with { type: "json" }
 import marketing from "./data/marketing.json" with { type: "json" }
 import phrasalVerbs from "./data/phrasal-verbs.json" with { type: "json" }
@@ -8,4 +9,5 @@ export const BUNDLED_RULE_DATA: RuleData = {
   "phrasal-verb": decodeDictionaryData(phrasalVerbs),
   hedging: decodeDictionaryData(hedging),
   marketing: decodeDictionaryData(marketing),
+  "adjectival-participle": decodeDictionaryData(adjectivalParticiples),
 }

--- a/src/dictionary/data/adjectival-participles.json
+++ b/src/dictionary/data/adjectival-participles.json
@@ -1,0 +1,15 @@
+{
+  "formatVersion": 1,
+  "source": {
+    "name": "HUF-167 adjectival-participle audit",
+    "repository": "https://linear.app/huffman",
+    "commit": "HUF-167",
+    "path": "issue/HUF-167"
+  },
+  "entries": [
+    {
+      "unapproved": ["deprecated", "missing"],
+      "suggestions": ["allow"]
+    }
+  ]
+}

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -16,6 +16,9 @@ export const BUNDLED_RULE_DATA_PATHS: Readonly<Record<RuleDataId, string>> = {
   "phrasal-verb": fileURLToPath(new URL("./data/phrasal-verbs.json", import.meta.url)),
   hedging: fileURLToPath(new URL("./data/hedging.json", import.meta.url)),
   marketing: fileURLToPath(new URL("./data/marketing.json", import.meta.url)),
+  "adjectival-participle": fileURLToPath(
+    new URL("./data/adjectival-participles.json", import.meta.url),
+  ),
 }
 
 type DictionaryLoadLabel = "STE dictionary" | "rule data"
@@ -121,4 +124,9 @@ export const loadRuleData = (
     "phrasal-verb": loadExtendedRuleData("phrasal-verb", extensions["phrasal-verb"] ?? [], cwd),
     hedging: loadExtendedRuleData("hedging", extensions.hedging ?? [], cwd),
     marketing: loadExtendedRuleData("marketing", extensions.marketing ?? [], cwd),
+    "adjectival-participle": loadExtendedRuleData(
+      "adjectival-participle",
+      extensions["adjectival-participle"] ?? [],
+      cwd,
+    ),
   })

--- a/src/dictionary/rule-data.ts
+++ b/src/dictionary/rule-data.ts
@@ -1,6 +1,11 @@
 import type { Dictionary } from "./schema.ts"
 
-export const ruleDataIds = ["phrasal-verb", "hedging", "marketing"] as const
+export const ruleDataIds = [
+  "phrasal-verb",
+  "hedging",
+  "marketing",
+  "adjectival-participle",
+] as const
 
 export type RuleDataId = (typeof ruleDataIds)[number]
 export type RuleData = Readonly<Partial<Record<RuleDataId, Dictionary>>>

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -305,7 +305,9 @@ const lintProse = (
         )),
     ...(options.tagger === undefined
       ? []
-      : sentenceFindings(verbForm(prepared.lines, options.tagger))),
+      : sentenceFindings(
+          verbForm(prepared.lines, options.tagger, options.ruleData?.["adjectival-participle"]),
+        )),
   ]
 }
 

--- a/src/engine/rules/verb-form.ts
+++ b/src/engine/rules/verb-form.ts
@@ -1,3 +1,5 @@
+import type { Dictionary } from "../../dictionary/schema.ts"
+import { caseFoldKey } from "../case-fold.ts"
 import type { TaggedToken, Tagger } from "../tagger.ts"
 import type { Violation } from "../types.ts"
 
@@ -20,6 +22,22 @@ const isProgressiveVerb = (token: TaggedToken) =>
 const isPastParticiple = (token: TaggedToken) =>
   token.pos === "VERB" && !token.text.toLowerCase().endsWith("ing")
 
+const allowlistByDictionary = new WeakMap<Dictionary, ReadonlySet<string>>()
+
+const allowlistFor = (dictionary: Dictionary): ReadonlySet<string> => {
+  const cached = allowlistByDictionary.get(dictionary)
+  if (cached !== undefined) return cached
+
+  const allowlist = new Set(
+    dictionary.entries.flatMap((entry) => entry.unapproved).map(caseFoldKey),
+  )
+  allowlistByDictionary.set(dictionary, allowlist)
+  return allowlist
+}
+
+const isAllowlisted = (token: TaggedToken, dictionary: Dictionary | undefined): boolean =>
+  dictionary !== undefined && allowlistFor(dictionary).has(caseFoldKey(token.text))
+
 function nextContentToken(tokens: readonly TaggedToken[], start: number): TaggedToken | undefined {
   for (let i = start; i < tokens.length; i++) {
     const token = tokens[i]
@@ -30,7 +48,11 @@ function nextContentToken(tokens: readonly TaggedToken[], start: number): Tagged
   return undefined
 }
 
-export function verbForm(lines: readonly string[], tag: Tagger): Violation[] {
+export function verbForm(
+  lines: readonly string[],
+  tag: Tagger,
+  adjectivalParticiples?: Dictionary,
+): Violation[] {
   const violations: Violation[] = []
 
   lines.forEach((line, index) => {
@@ -46,15 +68,16 @@ export function verbForm(lines: readonly string[], tag: Tagger): Violation[] {
       }
       const found = line.slice(token.offset, head.offset + head.text.length)
       const position = { line: index + 1, column: token.offset + 1 }
+      const allowlisted = isAllowlisted(head, adjectivalParticiples)
 
-      if (isBeForm(token) && isProgressiveVerb(head)) {
+      if (isBeForm(token) && isProgressiveVerb(head) && !allowlisted) {
         violations.push({
           ruleId: "verb-progressive",
           severity: "hard",
           message: `Use a simple tense. Do not use the progressive. Found: "${found}".`,
           ...position,
         })
-      } else if (isBeForm(token) && isPastParticiple(head)) {
+      } else if (isBeForm(token) && isPastParticiple(head) && !allowlisted) {
         violations.push({
           ruleId: "verb-passive",
           severity: "soft",

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -16,6 +16,9 @@ describe("config schema", () => {
       rules: { "sentence-length": "soft" },
       maxSentenceWords: 20,
       approvedWordsPath: "config/approved-words.json",
+      ruleDataExtensions: {
+        "adjectival-participle": ["config/adjectival-participles.json"],
+      },
     })
 
     expect(result._tag).toBe("Right")
@@ -24,6 +27,9 @@ describe("config schema", () => {
         rules: { "sentence-length": "soft" },
         maxSentenceWords: 20,
         approvedWordsPath: "config/approved-words.json",
+        ruleDataExtensions: {
+          "adjectival-participle": ["config/adjectival-participles.json"],
+        },
       })
     }
   })

--- a/test/engine/README.md
+++ b/test/engine/README.md
@@ -15,8 +15,8 @@ All cells must stay at Yes.
 | `phrasal-verb` | Yes. `flags a phrasal verb as a hard violation with the approved alternative`. | Yes. `does not flag the bare verb without its particle`. | Yes. `does not match within a token`. |
 | `semicolon` | Yes. `flags a semicolon as a hard violation at its column`. | Yes. `ignores semicolons inside inline code`. | Yes. `flags a prose semicolon beside inline code at its original column`. |
 | `sentence-length` | Yes. `flags a sentence over 25 words as a hard violation`. | Yes. `does not flag short sentences`. | Yes. `does not flag a sentence of exactly 25 words`. |
-| `verb-progressive` | Yes. `flags progressive tense as a hard violation`. | Yes. `does not flag simple present as progressive`. | Yes. `does not flag an adjective that ends in ing as progressive`. |
-| `verb-passive` | Yes. `flags passive voice as a soft violation with a rewrite hint`. | Yes. `does not flag active voice`. | Yes. `detects passive across an intervening adverb`. |
+| `verb-progressive` | Yes. `flags progressive tense as a hard violation`. | Yes. `does not flag a bundled adjectival participle`. | Yes. `allows a listed participle after an intervening adverb`. |
+| `verb-passive` | Yes. `flags passive voice as a soft violation with a rewrite hint`. | Yes. `does not flag an allowlisted passive participle`. | Yes. `detects passive across an intervening adverb`. |
 | `verb-perfect` | Yes. `flags perfect tense as a hard violation`. | Yes. `does not flag simple past as perfect`. | Yes. `does not flag main-verb have`. |
 
 Diff-only behavior has a separate engine seam in `diff-match.test.ts`.

--- a/test/engine/verb-form-fixtures.test.ts
+++ b/test/engine/verb-form-fixtures.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import { BUNDLED_RULE_DATA } from "../../src/dictionary/bundled-rule-data.ts"
 import { lint } from "../../src/engine/lint.ts"
 import { makeWinkTagger } from "../../src/tagger/wink.ts"
 
@@ -48,6 +49,11 @@ const perfects: readonly Fixture[] = [
   { text: "We have removed the old filter.", expected: ["verb-perfect"] },
 ]
 
+const adjectivalParticiples: readonly (Fixture & { readonly form: string })[] = [
+  { form: "deprecated", text: "The endpoint is deprecated.", expected: [] },
+  { form: "missing", text: "Two files are missing.", expected: [] },
+]
+
 const tricky: readonly Fixture[] = [
   {
     text: "The door is closed.",
@@ -84,6 +90,16 @@ const tricky: readonly Fixture[] = [
     expected: [],
     note: "main-verb have is not a perfect auxiliary",
   },
+  {
+    text: "The first step is running the installer.",
+    expected: ["verb-progressive"],
+    note: "gerund complement stays flagged until the tagger supplies syntax context",
+  },
+  {
+    text: "The build is going to fail without this flag.",
+    expected: ["verb-progressive"],
+    note: "going-to future stays flagged until the tagger supplies syntax context",
+  },
 ]
 
 const suites: readonly [string, readonly Fixture[]][] = [
@@ -91,10 +107,19 @@ const suites: readonly [string, readonly Fixture[]][] = [
   ["active voice", actives],
   ["progressive tense", progressives],
   ["perfect tense", perfects],
+  ["adjectival-participle allowlist", adjectivalParticiples],
   ["tricky pinned verdicts", tricky],
 ]
 
 describe("verb-form rules against the real wink-nlp tagger", () => {
+  test("pins every bundled adjectival-participle form", () => {
+    const bundledForms = BUNDLED_RULE_DATA["adjectival-participle"]?.entries.flatMap(
+      (entry) => entry.unapproved,
+    )
+
+    expect(bundledForms).toEqual(adjectivalParticiples.map((fixture) => fixture.form))
+  })
+
   for (const [name, fixtures] of suites) {
     describe(name, () => {
       for (const fixture of fixtures) {

--- a/test/engine/verb-form.test.ts
+++ b/test/engine/verb-form.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import { decodeDictionaryData } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
 import type { TaggedToken, Tagger } from "../../src/engine/tagger.ts"
 
@@ -114,6 +115,69 @@ describe("lint prose-file: verb-form rules (stub tagger)", () => {
     expect(lint("prose-file", text, { tagger }).violations).not.toContainEqual(
       expect.objectContaining({ ruleId: "verb-progressive" }),
     )
+  })
+
+  test("does not flag a bundled adjectival participle", () => {
+    const text = "Two files are missing."
+    const tagger = stubTagger({
+      [text]: "Two/NUM/two files/NOUN/file are/AUX/be missing/VERB/miss ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
+  })
+
+  test("does not flag an allowlisted passive participle", () => {
+    const text = "The endpoint is deprecated."
+    const tagger = stubTagger({
+      [text]: "The/DET/the endpoint/NOUN/endpoint is/AUX/be deprecated/VERB/deprecate ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
+  })
+
+  test("uses a validated rule-data extension as an allowlist", () => {
+    const text = "The door is closed."
+    const tagger = stubTagger({
+      [text]: "The/DET/the door/NOUN/door is/AUX/be closed/VERB/close ./PUNCT/.",
+    })
+    const extension = decodeDictionaryData({
+      formatVersion: 1,
+      source: {
+        name: "test extension",
+        repository: "https://example.test/rule-data",
+        commit: "fixture",
+        path: "adjectival-participles.json",
+      },
+      entries: [{ unapproved: ["CLOSED"], suggestions: ["allow"] }],
+    })
+
+    const report = lint("prose-file", text, {
+      tagger,
+      ruleData: { "adjectival-participle": extension },
+    })
+
+    expect(report.violations).toHaveLength(0)
+  })
+
+  test("allows a listed participle after an intervening adverb", () => {
+    const text = "The files are still missing."
+    const tagger = stubTagger({
+      [text]: "The/DET/the files/NOUN/file are/AUX/be still/ADV/still missing/VERB/miss ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toHaveLength(0)
+  })
+
+  test("keeps an unlisted gerund complement flagged", () => {
+    const text = "The first step is running the installer."
+    const tagger = stubTagger({
+      [text]:
+        "The/DET/the first/ADJ/first step/NOUN/step is/AUX/be running/VERB/run the/DET/the installer/NOUN/installer ./PUNCT/.",
+    })
+
+    expect(lint("prose-file", text, { tagger }).violations).toEqual([
+      expect.objectContaining({ ruleId: "verb-progressive", severity: "hard", column: 16 }),
+    ])
   })
 
   test("does not flag simple past as perfect", () => {


### PR DESCRIPTION
## Intent

Fix Linear ticket HUF-167 in the ste engine.
Add an adjectival-participle allowlist for the verb-form rule.
Use TDD at the pure Engine seam, with a failing test before the fix.
Ship the allowlist as extensible rule data with schema validation at the load boundary.
Let users extend the allowlist without an Engine release.
Before progressive or passive findings, consult the allowlist.
With bundled data, "Two files are missing." must raise no violation.
Real progressives such as "The pump is running." must remain hard verb-progressive violations.
Pin every bundled allowlist form with the real wink tagger.
Also pin the gerund-complement and going-to verdicts, which must stay flagged.
List finding, clean, and boundary engine cases in test/engine/README.md.
Copy the supplied probe to the worktree root and run it with Bun.
Do not commit the probe.
Keep runtime packages in dependencies rather than devDependencies.
Validate with bun run test, bun run lint, and bun run typecheck.
Do not format test/fixtures files because tests pin exact byte positions.
Use a Conventional Commit prefix.
Do not add AI attribution to commits or the PR body.
Skip Linear state updates and comments because firstmate handles them.

## What Changed

- Skip progressive and passive findings for bundled adjectival participles such as `missing` and `deprecated`.
- Add schema-validated, extensible `adjectival-participle` rule data so users can add allowed forms without an engine release.
- Document the matching behavior and pin bundled forms, real progressives, gerund complements, and going-to verdicts in engine tests.

## Risk Assessment

✅ Low: The change is well-bounded and satisfies the source-verifiable intent with validated extensible data and focused engine coverage.

## Testing

Installed locked dependencies, confirmed the new pure Engine regression test fails on the base commit and passes with the fix, ran focused Engine, real-wink, and config tests, and exercised bundled, extended, and invalid rule data through the CLI with reviewer-visible evidence. All targeted checks passed, and transient worktree files were removed. The full suite, lint, and typecheck were not run because this phase requires targeted testing and forbids lint or static analysis.

<details>
<summary>Evidence: End-to-end CLI transcript for bundled behavior, external extension, and schema rejection</summary>

```text
=== Bundled allowlist and pinned non-exempt forms ===
$ printf %b Two\ files\ are\ missing.\\nThe\ pump\ is\ running.\\nThe\ first\ step\ is\ running\ the\ installer.\\nThe\ build\ is\ going\ to\ fail\ without\ this\ flag.\\n | bun src/cli/main.ts --config /tmp/no-mistakes-evidence/01KZ5F9GXAEGQ3BN0WE95CD3VY/empty-config.json --kind prose-file --json
--- input ---
Two files are missing.
The pump is running.
The first step is running the installer.
The build is going to fail without this flag.
--- stdout ---
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "verb-progressive",
      "severity": "hard",
      "message": "Use a simple tense. Do not use the progressive. Found: \"is running\".",
      "line": 2,
      "column": 10
    },
    {
      "file": "<stdin>",
      "ruleId": "verb-progressive",
      "severity": "hard",
      "message": "Use a simple tense. Do not use the progressive. Found: \"is running\".",
      "line": 3,
      "column": 16
    },
    {
      "file": "<stdin>",
      "ruleId": "verb-progressive",
      "severity": "hard",
      "message": "Use a simple tense. Do not use the progressive. Found: \"is going\".",
      "line": 4,
      "column": 11
    }
  ],
  "summary": {
    "total": 3,
    "hard": 3
  }
}
--- stderr ---
exit_code=1

=== Unlisted passive before user extension ===
$ printf %b The\ door\ is\ closed.\\n | bun src/cli/main.ts --config /tmp/no-mistakes-evidence/01KZ5F9GXAEGQ3BN0WE95CD3VY/empty-config.json --kind prose-file --json
--- input ---
The door is closed.
--- stdout ---
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "verb-passive",
      "severity": "soft",
      "message": "Use the active voice, unless the actor is unknown. Found: \"is closed\".",
      "line": 1,
      "column": 10
    }
  ],
  "summary": {
    "total": 1,
    "hard": 0
  }
}
--- stderr ---
exit_code=0

=== User extension exempts closed without an Engine release ===
$ printf %b The\ door\ is\ closed.\\n | bun src/cli/main.ts --config /tmp/no-mistakes-evidence/01KZ5F9GXAEGQ3BN0WE95CD3VY/valid-extension-config.json --kind prose-file --json
--- input ---
The door is closed.
--- stdout ---
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
--- stderr ---
exit_code=0

=== Invalid user rule data is rejected at the load boundary ===
$ printf %b The\ door\ is\ closed.\\n | bun src/cli/main.ts --config /tmp/no-mistakes-evidence/01KZ5F9GXAEGQ3BN0WE95CD3VY/invalid-extension-config.json --kind prose-file --json
--- input ---
The door is closed.
--- stdout ---
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "verb-passive",
      "severity": "soft",
      "message": "Use the active voice, unless the actor is unknown. Found: \"is closed\".",
      "line": 1,
      "column": 10
    }
  ],
  "summary": {
    "total": 1,
    "hard": 0
  }
}
--- stderr ---
Cannot load rule data from /tmp/no-mistakes-evidence/01KZ5F9GXAEGQ3BN0WE95CD3VY/invalid-adjectival-participles-extension.json: entries[0].unapproved[0]: is missing
exit_code=0
```
</details>
<details>
<summary>Evidence: Bun probe output using the real wink tagger</summary>

```text
{
  "bundledForms": [
    "deprecated",
    "missing"
  ],
  "results": [
    {
      "text": "Two files are missing.",
      "violations": []
    },
    {
      "text": "The endpoint is deprecated.",
      "violations": []
    },
    {
      "text": "The pump is running.",
      "violations": [
        {
          "ruleId": "verb-progressive",
          "severity": "hard"
        }
      ]
    },
    {
      "text": "The first step is running the installer.",
      "violations": [
        {
          "ruleId": "verb-progressive",
          "severity": "hard"
        }
      ]
    },
    {
      "text": "The build is going to fail without this flag.",
      "violations": [
        {
          "ruleId": "verb-progressive",
          "severity": "hard"
        }
      ]
    }
  ]
}
```
</details>
<details>
<summary>Evidence: Regression test failure reproduced against the base commit</summary>

```text

 RUN  v3.2.7 /tmp/no-mistakes-evidence/01KZ5F9GXAEGQ3BN0WE95CD3VY/base-regression-check

 ❯ test/engine/verb-form.test.ts (20 tests | 1 failed | 19 skipped) 18ms
   ↓ lint prose-file: verb-form rules (stub tagger) > flags passive voice as a soft violation with a rewrite hint
   ↓ lint prose-file: verb-form rules (stub tagger) > flags progressive tense as a hard violation
   ↓ lint prose-file: verb-form rules (stub tagger) > flags perfect tense as a hard violation
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag active voice
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag simple present as progressive
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag an adjective that ends in ing as progressive
   × lint prose-file: verb-form rules (stub tagger) > does not flag a bundled adjectival participle 17ms
     → expected [ Array(1) ] to have a length of +0 but got 1
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag an allowlisted passive participle
   ↓ lint prose-file: verb-form rules (stub tagger) > uses a validated rule-data extension as an allowlist
   ↓ lint prose-file: verb-form rules (stub tagger) > allows a listed participle after an intervening adverb
   ↓ lint prose-file: verb-form rules (stub tagger) > keeps an unlisted gerund complement flagged
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag simple past as perfect
   ↓ lint prose-file: verb-form rules (stub tagger) > detects passive across an intervening adverb
   ↓ lint prose-file: verb-form rules (stub tagger) > detects passive across a negation
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag an infinitive after a linking verb
   ↓ lint prose-file: verb-form rules (stub tagger) > does not flag main-verb have
   ↓ lint prose-file: verb-form rules (stub tagger) > flags 'has been sent' as passive only, mirroring the pi-ste reference
   ↓ lint prose-file: verb-form rules (stub tagger) > skips verb-form rules when no tagger is provided
   ↓ lint prose-file: verb-form rules (stub tagger) > reports the line of the violation and ignores fenced code blocks
   ↓ lint prose-file: verb-form rules (stub tagger) > flags each occurrence on a line

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/engine/verb-form.test.ts > lint prose-file: verb-form rules (stub tagger) > does not flag a bundled adjectival participle
AssertionError: expected [ Array(1) ] to have a length of +0 but got 1

[32m- Expected[39m
[31m+ Received[39m

[32m- 0[39m
[31m+ 1[39m

 ❯ test/engine/verb-form.test.ts:126:61
    124|     })
    125| 
    126|     expect(lint("prose-file", text, { tagger }).violations).toHaveLeng…
       |                                                             ^
    127|   })
    128| 

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯


 Test Files  1 failed (1)
      Tests  1 failed | 19 skipped (20)
   Start at  12:11:51
   Duration  996ms (transform 250ms, setup 0ms, collect 586ms, tests 18ms, environment 0ms, prepare 143ms)


expected_base_failure_exit_code=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` for local test setup, followed by removal of `node_modules`</code>
- `bunx vitest run test/engine/verb-form.test.ts test/engine/verb-form-fixtures.test.ts test/config/schema.test.ts`
- <code>Ran `does not flag a bundled adjectival participle` against base commit `87f1e67c` and confirmed the regression test fails before the fix</code>
- <code>`bun ./huf-167-probe.ts` from the worktree root with the real wink tagger, then removed the uncommitted probe</code>
- <code>Ran `bun src/cli/main.ts --kind prose-file --json` with bundled data for missing, progressive, gerund-complement, and going-to cases</code>
- <code>Ran the CLI before and after configuring an external adjectival-participle extension for `closed`</code>
- `Ran the CLI with malformed external rule data and confirmed load-boundary rejection`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
