### PR TITLE
fix(engine): mask YAML frontmatter as non-prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ It is the default for standard input, extensionless paths, and file types that h
 File extension matching does not depend on letter case.
 Source kinds ignore comment markers inside string literals.
 All kinds preserve the original line and column.
-They ignore identifiers, valid GFM tables, and fenced, indented, and inline Markdown code.
+They ignore identifiers, YAML frontmatter, valid GFM tables, and fenced, indented, and inline Markdown code.
 
 ## Configuration
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@lezer/markdown": "^1.7.2",
         "effect": "^3.14.0",
         "micromark": "^4.0.2",
+        "micromark-extension-frontmatter": "^2.0.0",
         "micromark-extension-gfm-table": "^2.1.1",
         "micromark-util-character": "^2.1.1",
         "micromark-util-html-tag-name": "^2.0.1",
@@ -385,9 +386,13 @@
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
+    "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetch-blob": ["fetch-blob@3.2.0", "", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
+
+    "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
     "formdata-polyfill": ["formdata-polyfill@4.0.10", "", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
 
@@ -444,6 +449,8 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-frontmatter": ["micromark-extension-frontmatter@2.0.0", "", { "dependencies": { "fault": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg=="],
 
     "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@lezer/markdown": "^1.7.2",
     "effect": "^3.14.0",
     "micromark": "^4.0.2",
+    "micromark-extension-frontmatter": "^2.0.0",
     "micromark-extension-gfm-table": "^2.1.1",
     "micromark-util-character": "^2.1.1",
     "micromark-util-html-tag-name": "^2.0.1",

--- a/src/dictionary/README.md
+++ b/src/dictionary/README.md
@@ -30,7 +30,7 @@ Matching is exact and case-insensitive.
 For the `dictionary-not-approved-word` rule, matching is token based.
 A hyphenated form matches only that exact hyphenated token.
 A phrase can span horizontal whitespace or a soft line break in the same Markdown paragraph, but it cannot span Markdown block boundaries or hard line breaks.
-Fenced and indented Markdown code and valid GFM tables are excluded from matching.
+YAML frontmatter, fenced and indented Markdown code, and valid GFM tables are excluded from matching.
 The rule checks an entry with `partsOfSpeech` only when an injected tagger returns one of those tags for the form's first token.
 The rule checks an entry without `partsOfSpeech` by word or phrase alone.
 The root [README](../../README.md) owns user-facing matching behavior and configuration.
@@ -63,7 +63,7 @@ Add each permitted word form as a separate item.
 A listed hyphenated form approves only that exact hyphenated token.
 
 The rule checks visible Markdown prose, including link and image labels.
-It excludes identifiers, valid GFM tables, Markdown code, link destinations and reference definitions, autolinks, character references, and HTML syntax.
+It excludes identifiers, YAML frontmatter, valid GFM tables, Markdown code, link destinations and reference definitions, autolinks, character references, and HTML syntax.
 It also excludes raw content in `pre`, `script`, `style`, and `textarea` HTML flow blocks.
 
 See the root [Configuration](../../README.md#configuration) section for list selection, precedence, and load errors.

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -1,6 +1,7 @@
 import { parser as htmlParser } from "@lezer/html"
 import { parser as commonMarkParser } from "@lezer/markdown"
 import { parse, postprocess, preprocess } from "micromark"
+import { frontmatter } from "micromark-extension-frontmatter"
 import { gfmTable } from "micromark-extension-gfm-table"
 import { normalizeIdentifier } from "micromark-util-normalize-identifier"
 import { markdownSyntaxExtension } from "./markdown-syntax.ts"
@@ -57,7 +58,7 @@ const translateParserOffsets = <Events extends ReturnType<typeof postprocess>>(
   return events
 }
 
-const MARKDOWN_EXTENSIONS = [markdownSyntaxExtension, gfmTable()]
+const MARKDOWN_EXTENSIONS = [markdownSyntaxExtension, frontmatter(), gfmTable()]
 
 const markdownEvents = (source: string) => {
   const input = parserInput(source)
@@ -72,7 +73,7 @@ const markdownEvents = (source: string) => {
 type MarkdownEvents = ReturnType<typeof markdownEvents>
 type MarkdownToken = MarkdownEvents[number][1]
 
-const NON_PROSE_BLOCK_TOKENS = new Set(["codeFenced", "codeIndented", "table"])
+const NON_PROSE_BLOCK_TOKENS = new Set(["codeFenced", "codeIndented", "table", "yaml"])
 const CONTAINER_TOKENS = new Set(["blockQuotePrefix", "listItemIndent", "listItemPrefix"])
 const DICTIONARY_TOKENS = new Set([
   "atxHeadingSequence",

--- a/test/engine/README.md
+++ b/test/engine/README.md
@@ -26,6 +26,7 @@ Cross-cutting Markdown masks use the same finding, clean, and boundary audit at 
 | Feature | Finding | Clean | Boundary |
 | --- | --- | --- | --- |
 | GFM tables | Yes. `lints prose around a table at its original positions`. | Yes. `masks a valid multi-row GFM table from all prose rules`. | Yes. `does not mask table-like text with mismatched delimiter cells`. |
+| YAML frontmatter | Yes. `lints prose after frontmatter at its original position`. | Yes. `masks YAML frontmatter from all prose rules`. | Yes. `does not mask a thematic break in the middle of a document`. |
 
 Diff-only behavior has a separate engine seam in `diff-match.test.ts`.
 Tests at that seam call `newFindings` directly.

--- a/test/engine/frontmatter.test.ts
+++ b/test/engine/frontmatter.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest"
+import type { Dictionary } from "../../src/dictionary/schema.ts"
+import { lint } from "../../src/engine/lint.ts"
+import type { TaggedToken, Tagger } from "../../src/engine/tagger.ts"
+
+const dictionary = {
+  formatVersion: 1,
+  source: {
+    name: "test fixture",
+    repository: "https://example.test/dictionary",
+    commit: "fixture",
+    path: "dictionary.json",
+  },
+  entries: [{ unapproved: ["attempt"], suggestions: ["try"] }],
+} as const satisfies Dictionary
+
+const tagger: Tagger = (line) => {
+  if (line !== "author: someone has trusted") return []
+
+  return [
+    { text: "has", pos: "AUX", lemma: "have", offset: 16 },
+    { text: "trusted", pos: "VERB", lemma: "trust", offset: 20 },
+  ] satisfies TaggedToken[]
+}
+
+const words = (count: number): string =>
+  Array.from({ length: count }, (_, index) => `word${index + 1}`).join(" ")
+
+describe("lint prose-file: YAML frontmatter masking", () => {
+  test("masks YAML frontmatter from all prose rules", () => {
+    const text = [
+      "---",
+      "title: A seamless attempt as mentioned.",
+      "note: It isn't ready and must carry out this task; retry it.",
+      `summary: ${words(26)}.`,
+      "sentences: One. Two. Three. Four. Five. Six. Seven.",
+      "author: someone has trusted",
+      "---",
+      "",
+      "Body text here.",
+    ].join("\n")
+
+    expect(lint("prose-file", text, { dictionary, tagger }).violations).toEqual([])
+  })
+
+  test("lints prose after frontmatter at its original position", () => {
+    const text = ["---", "title: Plain metadata", "---", "This isn't ready."].join("\n")
+
+    expect(lint("prose-file", text).violations).toEqual([
+      expect.objectContaining({ ruleId: "contraction", line: 4, column: 6 }),
+    ])
+  })
+
+  test("does not mask a thematic break in the middle of a document", () => {
+    const text = ["Intro text.", "", "---", "title: This isn't hidden.", "---"].join("\n")
+
+    expect(lint("prose-file", text).violations).toEqual([
+      expect.objectContaining({ ruleId: "contraction", line: 4, column: 13 }),
+    ])
+  })
+
+  test("keeps changed frontmatter out of diff-only findings", () => {
+    const previousText = ["---", "title: Plain metadata", "---", "Body text."].join("\n")
+    const text = ["---", "title: It isn't visible", "---", "Body text."].join("\n")
+
+    expect(lint("prose-file", text, { previousText }).violations).toEqual([])
+  })
+})


### PR DESCRIPTION
## Intent

Fix Linear ticket HUF-164 in the ste engine by masking YAML frontmatter as non-prose in the existing Markdown analysis. YAML frontmatter keys and values must raise no violations from any rule. Prose after the closing frontmatter fence must still be linted, with violation positions mapped to the original file. A thematic break in the middle of a document must keep its current behavior. Use the frontmatter syntax extension from the existing CommonMark parser stack, and keep any new syntax package in runtime dependencies for the pi install flow. Keep this change in the pure Engine with no Adapter or Host changes. Add finding, clean, boundary, position-mapping, and diff-composition coverage at the pure Engine seam, and list the finding, clean, and boundary cases in test/engine/README.md. Follow TDD by reproducing the failure before implementing the fix. Copy and run the supplied fp-probe.ts from the worktree root, but do not commit it. Do not format test/fixtures because their exact byte positions are pinned. Validate with bun run test, bun run lint, and bun run typecheck. This ticket covers only the frontmatter half of HUF-161 mitigation 2. CLI E2E coverage is out of scope.

## What Changed

- Mask YAML frontmatter during Markdown analysis while preserving original positions and linting subsequent prose.
- Keep mid-document thematic breaks unchanged and exclude frontmatter edits from diff-only findings.
- Add the frontmatter syntax extension as a runtime dependency, with engine coverage and documentation updates.

## Risk Assessment

✅ Low: The change is narrowly scoped, uses the requested parser extension, preserves source offsets, and includes the required Engine-seam coverage.

## Testing

With no baseline results supplied, I restored locked dependencies, ran focused frontmatter and shared Markdown tests, demonstrated through the Engine API that YAML suppresses all registered rules while body and thematic-break findings retain original positions and diff-only changes stay clean, and verified the packaged runtime-only install can import the syntax extension. No full suite, lint, or typecheck was run under this test-phase boundary. The non-UI evidence is captured as JSON and command output, but the required supplied fp-probe was unavailable.

<details>
<summary>Evidence: Engine API frontmatter behavior</summary>

```text
{
  "allRegisteredRulesTriggeredWithoutMask": [
    "contraction",
    "dictionary-not-approved-word",
    "hedging",
    "marketing",
    "paragraph-length",
    "phrasal-verb",
    "semicolon",
    "sentence-length",
    "verb-passive",
    "verb-perfect",
    "verb-progressive"
  ],
  "sameViolatingValuesUsedAsYamlFrontmatter": {
    "violations": [],
    "summary": {
      "total": 0,
      "hard": 0
    }
  },
  "proseAfterClosingFence": {
    "violations": [
      {
        "ruleId": "contraction",
        "severity": "hard",
        "message": "Do not use a contraction. Write the words in full. Found \"isn't\".",
        "line": 4,
        "column": 6
      }
    ],
    "summary": {
      "total": 1,
      "hard": 1
    }
  },
  "thematicBreakInDocumentMiddle": {
    "violations": [
      {
        "ruleId": "contraction",
        "severity": "hard",
        "message": "Do not use a contraction. Write the words in full. Found \"isn't\".",
        "line": 4,
        "column": 13
      }
    ],
    "summary": {
      "total": 1,
      "hard": 1
    }
  },
  "frontmatterOnlyDiff": {
    "violations": [],
    "summary": {
      "total": 0,
      "hard": 0
    }
  }
}
```
</details>
<details>
<summary>Evidence: Reproducible Engine API evidence script</summary>

```text
import assert from "node:assert/strict"
import type { Dictionary } from "/home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KZ5GFGWKYSHNPRASS09878XE/src/dictionary/schema.ts"
import { lint } from "/home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KZ5GFGWKYSHNPRASS09878XE/src/engine/lint.ts"
import { ruleIds } from "/home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KZ5GFGWKYSHNPRASS09878XE/src/engine/rules/registry.ts"
import type { TaggedToken, Tagger } from "/home/jyooi/.no-mistakes/worktrees/5b49eff34526/01KZ5GFGWKYSHNPRASS09878XE/src/engine/tagger.ts"

const dictionary = {
  formatVersion: 1,
  source: {
    name: "evidence fixture",
    repository: "https://example.test/dictionary",
    commit: "evidence",
    path: "dictionary.json",
  },
  entries: [{ unapproved: ["attempt"], suggestions: ["try"] }],
} as const satisfies Dictionary

const tagger: Tagger = (line) => {
  const patterns: ReadonlyArray<readonly [string, string, string]> = [
    ["is", "running", "run"],
    ["was", "removed", "remove"],
    ["has", "finished", "finish"],
  ]
  const match = patterns.find(([auxiliary, verb]) => line.includes(`${auxiliary} ${verb}`))
  if (match === undefined) return []
  const [auxiliary, verb, lemma] = match
  return [
    { text: auxiliary, pos: "AUX", lemma: auxiliary === "has" ? "have" : "be", offset: line.indexOf(auxiliary) },
    { text: verb, pos: "VERB", lemma, offset: line.indexOf(verb) },
  ] satisfies TaggedToken[]
}

const words = Array.from({ length: 26 }, (_, index) => `word${index + 1}`).join(" ")
const triggeringValues = [
  "It isn't ready.",
  "Attempt the repair.",
  "It is important to note that the lock is held.",
  "This is a seamless flow.",
  "Carry out the test.",
  "Use this; then continue.",
  `${words}.`,
  "One. Two. Three. Four. Five. Six. Seven.",
  "The pump is running.",
  "The bolt was removed.",
  "The technician has finished the task.",
]
const options = { dictionary, tagger }

const unmaskedReport = lint("prose-file", triggeringValues.join("\n\n"), options)
const unmaskedRuleIds = [...new Set(unmaskedReport.violations.map(({ ruleId }) => ruleId))].sort()
assert.deepEqual(unmaskedRuleIds, [...ruleIds].sort())

const frontmatter = [
  "---",
  ...triggeringValues.map((value, index) => `field${index + 1}: ${value}`),
  "---",
  "Body text here.",
].join("\n")
const frontmatterReport = lint("prose-file", frontmatter, options)
assert.deepEqual(frontmatterReport.violations, [])

const bodyText = ["---", "title: It isn't hidden here.", "---", "Body isn't ready."].join("\n")
const bodyReport = lint("prose-file", bodyText)
assert.deepEqual(
  bodyReport.violations.map(({ ruleId, line, column }) => ({ ruleId, line, column })),
  [{ ruleId: "contraction", line: 4, column: 6 }],
)

const middleBreakText = ["Intro text.", "", "---", "title: This isn't hidden.", "---"].join("\n")
const middleBreakReport = lint("prose-file", middleBreakText)
assert.deepEqual(
  middleBreakReport.violations.map(({ ruleId, line, column }) => ({ ruleId, line, column })),
  [{ ruleId: "contraction", line: 4, column: 13 }],
)

const previousText = ["---", "title: Plain metadata", "---", "Body text."].join("\n")
const changedFrontmatterText = ["---", "title: It isn't visible", "---", "Body text."].join("\n")
const diffReport = lint("prose-file", changedFrontmatterText, { previousText })
assert.deepEqual(diffReport.violations, [])

console.log(
  JSON.stringify(
    {
      allRegisteredRulesTriggeredWithoutMask: unmaskedRuleIds,
      sameViolatingValuesUsedAsYamlFrontmatter: frontmatterReport,
      proseAfterClosingFence: bodyReport,
      thematicBreakInDocumentMiddle: middleBreakReport,
      frontmatterOnlyDiff: diffReport,
    },
    null,
    2,
  ),
)
```
</details>
<details>
<summary>Evidence: Runtime-only dependency installation and import</summary>

```text
Runtime-only install dependency tree:
runtime-install@ /tmp/no-mistakes-evidence/01KZ5GFGWKYSHNPRASS09878XE/runtime-install
└─┬ agent-simple-english@0.1.0
  └── micromark-extension-frontmatter@2.0.0


Runtime import check:
frontmatter extension import: OK
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `fp-probe.ts` - The required supplied fp-probe.ts was not present at the worktree root, so this phase could not copy and run it. Provide the probe or confirm that the equivalent Engine API evidence is acceptable.
- <code>`bun run test -- test/engine/frontmatter.test.ts` initially failed because dependencies were absent</code>
- <code>`bun install --frozen-lockfile` restored the locked test environment</code>
- `bun run test -- test/engine/frontmatter.test.ts`
- `bun run test -- test/engine/frontmatter.test.ts test/engine/markdown.test.ts`
- `bun /tmp/no-mistakes-evidence/01KZ5GFGWKYSHNPRASS09878XE/frontmatter-engine-evidence.ts | tee /tmp/no-mistakes-evidence/01KZ5GFGWKYSHNPRASS09878XE/frontmatter-engine-output.json`
- <code>`npm pack`, followed by `npm install --omit=dev --ignore-scripts` and a runtime import of `micromark-extension-frontmatter`</code>
- <code>`find . -maxdepth 2 -name &#39;*fp-probe*&#39; -o -name &#39;fp-probe.ts&#39;` found no supplied probe</code>
- <code>Removed generated `node_modules` and confirmed the worktree remained clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
