### PR TITLE
feat(engine): exempt block quotes from wording rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ This example contains every config key and every rule:
 ```json
 {
   "maxSentenceWords": 25,
+  "exemptBlockQuotes": true,
   "approvedWordsPath": "./approved-words.json",
   "ruleDataExtensions": {
     "phrasal-verb": ["config/phrasal-verbs.json"],
@@ -302,6 +303,9 @@ A soft violation produces a report or warning but does not block the action.
 The `off` value disables that rule.
 
 `maxSentenceWords` must be a positive integer and has a default value of 25.
+`exemptBlockQuotes` must be a boolean and has a default value of `false`.
+When it is `true`, block-quote content is exempt from dictionary, contraction, phrasal-verb, hedging, and marketing checks.
+All other rules continue to check block-quote content.
 `approvedWordsPath` selects a user-owned approved-word list.
 The loader resolves a relative path from the working directory that requested the config.
 This list replaces the bundled not-approved sample and any `SIMPLE_ENGLISH_DICTIONARY` replacement.

--- a/README.md
+++ b/README.md
@@ -304,8 +304,9 @@ The `off` value disables that rule.
 
 `maxSentenceWords` must be a positive integer and has a default value of 25.
 `exemptBlockQuotes` must be a boolean and has a default value of `false`.
-When it is `true`, block-quote content is exempt from dictionary, contraction, phrasal-verb, hedging, and marketing checks.
-All other rules continue to check block-quote content.
+When it is omitted or `false`, block quotes receive the same checks as other prose.
+When it is `true`, CommonMark block quote content is exempt from `dictionary-not-approved-word`, `contraction`, `phrasal-verb`, `hedging`, and `marketing` checks.
+All other rules continue to check block quote content.
 `approvedWordsPath` selects a user-owned approved-word list.
 The loader resolves a relative path from the working directory that requested the config.
 This list replaces the bundled not-approved sample and any `SIMPLE_ENGLISH_DICTIONARY` replacement.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,6 +6,7 @@ import type { RuleSetting } from "../engine/types.ts"
 export interface SteConfig {
   readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
   readonly maxSentenceWords?: number
+  readonly exemptBlockQuotes?: boolean
   readonly ruleDataExtensions?: RuleDataExtensions
   readonly approvedWordsPath?: string
 }
@@ -28,6 +29,13 @@ const MaxSentenceWordsSchema = Schema.Int.pipe(Schema.positive()).annotations({
   }),
 })
 
+const ExemptBlockQuotesSchema = Schema.Boolean.annotations({
+  message: (issue) => ({
+    message: `must be a boolean, got ${JSON.stringify(issue.actual)}`,
+    override: true,
+  }),
+})
+
 const RuleDataExtensionsSchema = Schema.partial(
   Schema.Struct({
     "phrasal-verb": Schema.Array(Schema.NonEmptyTrimmedString),
@@ -40,6 +48,7 @@ const RuleDataExtensionsSchema = Schema.partial(
 const SteConfigSchema = Schema.Struct({
   rules: Schema.optional(RulesSchema),
   maxSentenceWords: Schema.optional(MaxSentenceWordsSchema),
+  exemptBlockQuotes: Schema.optional(ExemptBlockQuotesSchema),
   ruleDataExtensions: Schema.optional(RuleDataExtensionsSchema),
   approvedWordsPath: Schema.optional(Schema.NonEmptyTrimmedString),
 })

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -48,6 +48,7 @@ interface PreparedProse {
   readonly wordingDictionaryLines: readonly string[]
   readonly wordingStructuralLines: readonly string[]
   readonly structuralBlanks: readonly boolean[]
+  readonly wordingStructuralBlanks: readonly boolean[]
 }
 
 interface SentenceScopeIndex {
@@ -141,6 +142,7 @@ const prepareProse = (
     wordingDictionaryLines,
     wordingStructuralLines,
     structuralBlanks: markdown.structuralBlanks,
+    wordingStructuralBlanks: markdown.wordingStructuralBlanks,
   }
 }
 
@@ -262,7 +264,7 @@ const lintProse = (
         segmentSentences(
           prepared.wordingLines,
           prepared.wordingLines.join("\n"),
-          prepared.structuralBlanks,
+          prepared.wordingStructuralBlanks,
         ),
         prepared.wordingLines.length,
         sourceOffset,
@@ -274,7 +276,7 @@ const lintProse = (
         segmentSentences(
           prepared.wordingDictionaryLines,
           prepared.wordingDictionaryLines.join("\n"),
-          prepared.structuralBlanks,
+          prepared.wordingStructuralBlanks,
         ),
         prepared.wordingDictionaryLines.length,
         sourceOffset,

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -257,6 +257,17 @@ const lintProse = (
   )
   const offsets = lineOffsets(prepared.structuralLines)
   const sentenceIndex = indexSentenceScopes(sentences, prepared.lines.length, sourceOffset)
+  const wordingSentenceIndex = options.exemptBlockQuotes
+    ? indexSentenceScopes(
+        segmentSentences(
+          prepared.wordingLines,
+          prepared.wordingLines.join("\n"),
+          prepared.structuralBlanks,
+        ),
+        prepared.wordingLines.length,
+        sourceOffset,
+      )
+    : sentenceIndex
   const approvedWordMode = isApprovedWordMode(options.dictionary)
   const dictionarySentenceIndex = approvedWordMode
     ? indexSentenceScopes(
@@ -268,7 +279,7 @@ const lintProse = (
         prepared.wordingDictionaryLines.length,
         sourceOffset,
       )
-    : sentenceIndex
+    : wordingSentenceIndex
   const sentenceFindings = (
     violations: readonly Violation[],
     findingSentenceIndex: SentenceScopeIndex = sentenceIndex,
@@ -289,6 +300,12 @@ const lintProse = (
         occurrenceOffset: sourceOffset + (offsets[violation.line - 1] ?? 0) + violation.column - 1,
       }
     })
+  const wordingFindings = (violations: readonly Violation[]): ScopedViolation[] =>
+    sentenceFindings(
+      violations,
+      wordingSentenceIndex,
+      options.exemptBlockQuotes ? prepared.wordingLines : prepared.structuralLines,
+    )
 
   return [
     ...sentences.flatMap((sentence) =>
@@ -303,17 +320,17 @@ const lintProse = (
         scope: paragraphScope(paragraph, prepared.structuralLines, offsets, sourceOffset),
       })),
     ),
-    ...sentenceFindings(contraction(prepared.wordingLines)),
+    ...wordingFindings(contraction(prepared.wordingLines)),
     ...sentenceFindings(semicolon(prepared.lines)),
     ...(options.ruleData?.["phrasal-verb"] === undefined
       ? []
-      : sentenceFindings(phrasalVerb(prepared.wordingLines, options.ruleData["phrasal-verb"]))),
+      : wordingFindings(phrasalVerb(prepared.wordingLines, options.ruleData["phrasal-verb"]))),
     ...(options.ruleData?.hedging === undefined
       ? []
-      : sentenceFindings(hedging(prepared.wordingLines, options.ruleData.hedging))),
+      : wordingFindings(hedging(prepared.wordingLines, options.ruleData.hedging))),
     ...(options.ruleData?.marketing === undefined
       ? []
-      : sentenceFindings(marketing(prepared.wordingLines, options.ruleData.marketing))),
+      : wordingFindings(marketing(prepared.wordingLines, options.ruleData.marketing))),
     ...(options.dictionary === undefined
       ? []
       : sentenceFindings(

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -43,7 +43,6 @@ interface ProseRun extends ExtractedProse {
 
 interface PreparedProse {
   readonly lines: readonly string[]
-  readonly dictionaryLines: readonly string[]
   readonly structuralLines: readonly string[]
   readonly wordingLines: readonly string[]
   readonly wordingDictionaryLines: readonly string[]
@@ -124,16 +123,23 @@ const prepareProse = (
     exemptBlockQuotes,
   )
   const lines = blankIdentifiers(markdown.lines)
-  const wordingLines = blankIdentifiers(markdown.wordingLines)
+  const structuralLines = blankIdentifiers(markdown.structuralLines)
+  const wordingLines = exemptBlockQuotes ? blankIdentifiers(markdown.wordingLines) : lines
+  const wordingStructuralLines = exemptBlockQuotes
+    ? blankIdentifiers(markdown.wordingStructuralLines)
+    : structuralLines
+  const wordingDictionaryLines = approvedWordMode
+    ? blankIdentifiers(
+        exemptBlockQuotes ? markdown.wordingDictionaryLines : markdown.dictionaryLines,
+      )
+    : wordingLines
+
   return {
     lines,
-    dictionaryLines: approvedWordMode ? blankIdentifiers(markdown.dictionaryLines) : lines,
-    structuralLines: blankIdentifiers(markdown.structuralLines),
+    structuralLines,
     wordingLines,
-    wordingDictionaryLines: approvedWordMode
-      ? blankIdentifiers(markdown.wordingDictionaryLines)
-      : wordingLines,
-    wordingStructuralLines: blankIdentifiers(markdown.wordingStructuralLines),
+    wordingDictionaryLines,
+    wordingStructuralLines,
     structuralBlanks: markdown.structuralBlanks,
   }
 }

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -23,6 +23,7 @@ export const DEFAULT_MAX_SENTENCE_WORDS = 25
 
 interface ResolvedOptions {
   readonly maxSentenceWords: number
+  readonly exemptBlockQuotes: boolean
   readonly dictionary?: CompiledDictionary
   readonly ruleData?: RuleData
   readonly tagger?: Tagger
@@ -44,6 +45,9 @@ interface PreparedProse {
   readonly lines: readonly string[]
   readonly dictionaryLines: readonly string[]
   readonly structuralLines: readonly string[]
+  readonly wordingLines: readonly string[]
+  readonly wordingDictionaryLines: readonly string[]
+  readonly wordingStructuralLines: readonly string[]
   readonly structuralBlanks: readonly boolean[]
 }
 
@@ -108,14 +112,28 @@ const extract = (kind: LintKind, text: string, options: LintOptions): ExtractedP
 const isApprovedWordMode = (dictionary: CompiledDictionary | undefined): boolean =>
   dictionary?.mode === "approved-words"
 
-const prepareProse = (extracted: ProseRun, approvedWordMode: boolean): PreparedProse => {
-  const markdown = blankMarkdownForLint(extracted.lines, extracted.contentStarts, approvedWordMode)
+const prepareProse = (
+  extracted: ProseRun,
+  approvedWordMode: boolean,
+  exemptBlockQuotes: boolean,
+): PreparedProse => {
+  const markdown = blankMarkdownForLint(
+    extracted.lines,
+    extracted.contentStarts,
+    approvedWordMode,
+    exemptBlockQuotes,
+  )
   const lines = blankIdentifiers(markdown.lines)
-  const dictionaryLines = approvedWordMode ? blankIdentifiers(markdown.dictionaryLines) : lines
+  const wordingLines = blankIdentifiers(markdown.wordingLines)
   return {
     lines,
-    dictionaryLines,
+    dictionaryLines: approvedWordMode ? blankIdentifiers(markdown.dictionaryLines) : lines,
     structuralLines: blankIdentifiers(markdown.structuralLines),
+    wordingLines,
+    wordingDictionaryLines: approvedWordMode
+      ? blankIdentifiers(markdown.wordingDictionaryLines)
+      : wordingLines,
+    wordingStructuralLines: blankIdentifiers(markdown.wordingStructuralLines),
     structuralBlanks: markdown.structuralBlanks,
   }
 }
@@ -237,11 +255,11 @@ const lintProse = (
   const dictionarySentenceIndex = approvedWordMode
     ? indexSentenceScopes(
         segmentSentences(
-          prepared.dictionaryLines,
-          prepared.dictionaryLines.join("\n"),
+          prepared.wordingDictionaryLines,
+          prepared.wordingDictionaryLines.join("\n"),
           prepared.structuralBlanks,
         ),
-        prepared.dictionaryLines.length,
+        prepared.wordingDictionaryLines.length,
         sourceOffset,
       )
     : sentenceIndex
@@ -279,29 +297,29 @@ const lintProse = (
         scope: paragraphScope(paragraph, prepared.structuralLines, offsets, sourceOffset),
       })),
     ),
-    ...sentenceFindings(contraction(prepared.lines)),
+    ...sentenceFindings(contraction(prepared.wordingLines)),
     ...sentenceFindings(semicolon(prepared.lines)),
     ...(options.ruleData?.["phrasal-verb"] === undefined
       ? []
-      : sentenceFindings(phrasalVerb(prepared.lines, options.ruleData["phrasal-verb"]))),
+      : sentenceFindings(phrasalVerb(prepared.wordingLines, options.ruleData["phrasal-verb"]))),
     ...(options.ruleData?.hedging === undefined
       ? []
-      : sentenceFindings(hedging(prepared.lines, options.ruleData.hedging))),
+      : sentenceFindings(hedging(prepared.wordingLines, options.ruleData.hedging))),
     ...(options.ruleData?.marketing === undefined
       ? []
-      : sentenceFindings(marketing(prepared.lines, options.ruleData.marketing))),
+      : sentenceFindings(marketing(prepared.wordingLines, options.ruleData.marketing))),
     ...(options.dictionary === undefined
       ? []
       : sentenceFindings(
           dictionaryRule(
-            prepared.structuralLines,
+            prepared.wordingStructuralLines,
             options.dictionary,
             options.tagger,
             contentStarts,
-            prepared.dictionaryLines,
+            prepared.wordingDictionaryLines,
           ),
           dictionarySentenceIndex,
-          approvedWordMode ? prepared.dictionaryLines : prepared.structuralLines,
+          approvedWordMode ? prepared.wordingDictionaryLines : prepared.wordingStructuralLines,
         )),
     ...(options.tagger === undefined
       ? []
@@ -313,7 +331,7 @@ const lintProse = (
 
 const lintExtracted = (extracted: ProseRun, options: ResolvedOptions): ScopedViolation[] =>
   lintProse(
-    prepareProse(extracted, isApprovedWordMode(options.dictionary)),
+    prepareProse(extracted, isApprovedWordMode(options.dictionary), options.exemptBlockQuotes),
     extracted.contentStarts,
     extracted.sourceOffset,
     options,
@@ -361,6 +379,7 @@ function evaluate(
 export function lint(kind: LintKind, text: string, options: LintOptions = {}): LintReport {
   const resolved: ResolvedOptions = {
     maxSentenceWords: options.maxSentenceWords ?? DEFAULT_MAX_SENTENCE_WORDS,
+    exemptBlockQuotes: options.exemptBlockQuotes ?? false,
     dictionary:
       options.dictionary === undefined ? undefined : compileDictionary(options.dictionary),
     ruleData: options.ruleData ?? BUNDLED_RULE_DATA,

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -345,13 +345,21 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
   const events = markdownEvents(state.source)
   const definitionEnds = includeDictionary ? definitionMaskEnds(events) : new Map<number, number>()
   const htmlFlows: SourceRange[] = []
+  let blockQuoteDepth = 0
 
   for (const [phase, token] of events) {
+    if (token.type === "blockQuote" && state.blockQuoteMask !== undefined) {
+      if (phase === "enter") {
+        if (blockQuoteDepth === 0) {
+          markRange(state.blockQuoteMask, token.start.offset, token.end.offset)
+        }
+        blockQuoteDepth++
+      } else {
+        blockQuoteDepth--
+      }
+    }
     if (phase !== "enter") continue
 
-    if (token.type === "blockQuote" && state.blockQuoteMask !== undefined) {
-      markRange(state.blockQuoteMask, token.start.offset, token.end.offset)
-    }
     if (NON_PROSE_BLOCK_TOKENS.has(token.type)) {
       markNonProseBlock(state, token)
       continue

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -14,6 +14,7 @@ interface MarkdownAnalysis {
   readonly wordingStructuralLines: string[]
   readonly wordingDictionaryLines: string[]
   readonly structuralBlanks: boolean[]
+  readonly wordingStructuralBlanks: boolean[]
 }
 
 export interface MarkdownCodeResult {
@@ -32,6 +33,7 @@ interface AnalysisState {
   readonly dictionaryMask: Uint8Array
   readonly containerMask: Uint8Array
   readonly blockQuoteMask: Uint8Array | undefined
+  readonly blockQuoteLines: Uint8Array | undefined
   readonly structuralBlanks: boolean[]
 }
 
@@ -144,6 +146,7 @@ const createAnalysisState = (
     dictionaryMask: new Uint8Array(source.length),
     containerMask: new Uint8Array(source.length),
     blockQuoteMask: exemptBlockQuotes ? new Uint8Array(source.length) : undefined,
+    blockQuoteLines: exemptBlockQuotes ? new Uint8Array(parseLines.length) : undefined,
     structuralBlanks: parseLines.map((line) => line.trim() === ""),
   }
 }
@@ -166,6 +169,16 @@ const markContainerOnlyLinesAsBlank = (state: AnalysisState): void => {
 
     if (hasContainer && !hasOtherContent) state.structuralBlanks[line] = true
   }
+}
+
+const markBlockQuote = (state: AnalysisState, token: MarkdownToken): void => {
+  if (state.blockQuoteMask === undefined || state.blockQuoteLines === undefined) return
+
+  markRange(state.blockQuoteMask, token.start.offset, token.end.offset)
+  const firstLine = state.lineAtOffset[Math.min(token.start.offset, state.source.length)] ?? 0
+  const lastOffset = Math.max(token.start.offset, token.end.offset - 1)
+  const lastLine = state.lineAtOffset[Math.min(lastOffset, state.source.length)] ?? firstLine
+  state.blockQuoteLines.fill(1, firstLine, lastLine + 1)
 }
 
 const markNonProseBlock = (state: AnalysisState, token: MarkdownToken): void => {
@@ -350,9 +363,7 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
   for (const [phase, token] of events) {
     if (token.type === "blockQuote" && state.blockQuoteMask !== undefined) {
       if (phase === "enter") {
-        if (blockQuoteDepth === 0) {
-          markRange(state.blockQuoteMask, token.start.offset, token.end.offset)
-        }
+        if (blockQuoteDepth === 0) markBlockQuote(state, token)
         blockQuoteDepth++
       } else {
         blockQuoteDepth--
@@ -434,6 +445,7 @@ const analyzeMarkdown = (
       wordingStructuralLines: [],
       wordingDictionaryLines: [],
       structuralBlanks: [],
+      wordingStructuralBlanks: [],
     }
   }
 
@@ -500,6 +512,12 @@ const analyzeMarkdown = (
             wordingMask,
           ),
     structuralBlanks: state.structuralBlanks,
+    wordingStructuralBlanks:
+      state.blockQuoteLines === undefined
+        ? state.structuralBlanks
+        : state.structuralBlanks.map(
+            (blank, lineIndex) => blank || state.blockQuoteLines?.[lineIndex] === 1,
+          ),
   }
 }
 

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -10,6 +10,9 @@ interface MarkdownAnalysis {
   readonly lines: string[]
   readonly structuralLines: string[]
   readonly dictionaryLines: string[]
+  readonly wordingLines: string[]
+  readonly wordingStructuralLines: string[]
+  readonly wordingDictionaryLines: string[]
   readonly structuralBlanks: boolean[]
 }
 
@@ -28,6 +31,7 @@ interface AnalysisState {
   readonly structuralMask: Uint8Array
   readonly dictionaryMask: Uint8Array
   readonly containerMask: Uint8Array
+  readonly blockQuoteMask: Uint8Array
   readonly structuralBlanks: boolean[]
 }
 
@@ -135,6 +139,7 @@ const createAnalysisState = (source: string, parseLines: readonly string[]): Ana
     structuralMask: new Uint8Array(source.length),
     dictionaryMask: new Uint8Array(source.length),
     containerMask: new Uint8Array(source.length),
+    blockQuoteMask: new Uint8Array(source.length),
     structuralBlanks: parseLines.map((line) => line.trim() === ""),
   }
 }
@@ -340,6 +345,9 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
   for (const [phase, token] of events) {
     if (phase !== "enter") continue
 
+    if (token.type === "blockQuote") {
+      markRange(state.blockQuoteMask, token.start.offset, token.end.offset)
+    }
     if (NON_PROSE_BLOCK_TOKENS.has(token.type)) {
       markNonProseBlock(state, token)
       continue
@@ -380,6 +388,7 @@ const applyMask = (
   parseLines: readonly string[],
   sourceLineStarts: readonly number[],
   mask: Uint8Array,
+  additionalMask?: Uint8Array,
 ): string[] =>
   lines.map((line, lineIndex) => {
     const characters = line.split("")
@@ -388,7 +397,12 @@ const applyMask = (
     const parseLine = parseLines[lineIndex] ?? ""
 
     for (let column = 0; column < parseLine.length; column++) {
-      if (mask[sourceStart + column] !== 0) characters[contentStart + column] = " "
+      if (
+        mask[sourceStart + column] !== 0 ||
+        (additionalMask !== undefined && additionalMask[sourceStart + column] !== 0)
+      ) {
+        characters[contentStart + column] = " "
+      }
     }
     return characters.join("")
   })
@@ -397,9 +411,18 @@ const analyzeMarkdown = (
   lines: readonly string[],
   contentStarts: readonly number[] = lines.map(() => 0),
   includeDictionary = true,
+  exemptBlockQuotes = false,
 ): MarkdownAnalysis => {
   if (lines.length === 0) {
-    return { lines: [], structuralLines: [], dictionaryLines: [], structuralBlanks: [] }
+    return {
+      lines: [],
+      structuralLines: [],
+      dictionaryLines: [],
+      wordingLines: [],
+      wordingStructuralLines: [],
+      wordingDictionaryLines: [],
+      structuralBlanks: [],
+    }
   }
 
   const starts = lines.map((line, index) =>
@@ -410,22 +433,60 @@ const analyzeMarkdown = (
   const state = createAnalysisState(source, parseLines)
   analyzeEvents(state, includeDictionary)
 
+  const proseLines = applyMask(lines, starts, parseLines, state.sourceLineStarts, state.proseMask)
+  const structuralLines = applyMask(
+    lines,
+    starts,
+    parseLines,
+    state.sourceLineStarts,
+    state.structuralMask,
+  )
+  const dictionaryLines = applyMask(
+    lines,
+    starts,
+    parseLines,
+    state.sourceLineStarts,
+    state.dictionaryMask,
+  )
+  const wordingMask = exemptBlockQuotes ? state.blockQuoteMask : undefined
+
   return {
-    lines: applyMask(lines, starts, parseLines, state.sourceLineStarts, state.proseMask),
-    structuralLines: applyMask(
-      lines,
-      starts,
-      parseLines,
-      state.sourceLineStarts,
-      state.structuralMask,
-    ),
-    dictionaryLines: applyMask(
-      lines,
-      starts,
-      parseLines,
-      state.sourceLineStarts,
-      state.dictionaryMask,
-    ),
+    lines: proseLines,
+    structuralLines,
+    dictionaryLines,
+    wordingLines:
+      wordingMask === undefined
+        ? proseLines
+        : applyMask(
+            lines,
+            starts,
+            parseLines,
+            state.sourceLineStarts,
+            state.proseMask,
+            wordingMask,
+          ),
+    wordingStructuralLines:
+      wordingMask === undefined
+        ? structuralLines
+        : applyMask(
+            lines,
+            starts,
+            parseLines,
+            state.sourceLineStarts,
+            state.structuralMask,
+            wordingMask,
+          ),
+    wordingDictionaryLines:
+      wordingMask === undefined
+        ? dictionaryLines
+        : applyMask(
+            lines,
+            starts,
+            parseLines,
+            state.sourceLineStarts,
+            state.dictionaryMask,
+            wordingMask,
+          ),
     structuralBlanks: state.structuralBlanks,
   }
 }
@@ -434,8 +495,9 @@ export function blankMarkdownForLint(
   inputLines: readonly string[],
   contentStarts: readonly number[],
   includeDictionary: boolean,
+  exemptBlockQuotes = false,
 ): MarkdownAnalysis {
-  return analyzeMarkdown(inputLines, contentStarts, includeDictionary)
+  return analyzeMarkdown(inputLines, contentStarts, includeDictionary, exemptBlockQuotes)
 }
 
 export function blankMarkdownCodeWithStructure(

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -31,7 +31,7 @@ interface AnalysisState {
   readonly structuralMask: Uint8Array
   readonly dictionaryMask: Uint8Array
   readonly containerMask: Uint8Array
-  readonly blockQuoteMask: Uint8Array
+  readonly blockQuoteMask: Uint8Array | undefined
   readonly structuralBlanks: boolean[]
 }
 
@@ -118,7 +118,11 @@ const markRange = (mask: Uint8Array, start: number, end: number): void => {
   mask.fill(1, Math.max(0, start), Math.min(mask.length, end))
 }
 
-const createAnalysisState = (source: string, parseLines: readonly string[]): AnalysisState => {
+const createAnalysisState = (
+  source: string,
+  parseLines: readonly string[],
+  exemptBlockQuotes: boolean,
+): AnalysisState => {
   const sourceLineStarts: number[] = []
   const lineAtOffset = new Int32Array(source.length + 1)
   let offset = 0
@@ -139,7 +143,7 @@ const createAnalysisState = (source: string, parseLines: readonly string[]): Ana
     structuralMask: new Uint8Array(source.length),
     dictionaryMask: new Uint8Array(source.length),
     containerMask: new Uint8Array(source.length),
-    blockQuoteMask: new Uint8Array(source.length),
+    blockQuoteMask: exemptBlockQuotes ? new Uint8Array(source.length) : undefined,
     structuralBlanks: parseLines.map((line) => line.trim() === ""),
   }
 }
@@ -345,7 +349,7 @@ const analyzeEvents = (state: AnalysisState, includeDictionary: boolean): void =
   for (const [phase, token] of events) {
     if (phase !== "enter") continue
 
-    if (token.type === "blockQuote") {
+    if (token.type === "blockQuote" && state.blockQuoteMask !== undefined) {
       markRange(state.blockQuoteMask, token.start.offset, token.end.offset)
     }
     if (NON_PROSE_BLOCK_TOKENS.has(token.type)) {
@@ -430,7 +434,7 @@ const analyzeMarkdown = (
   )
   const parseLines = lines.map((line, index) => line.slice(starts[index]))
   const source = parseLines.join("\n")
-  const state = createAnalysisState(source, parseLines)
+  const state = createAnalysisState(source, parseLines, exemptBlockQuotes)
   analyzeEvents(state, includeDictionary)
 
   const proseLines = applyMask(lines, starts, parseLines, state.sourceLineStarts, state.proseMask)
@@ -448,7 +452,7 @@ const analyzeMarkdown = (
     state.sourceLineStarts,
     state.dictionaryMask,
   )
-  const wordingMask = exemptBlockQuotes ? state.blockQuoteMask : undefined
+  const wordingMask = state.blockQuoteMask
 
   return {
     lines: proseLines,

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -24,6 +24,7 @@ export type SourceDialect = "general" | "shell"
 export interface LintOptions {
   readonly rules?: Partial<Record<RuleId, RuleSetting>>
   readonly maxSentenceWords?: number
+  readonly exemptBlockQuotes?: boolean
   readonly dictionary?: DictionaryData
   readonly ruleData?: RuleData
   // POS tagger for the verb-form rules and POS-aware dictionary entries.

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -100,6 +100,18 @@ describe("simple-english CLI config", () => {
     expect(result.stdout).toContain("maximum is 5")
   })
 
+  test("project config exempts block quotes from wording rules", async () => {
+    const cwd = await makeProject({ exemptBlockQuotes: true })
+    const result = await runCli([], {
+      cwd,
+      stdin: "> A seamless interface can't help.",
+    })
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toBe("")
+  })
+
   test("global config in the XDG config directory applies", async () => {
     const home = await makeHome({ maxSentenceWords: 5 })
     const cwd = await makeProject()

--- a/test/config/merge.test.ts
+++ b/test/config/merge.test.ts
@@ -4,11 +4,23 @@ import { mergeConfigs } from "../../src/config/merge.ts"
 describe("config merge", () => {
   test("project scalars win over global values", () => {
     const merged = mergeConfigs(
-      { maxSentenceWords: 20, approvedWordsPath: "global.json" },
-      { maxSentenceWords: 15, approvedWordsPath: "project.json" },
+      {
+        maxSentenceWords: 20,
+        exemptBlockQuotes: false,
+        approvedWordsPath: "global.json",
+      },
+      {
+        maxSentenceWords: 15,
+        exemptBlockQuotes: true,
+        approvedWordsPath: "project.json",
+      },
     )
 
-    expect(merged).toEqual({ maxSentenceWords: 15, approvedWordsPath: "project.json" })
+    expect(merged).toEqual({
+      maxSentenceWords: 15,
+      exemptBlockQuotes: true,
+      approvedWordsPath: "project.json",
+    })
   })
 
   test("rules deep-merge per key with project winning", () => {

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -15,6 +15,7 @@ describe("config schema", () => {
     const result = decode({
       rules: { "sentence-length": "soft" },
       maxSentenceWords: 20,
+      exemptBlockQuotes: true,
       approvedWordsPath: "config/approved-words.json",
       ruleDataExtensions: {
         "adjectival-participle": ["config/adjectival-participles.json"],
@@ -26,6 +27,7 @@ describe("config schema", () => {
       expect(result.right).toEqual({
         rules: { "sentence-length": "soft" },
         maxSentenceWords: 20,
+        exemptBlockQuotes: true,
         approvedWordsPath: "config/approved-words.json",
         ruleDataExtensions: {
           "adjectival-participle": ["config/adjectival-participles.json"],
@@ -72,6 +74,17 @@ describe("config schema", () => {
       const message = expectDecodeError({ maxSentenceWords: bad })
       expect(message).toContain("maxSentenceWords")
       expect(message).toContain("positive integer")
+    }
+  })
+
+  test("exemptBlockQuotes must be a boolean", () => {
+    expect(decode({ exemptBlockQuotes: true })._tag).toBe("Right")
+    expect(decode({ exemptBlockQuotes: false })._tag).toBe("Right")
+
+    for (const bad of ["true", 1, null]) {
+      const message = expectDecodeError({ exemptBlockQuotes: bad })
+      expect(message).toContain("exemptBlockQuotes")
+      expect(message).toContain("boolean")
     }
   })
 

--- a/test/engine/README.md
+++ b/test/engine/README.md
@@ -28,5 +28,11 @@ Cross-cutting Markdown masks use the same finding, clean, and boundary audit at 
 | GFM tables | Yes. `lints prose around a table at its original positions`. | Yes. `masks a valid multi-row GFM table from all prose rules`. | Yes. `does not mask table-like text with mismatched delimiter cells`. |
 | YAML frontmatter | Yes. `lints prose after frontmatter at its original position`. | Yes. `masks YAML frontmatter from all prose rules`. | Yes. `does not mask a thematic break in the middle of a document`. |
 
+## Engine options
+
+| Option | Finding | Clean | Boundary |
+| --- | --- | --- | --- |
+| `exemptBlockQuotes` | Yes. `keeps structural rules active in quoted content`. | Yes. `exempts quoted content from all wording rules`. | Yes. `lints prose outside quotes at its original position`. |
+
 Diff-only behavior has a separate engine seam in `diff-match.test.ts`.
 Tests at that seam call `newFindings` directly.

--- a/test/engine/block-quote-exemption.test.ts
+++ b/test/engine/block-quote-exemption.test.ts
@@ -74,6 +74,12 @@ describe("lint prose-file: block quote exemption", () => {
     expect(lint("prose-file", text, { exemptBlockQuotes: true }).violations).toEqual([])
   })
 
+  test("handles deeply nested block quotes", () => {
+    const text = `${"> ".repeat(10_000)}We're rolling out a seamless change.`
+
+    expect(lint("prose-file", text, { exemptBlockQuotes: true }).violations).toEqual([])
+  })
+
   test("keeps default and disabled behavior unchanged", () => {
     expect(lint("prose-file", quotedWording, { dictionary })).toEqual(
       lint("prose-file", quotedWording, { dictionary, exemptBlockQuotes: false }),

--- a/test/engine/block-quote-exemption.test.ts
+++ b/test/engine/block-quote-exemption.test.ts
@@ -104,6 +104,18 @@ describe("lint prose-file: block quote exemption", () => {
     ])
   })
 
+  test("does not report retained outside wording after a quote-only edit", () => {
+    const outside = "# Outside can't be approximately correct."
+
+    const report = lint("prose-file", `> Revised quote\n${outside}`, {
+      dictionary,
+      exemptBlockQuotes: true,
+      previousText: `> Old quote\n${outside}`,
+    })
+
+    expect(report.violations).toEqual([])
+  })
+
   test("lints prose outside quotes at its original position", () => {
     const text = "> We're seamless.\n\nOutside prose can't be seamless."
 

--- a/test/engine/block-quote-exemption.test.ts
+++ b/test/engine/block-quote-exemption.test.ts
@@ -122,6 +122,34 @@ describe("lint prose-file: block quote exemption", () => {
     expect(report.violations).toEqual([])
   })
 
+  test("keeps an outside finding retained across a later edit separated by a quote", () => {
+    const outside = "Outside can't proceed"
+    const quote = "> # Quoted heading."
+
+    const report = lint("prose-file", `${outside}\n${quote}\nRevised text.`, {
+      exemptBlockQuotes: true,
+      previousText: `${outside}\n${quote}\nFollowing text.`,
+    })
+
+    expect(report.violations).toEqual([])
+  })
+
+  test("keeps an outside approved-word finding retained across a separated edit", () => {
+    const quote = "> Quoted heading."
+    const approvedWordFixture = {
+      ...approvedWords,
+      approvedWords: ["following", "revised", "text"],
+    } satisfies ApprovedWordList
+
+    const report = lint("prose-file", `Unknown\n${quote}\nRevised text.`, {
+      dictionary: approvedWordFixture,
+      exemptBlockQuotes: true,
+      previousText: `Unknown\n${quote}\nFollowing text.`,
+    })
+
+    expect(report.violations).toEqual([])
+  })
+
   test("lints prose outside quotes at its original position", () => {
     const text = "> We're seamless.\n\nOutside prose can't be seamless."
 

--- a/test/engine/block-quote-exemption.test.ts
+++ b/test/engine/block-quote-exemption.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "vitest"
+import type { ApprovedWordList, Dictionary } from "../../src/dictionary/schema.ts"
+import { lint } from "../../src/engine/lint.ts"
+
+const dictionary = {
+  formatVersion: 1,
+  source: {
+    name: "block quote test fixture",
+    repository: "https://example.test/dictionary",
+    commit: "fixture",
+    path: "dictionary.json",
+  },
+  entries: [{ unapproved: ["approximately"], suggestions: ["about"] }],
+} as const satisfies Dictionary
+
+const approvedWords = {
+  formatVersion: 1,
+  source: {
+    name: "block quote approved-word fixture",
+    repository: "https://example.test/approved-words",
+    commit: "fixture",
+    path: "approved-words.json",
+  },
+  approvedWords: ["allowed"],
+} as const satisfies ApprovedWordList
+
+const quotedWording =
+  "> We're rolling out a seamless change. Please note that this is approximately correct."
+
+describe("lint prose-file: block quote exemption", () => {
+  test("exempts quoted content from all wording rules", () => {
+    const report = lint("prose-file", quotedWording, {
+      dictionary,
+      exemptBlockQuotes: true,
+    })
+
+    expect(report.violations).toEqual([])
+  })
+
+  test("exempts quotes in approved-word mode", () => {
+    expect(
+      lint("prose-file", "> Upstream vocabulary.", {
+        dictionary: approvedWords,
+        exemptBlockQuotes: true,
+      }).violations,
+    ).toEqual([])
+  })
+
+  test("keeps structural rules active in quoted content", () => {
+    const words = Array.from({ length: 26 }, (_, index) => `word${index + 1}`).join(" ")
+    const text = [
+      "> One; two.",
+      "",
+      `> ${words}.`,
+      "",
+      "> One. Two. Three. Four. Five. Six. Seven.",
+    ].join("\n")
+
+    const report = lint("prose-file", text, { exemptBlockQuotes: true })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "semicolon", line: 1, column: 6 }),
+      expect.objectContaining({ ruleId: "sentence-length", line: 3, column: 3 }),
+      expect.objectContaining({ ruleId: "paragraph-length", line: 5, column: 1 }),
+    ])
+  })
+
+  test.each([
+    ["> We're rolling out a seamless change."],
+    ["> Start the quote\nWe're rolling out a seamless change."],
+    ["> > We're rolling out a seamless change."],
+    ["- > We're rolling out a seamless change."],
+  ])("exempts CommonMark block quote form %#", (text) => {
+    expect(lint("prose-file", text, { exemptBlockQuotes: true }).violations).toEqual([])
+  })
+
+  test("keeps default and disabled behavior unchanged", () => {
+    expect(lint("prose-file", quotedWording, { dictionary })).toEqual(
+      lint("prose-file", quotedWording, { dictionary, exemptBlockQuotes: false }),
+    )
+    expect(
+      lint("prose-file", quotedWording, { dictionary }).violations.map(
+        (violation) => violation.ruleId,
+      ),
+    ).toEqual([
+      "contraction",
+      "phrasal-verb",
+      "marketing",
+      "hedging",
+      "dictionary-not-approved-word",
+    ])
+  })
+
+  test("keeps structural findings in diff-only reports", () => {
+    const words = Array.from({ length: 26 }, (_, index) => `word${index + 1}`).join(" ")
+
+    const report = lint("prose-file", `> ${words}.`, {
+      exemptBlockQuotes: true,
+      previousText: "> Short quote.",
+    })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "sentence-length", line: 1, column: 3 }),
+    ])
+  })
+
+  test("lints prose outside quotes at its original position", () => {
+    const text = "> We're seamless.\n\nOutside prose can't be seamless."
+
+    const report = lint("prose-file", text, { exemptBlockQuotes: true })
+
+    expect(report.violations).toEqual([
+      expect.objectContaining({ ruleId: "contraction", line: 3, column: 15 }),
+      expect.objectContaining({ ruleId: "marketing", line: 3, column: 24 }),
+    ])
+  })
+})


### PR DESCRIPTION
## Intent

Implement Linear ticket HUF-168 in the ste Engine. Add a new opt-in lint and config option that exempts CommonMark block-quote content from dictionary, contraction, phrasal-verb, hedging, and marketing findings. Structural rules and all other rules must still check quoted content. The default and explicit off behavior must preserve current quote linting. Prose outside quotes must lint identically in both modes, with original line and column positions. The option must pass config loading, validation, and merge behavior. Follow the HUF-161 implementation decisions and keep the change in the pure Engine without Adapter-specific behavior. Use TDD at the pure Engine seam. Cover finding, clean, boundary, approved-word dictionary, diff-only, CommonMark container, and config cases. List finding, clean, and boundary cases in test/engine/README.md. Run the supplied false-positive probe from the worktree without committing it. Do not add runtime packages unless they are in dependencies. Validate with bun run test, bun run lint, and bun run typecheck.

## What Changed

- Add an opt-in `exemptBlockQuotes` engine and config option for dictionary, contraction, phrasal-verb, hedging, and marketing rules while keeping structural rules active.
- Preserve default behavior, source positions, outside-quote linting, approved-word handling, and diff-only scopes across CommonMark containers.
- Document the option and add engine, config, merge, and CLI coverage.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the disabled path, and consistently applies parser-backed quote masking only to the specified wording rules.

## Testing

No baseline results were supplied. Targeted engine, config, CLI, CommonMark, and dictionary tests passed; manual CLI evidence confirmed default/off parity, all five wording exemptions, preserved outside positions, active structural and verb rules, and config merging. The exact supplied probe could not be run because it was absent. The full suite, lint, and typecheck were not run because this phase explicitly requires targeted tests and forbids static analysis.

<details>
<summary>Evidence: CLI quote exemption and retained-rule transcript</summary>

```text
$ quote-probe.md
> We're rolling out a seamless change. Please note that this is approximately correct.

Outside prose can't be seamless.

$ env -u SIMPLE_ENGLISH_DICTIONARY bun src/cli/main.ts --json --config /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/default.json /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"We're\".",
      "line": 1,
      "column": 3
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "phrasal-verb",
      "severity": "hard",
      "message": "Do not use a phrasal verb. Use \"release\", not \"rolling out\".",
      "line": 1,
      "column": 9,
      "suggestion": "release"
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 1,
      "column": 23
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "hedging",
      "severity": "soft",
      "message": "Do not hedge. Delete \"please note that\".",
      "line": 1,
      "column": 40
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "Use \"about\", not \"approximately\".",
      "suggestions": [
        "about"
      ],
      "line": 1,
      "column": 65
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"can't\".",
      "line": 3,
      "column": 15
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 3,
      "column": 24
    }
  ],
  "summary": {
    "total": 7,
    "hard": 4
  }
}
exit=1

$ env -u SIMPLE_ENGLISH_DICTIONARY bun src/cli/main.ts --json --config /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/off.json /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"We're\".",
      "line": 1,
      "column": 3
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "phrasal-verb",
      "severity": "hard",
      "message": "Do not use a phrasal verb. Use \"release\", not \"rolling out\".",
      "line": 1,
      "column": 9,
      "suggestion": "release"
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 1,
      "column": 23
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "hedging",
      "severity": "soft",
      "message": "Do not hedge. Delete \"please note that\".",
      "line": 1,
      "column": 40
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "dictionary-not-approved-word",
      "severity": "hard",
      "message": "Use \"about\", not \"approximately\".",
      "suggestions": [
        "about"
      ],
      "line": 1,
      "column": 65
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"can't\".",
      "line": 3,
      "column": 15
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 3,
      "column": 24
    }
  ],
  "summary": {
    "total": 7,
    "hard": 4
  }
}
exit=1

$ env -u SIMPLE_ENGLISH_DICTIONARY bun src/cli/main.ts --json --config /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/on.json /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"can't\".",
      "line": 3,
      "column": 15
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/quote-probe.md",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 3,
      "column": 24
    }
  ],
  "summary": {
    "total": 2,
    "hard": 1
  }
}
exit=1

$ structural-probe.md
> A bolt was removed; the pump was installed.

$ env -u SIMPLE_ENGLISH_DICTIONARY bun src/cli/main.ts --json --config /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/on.json /tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/structural-probe.md
{
  "violations": [
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/structural-probe.md",
      "ruleId": "verb-passive",
      "severity": "soft",
      "message": "Use the active voice, unless the actor is unknown. Found: \"was removed\".",
      "line": 1,
      "column": 10
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/structural-probe.md",
      "ruleId": "semicolon",
      "severity": "hard",
      "message": "Do not use a semicolon. Write two sentences.",
      "line": 1,
      "column": 21
    },
    {
      "file": "/tmp/no-mistakes-evidence/01KZ5FH7CYE3NJN313MXAGX7J4/structural-probe.md",
      "ruleId": "verb-passive",
      "severity": "soft",
      "message": "Use the active voice, unless the actor is unknown. Found: \"was installed\".",
      "line": 1,
      "column": 32
    }
  ],
  "summary": {
    "total": 3,
    "hard": 1
  }
}
exit=1
```
</details>
<details>
<summary>Evidence: Global and project config merge transcript</summary>

```text
$ global config: {"exemptBlockQuotes":false}
$ project config: {"exemptBlockQuotes":true}
$ stdin: > We're rolling out a seamless change.

$ run from project without a project config (inherits global false)
{
  "violations": [
    {
      "file": "<stdin>",
      "ruleId": "contraction",
      "severity": "hard",
      "message": "Do not use a contraction. Write the words in full. Found \"We're\".",
      "line": 1,
      "column": 3
    },
    {
      "file": "<stdin>",
      "ruleId": "phrasal-verb",
      "severity": "hard",
      "message": "Do not use a phrasal verb. Use \"release\", not \"rolling out\".",
      "line": 1,
      "column": 9,
      "suggestion": "release"
    },
    {
      "file": "<stdin>",
      "ruleId": "marketing",
      "severity": "soft",
      "message": "Do not use marketing language. Delete \"seamless\".",
      "line": 1,
      "column": 23
    }
  ],
  "summary": {
    "total": 3,
    "hard": 2
  }
}
exit=1

$ run from project with project config (project true overrides global false)
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  }
}
exit=0
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (2m34s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4) ✅</summary>

- ⚠️ `src/engine/markdown.ts:138` - The opt-out path now allocates a document-sized blockQuoteMask, and prepareProse rescans aliased normal and wording arrays with blankIdentifiers even when exemptBlockQuotes is false. This adds unused memory, duplicate regex passes, and a dead dictionaryLines result to every default lint. Allocate and process the quote mask only when enabled, and reuse the prepared normal arrays when the option is off.

🔧 Fix: Optimize block quote exemption preparation
1 error still open:
- 🚨 `src/engine/lint.ts:306` - Wording rules scan `wordingLines` but still receive scopes from unmasked `prepared.lines`. For `&gt; Old quote\n# Outside can&#39;t proceed.` changed only to `&gt; Revised quote`, the outside contraction&#39;s sentence identity changes because it includes the exempt quote, so diff-only matching reports the retained hard violation as new. Build and use a wording sentence index from the quote-masked lines for all exempt rules, including the standard dictionary path.

🔧 Fix: Fix diff scopes for exempted wording rules
1 error still open:
- 🚨 `src/engine/markdown.ts:349` - Each nested CommonMark `blockQuote` token fills its full source range. For input with N nested `&gt; ` containers, those overlapping ranges produce O(N²) mask writes and can stall lint gates when exemption is enabled. Track quote nesting and mark only outermost ranges, or merge ranges before filling the mask.

🔧 Fix: Avoid quadratic nested block quote masking
1 error still open:
- 🚨 `src/engine/lint.ts:265` - This contradicts the requirement that &#34;Prose outside quotes must lint identically in both modes.&#34; The quote-masked wording lines reuse unmasked structuralBlanks, so an ordinary quoted line does not close an open wording sentence. Between previous `Outside can&#39;t proceed\n&gt; # Quoted heading.\nFollowing text.` and a current version changing only the final line, the retained contraction on line 1 becomes part of the changed sentence identity and is falsely reported as new, while exemption-off mode closes that scope at the quoted period. Supply quote-aware structural blanks to both wording sentence indexes so block quotes remain sentence boundaries after masking.

🔧 Fix: Preserve diff scopes across exempt block quotes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ The required supplied false-positive probe was not present anywhere in the worktree, so that exact probe could not be run. Provide the probe file or its contents to complete this acceptance check.
- `bunx vitest run test/engine/block-quote-exemption.test.ts test/config/schema.test.ts test/config/merge.test.ts test/cli/config.test.ts`
- `bunx vitest run test/engine/kinds.test.ts test/engine/dictionary.test.ts -t 'block.?quote|blockquote'`
- <code>Ran `bun src/cli/main.ts --json --config` against default, explicit-off, and opt-in configs using quoted and outside prose.</code>
- `Ran the CLI with opt-in enabled against quoted passive voice and a semicolon to confirm non-exempt rules remain active.`
- <code>Ran the CLI from isolated projects to confirm project `true` overrides global `false` through config loading and merging.</code>
- `Searched tracked, untracked, and ignored worktree files for the supplied false-positive probe; none was present.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
