### PR TITLE
feat(cli): add hook observation log and human verdicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,37 @@ Malformed JSON returns a non-blocking error so Claude Code can continue.
 The hook also allows the event when configuration, dictionary, rule-data, tagger, transcript, state, or file processing fails.
 It adds warning text.
 
+### Review hook observations
+
+Hook mode logs every lint decision to the local XDG state directory.
+The log includes clean allows and soft Findings.
+Plain lint runs, disabled hook sessions, and the pi Adapter do not write Observations.
+Set `SIMPLE_ENGLISH_OBSERVE=0` to stop observation logging.
+
+Monthly Observation files use `$XDG_STATE_HOME/simple-english/observations/YYYY-MM.jsonl`.
+The default base directory is `~/.local/state`.
+Each Finding stores its offending snippet for later review.
+Verdicts use the separate `$XDG_STATE_HOME/simple-english/verdicts.jsonl` file.
+Both streams use append-only JSONL records.
+
+Review each unjudged Finding:
+
+```sh
+simple-english observe review
+```
+
+Press `t` for a true positive or `f` for a false positive.
+Press `s` to leave a Finding unjudged or `q` to quit.
+A Verdict can include an optional note.
+A false positive exists only after a human records that Verdict.
+The latest Verdict for a Finding wins.
+
+Show fire counts, judged counts, and false-positive rates for each rule:
+
+```sh
+simple-english observe stats
+```
+
 ### Lint files and standard input
 
 Lint one or more files:
@@ -214,6 +245,7 @@ Soft violations can appear with exit code 0.
 ### CLI flags
 
 - `--json` writes one JSON report with `violations` and `summary` fields.
+  Each violation includes its offending sentence or paragraph as `snippet`.
 
 - `--config <path>` uses only that config file and disables config discovery.
 

--- a/README.md
+++ b/README.md
@@ -167,12 +167,13 @@ A `UserPromptSubmit` event adds pending feedback to context and clears that feed
 Every hook reads the current session mode before it applies a gate.
 Malformed JSON returns a non-blocking error so Claude Code can continue.
 The hook also allows the event when configuration, dictionary, rule-data, tagger, transcript, state, or file processing fails.
-It adds warning text.
+It adds warning text for these operational failures.
+Observation-write failures are silent and do not change the hook output or decision.
 
 ### Review hook observations
 
-Hook mode logs every lint decision to the local XDG state directory.
-The log includes clean allows and soft Findings.
+Enabled Hook mode logs every write, edit, static commit-message, and reply lint decision to the local XDG state directory.
+Observation logging is on by default, and the log includes clean allows and soft Findings.
 Plain lint runs, disabled hook sessions, and the pi Adapter do not write Observations.
 Set `SIMPLE_ENGLISH_OBSERVE=0` to stop observation logging.
 
@@ -180,7 +181,9 @@ Monthly Observation files use `$XDG_STATE_HOME/simple-english/observations/YYYY-
 The default base directory is `~/.local/state`.
 Each Finding stores its offending snippet for later review.
 Verdicts use the separate `$XDG_STATE_HOME/simple-english/verdicts.jsonl` file.
-Both streams use append-only JSONL records.
+These global, host-local records can contain snippets, working directories, and file paths.
+New state directories use mode `0700`, and new JSONL files use mode `0600`.
+Each record uses one append-mode write without a lock, so concurrent hooks can safely add complete lines.
 
 Review each unjudged Finding:
 
@@ -199,6 +202,8 @@ Show fire counts, judged counts, and false-positive rates for each rule:
 ```sh
 simple-english observe stats
 ```
+
+The report also shows total Observations and clean allows.
 
 ### Lint files and standard input
 

--- a/docs/adr/0003-observation-log.md
+++ b/docs/adr/0003-observation-log.md
@@ -1,0 +1,36 @@
+# Local observation log with human verdicts for false-positive measurement
+
+We add an observation layer that records every hook-mode lint decision to a local append-only log.
+A false positive is a human judgment, not a machine inference.
+The log records Observations and Findings, and a person attaches Verdicts later through `observe review`.
+`observe stats` reports per-rule fire counts, judged counts, and the false-positive rate among judged Findings.
+
+## Shape
+
+Observations go to `~/.local/state/simple-english/observations/YYYY-MM.jsonl`, one JSON line per lint decision.
+Each Observation carries id, timestamp, surface, event, session id, cwd, path, kind, decision, a text hash, and embedded Findings.
+Each Finding carries the rule id, severity, message, position, and the offending snippet, so review needs no archaeology in git history.
+Verdicts are separate append-only records in `verdicts.jsonl` that reference an Observation id and Finding index.
+The latest Verdict for a Finding wins.
+
+## Boundaries
+
+Only hook-mode gates write Observations: write, edit, commit-message, and reply checks.
+Plain CLI runs and corpus sweeps stay silent, because bulk runs over ungated documents would skew the rates.
+A `surface` field exists from day one, so the pi Adapter can adopt the log as a new field value.
+The Engine stays pure.
+The only engine change exposes the offending snippet on each violation.
+Logging happens after the decision and can never alter it, and the logger swallows its own failures.
+
+## Rejected alternatives
+
+We rejected inferred verdicts from proxy signals (deny-then-retry patterns, session toggles) as the primary mechanism.
+Wrong inference would poison the false-positive counts, which are the numbers this layer must make trustworthy.
+The single event stream keeps deny-retry sequences adjacent, so proxy signals stay possible as a later, additive analysis.
+We rejected in-place verdict fields on the log because mutation breaks append-only semantics under concurrent hook writes.
+We rejected per-project log files because the usage question is cross-project, and records already carry cwd for slicing.
+
+Logging is on by default with a `SIMPLE_ENGLISH_OBSERVE=0` kill switch.
+The log includes soft findings, and they are reviewable.
+The log includes reply checks even outside strict mode.
+See `CONTEXT.md` for the Observation, Finding, Verdict, and false-positive vocabulary.

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -649,18 +649,11 @@ function evaluateEvent(
     const invocations = findCommitInvocations(event.command)
     if (invocations.length === 0) return Effect.succeed({ output: allow() })
     if (invocations.some((invocation) => invocation.requiresExplicitMessage)) {
-      return Effect.succeed(
-        evaluated(
-          deny(
-            "Writing rules could not check the git commit message. Use git commit with a static -m or --message argument.",
-          ),
-          "commit-message",
-          "commit-message",
-          event.command,
-          [],
-          event.cwd,
+      return Effect.succeed({
+        output: deny(
+          "Writing rules could not check the git commit message. Use git commit with a static -m or --message argument.",
         ),
-      )
+      })
     }
     return Effect.gen(function* () {
       const options = yield* loadLintOptions(event.cwd, tagger)

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -11,8 +11,13 @@ import { loadRuleData } from "../dictionary/load.ts"
 import { classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { Tagger } from "../engine/tagger.ts"
-import type { LintOptions, Violation } from "../engine/types.ts"
+import type { LintKind, LintOptions, ReportViolation } from "../engine/types.ts"
 import { TaggerService } from "../tagger/wink.ts"
+import {
+  type ObservationDraft,
+  type ObservationEvent,
+  appendObservation,
+} from "./observation-log.ts"
 import {
   consumePendingFeedback,
   getSessionControl,
@@ -527,13 +532,48 @@ const loadLintOptions = (cwd: string, tagger: Tagger) =>
     return { ...config, dictionary, ruleData, tagger } satisfies LintOptions
   })
 
-function splitViolations(violations: readonly Violation[]): {
-  readonly hard: Violation[]
-  readonly soft: Violation[]
+function splitViolations(violations: readonly ReportViolation[]): {
+  readonly hard: ReportViolation[]
+  readonly soft: ReportViolation[]
 } {
   return {
     hard: violations.filter((violation) => violation.severity === "hard"),
     soft: violations.filter((violation) => violation.severity === "soft"),
+  }
+}
+
+type EvaluationObservation = Omit<ObservationDraft, "sessionId" | "cwd">
+
+interface HookEvaluation {
+  readonly output: HookOutput
+  readonly observation?: EvaluationObservation
+}
+
+function evaluated(
+  output: HookOutput,
+  event: ObservationEvent,
+  kind: LintKind,
+  text: string,
+  violations: readonly ReportViolation[],
+  path?: string,
+): HookEvaluation {
+  const preToolDenied =
+    "hookSpecificOutput" in output &&
+    output.hookSpecificOutput !== undefined &&
+    "permissionDecision" in output.hookSpecificOutput &&
+    output.hookSpecificOutput.permissionDecision === "deny"
+  const decision =
+    ("decision" in output && output.decision === "block") || preToolDenied ? "deny" : "allow"
+  return {
+    output,
+    observation: {
+      event,
+      kind,
+      text,
+      violations,
+      decision,
+      ...(path === undefined ? {} : { path }),
+    },
   }
 }
 
@@ -543,7 +583,7 @@ function textDecision(
   text: string,
   options: LintOptions,
   previousText?: string,
-): HookDecision {
+): HookEvaluation {
   const classification = classifyPath(path)
   const report = lint(classification.kind, text, {
     ...options,
@@ -551,70 +591,106 @@ function textDecision(
     previousText,
   })
   const { hard, soft } = splitViolations(report.violations)
-  if (hard.length > 0) {
-    return deny(formatViolations(path, `Writing rules blocked ${operation} for`, hard))
-  }
-  return allow(soft.length === 0 ? [] : [formatViolations(path, "Writing-rule warnings for", soft)])
+  const output =
+    hard.length > 0
+      ? deny(formatViolations(path, `Writing rules blocked ${operation} for`, hard))
+      : allow(soft.length === 0 ? [] : [formatViolations(path, "Writing-rule warnings for", soft)])
+  return evaluated(output, operation, classification.kind, text, report.violations, path)
 }
 
-function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookOutput, Error> {
+function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookEvaluation, Error> {
   return Effect.gen(function* () {
     const reply = yield* event.lastAssistantMessage === undefined
       ? readAssistantReply(event.transcriptPath)
       : readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath)
     if (yield* replyWasProcessed(event.sessionId, reply.identity)) {
-      return {} as Record<string, never>
+      return { output: {} as Record<string, never> }
     }
     const options = yield* loadLintOptions(event.cwd, tagger)
-    const hard = lint("prose-file", reply.text, options).violations.filter(
-      (violation) => violation.severity === "hard",
-    )
+    const violations = lint("prose-file", reply.text, options).violations
+    const hard = violations.filter((violation) => violation.severity === "hard")
     const feedback =
       hard.length === 0
         ? undefined
         : formatViolations("assistant reply", "Writing-rule reply feedback for", hard)
     const currentControl = yield* updateReplyFeedback(event.sessionId, reply.identity, feedback)
-    if (
+    const output: HookOutput =
       currentControl === undefined ||
       !currentControl.strict ||
       event.stopHookActive ||
       hard.length === 0
-    ) {
-      return {} as Record<string, never>
-    }
-    return {
-      decision: "block",
-      reason: formatViolations("assistant reply", "Writing rules blocked reply for", hard),
-    }
+        ? ({} as Record<string, never>)
+        : {
+            decision: "block",
+            reason: formatViolations("assistant reply", "Writing rules blocked reply for", hard),
+          }
+    return evaluated(output, "reply", "prose-file", reply.text, violations)
   })
 }
 
-function evaluateEvent(event: PreToolUseEvent, tagger: Tagger): Effect.Effect<HookDecision, Error> {
+function restoreCommitSnippets(
+  message: string,
+  prepared: string,
+  violations: readonly ReportViolation[],
+): ReportViolation[] {
+  return violations.map((violation) => {
+    const offset = prepared.indexOf(violation.snippet)
+    return offset === -1
+      ? violation
+      : { ...violation, snippet: message.slice(offset, offset + violation.snippet.length) }
+  })
+}
+
+function evaluateEvent(
+  event: PreToolUseEvent,
+  tagger: Tagger,
+): Effect.Effect<HookEvaluation, Error> {
   if (event.toolName === "Bash") {
     const invocations = findCommitInvocations(event.command)
-    if (invocations.length === 0) return Effect.succeed(allow())
+    if (invocations.length === 0) return Effect.succeed({ output: allow() })
     if (invocations.some((invocation) => invocation.requiresExplicitMessage)) {
       return Effect.succeed(
-        deny(
-          "Writing rules could not check the git commit message. Use git commit with a static -m or --message argument.",
+        evaluated(
+          deny(
+            "Writing rules could not check the git commit message. Use git commit with a static -m or --message argument.",
+          ),
+          "commit-message",
+          "commit-message",
+          event.command,
+          [],
+          event.cwd,
         ),
       )
     }
     return Effect.gen(function* () {
       const options = yield* loadLintOptions(event.cwd, tagger)
-      const violations = invocations.flatMap((invocation) =>
-        invocation.requiresExplicitMessage
-          ? []
-          : lint("commit-message", blankCommitMetadata(invocation.message), options).violations,
+      const messages = invocations.flatMap((invocation) =>
+        invocation.requiresExplicitMessage ? [] : [invocation.message],
       )
+      const violations = messages.flatMap((message) => {
+        const prepared = blankCommitMetadata(message)
+        return restoreCommitSnippets(
+          message,
+          prepared,
+          lint("commit-message", prepared, options).violations,
+        )
+      })
       const { hard, soft } = splitViolations(violations)
-      if (hard.length > 0) {
-        return deny(formatViolations("commit message", "Writing rules blocked commit for", hard))
-      }
-      return allow(
-        soft.length === 0
-          ? []
-          : [formatViolations("commit message", "Writing-rule warnings for", soft)],
+      const output =
+        hard.length > 0
+          ? deny(formatViolations("commit message", "Writing rules blocked commit for", hard))
+          : allow(
+              soft.length === 0
+                ? []
+                : [formatViolations("commit message", "Writing-rule warnings for", soft)],
+            )
+      return evaluated(
+        output,
+        "commit-message",
+        "commit-message",
+        messages.join("\n\n"),
+        violations,
+        event.cwd,
       )
     })
   }
@@ -629,6 +705,23 @@ function evaluateEvent(event: PreToolUseEvent, tagger: Tagger): Effect.Effect<Ho
     const text = proposedEdit(previousText, event.oldString, event.newString, event.replaceAll)
     return textDecision("edit", path, text, options, previousText)
   })
+}
+
+function recordEvaluation(event: HookEvent, evaluation: HookEvaluation): Effect.Effect<HookOutput> {
+  const observation = evaluation.observation
+  if (observation === undefined) return Effect.succeed(evaluation.output)
+  return Effect.tryPromise({
+    try: () =>
+      appendObservation({
+        ...observation,
+        sessionId: event.sessionId,
+        cwd: event.cwd,
+      }),
+    catch: () => undefined,
+  }).pipe(
+    Effect.catchAll(() => Effect.void),
+    Effect.as(evaluation.output),
+  )
 }
 
 export function runHookMode(raw: string): Effect.Effect<HookOutput, never, TaggerService> {
@@ -661,12 +754,14 @@ export function runHookMode(raw: string): Effect.Effect<HookOutput, never, Tagge
             if (event.hookEventName === "Stop") {
               return Effect.gen(function* () {
                 const tagger = yield* TaggerService
-                return yield* evaluateReply(event, tagger)
+                const evaluation = yield* evaluateReply(event, tagger)
+                return yield* recordEvaluation(event, evaluation)
               })
             }
             return Effect.gen(function* () {
               const tagger = yield* TaggerService
-              return yield* evaluateEvent(event, tagger)
+              const evaluation = yield* evaluateEvent(event, tagger)
+              return yield* recordEvaluation(event, evaluation)
             })
           }),
           Effect.catchAll((error) =>

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -10,11 +10,14 @@ import { lint } from "../engine/lint.ts"
 import type { LintKind, LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
 import { hookInternalFailure, runHookMode } from "./hook.ts"
+import { observationStats, reviewObservations } from "./observation-log.ts"
 import { runSessionCommand } from "./session-command.ts"
 
 const KINDS: readonly LintKind[] = ["prose-file", "slash-source", "hash-source", "commit-message"]
 
 const USAGE = `Usage: simple-english [options] [paths...]
+       simple-english observe review
+       simple-english observe stats
 
 Options:
   --json           Write a JSON report.
@@ -89,6 +92,7 @@ interface FileViolation {
   readonly ruleId: string
   readonly severity: string
   readonly message: string
+  readonly snippet: string
   readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
@@ -155,6 +159,27 @@ const hookProgram = Effect.gen(function* () {
 
 const sessionProgram = Effect.gen(function* () {
   console.log(yield* runSessionCommand(args.slice(1)))
+  return 0
+})
+
+const observeProgram = Effect.gen(function* () {
+  const command = args[1]
+  if (args.length !== 2 || (command !== "review" && command !== "stats")) {
+    return yield* Effect.fail(new Error("Usage: simple-english observe <review|stats>"))
+  }
+  if (command === "review") {
+    yield* Effect.tryPromise({
+      try: () => reviewObservations(),
+      catch: (cause) => new Error(`cannot review observations: ${cause}`),
+    })
+  } else {
+    console.log(
+      yield* Effect.tryPromise({
+        try: () => observationStats(),
+        catch: (cause) => new Error(`cannot read observation stats: ${cause}`),
+      }),
+    )
+  }
   return 0
 })
 
@@ -228,7 +253,9 @@ const program: Effect.Effect<number, Error> =
     ? rejectUnknownFlags(args.slice(1)).pipe(Effect.andThen(hookProgram))
     : args[0] === "session"
       ? rejectUnknownFlags(args.slice(1)).pipe(Effect.andThen(sessionProgram))
-      : lintProgram.pipe(Effect.provide(WinkTaggerLive))
+      : args[0] === "observe"
+        ? observeProgram
+        : lintProgram.pipe(Effect.provide(WinkTaggerLive))
 
 const handled = program.pipe(
   Effect.catchAll((error) =>

--- a/src/cli/observation-log.ts
+++ b/src/cli/observation-log.ts
@@ -1,0 +1,257 @@
+import { createHash, randomUUID } from "node:crypto"
+import { mkdir, open, readFile, readdir } from "node:fs/promises"
+import { join } from "node:path"
+import { createInterface } from "node:readline"
+import type { LintKind, ReportViolation } from "../engine/types.ts"
+import { applicationStateDirectory } from "./state-directory.ts"
+
+export type ObservationEvent = "write" | "edit" | "commit-message" | "reply"
+export type ObservationDecision = "allow" | "deny"
+export type VerdictValue = "true-positive" | "false-positive"
+
+export interface ObservationFinding {
+  readonly index: number
+  readonly ruleId: string
+  readonly severity: "hard" | "soft"
+  readonly message: string
+  readonly snippet: string
+  readonly line: number
+  readonly column: number
+}
+
+export interface Observation {
+  readonly id: string
+  readonly at: string
+  readonly surface: "claude-code-hook"
+  readonly event: ObservationEvent
+  readonly sessionId: string
+  readonly cwd: string
+  readonly path?: string
+  readonly kind: LintKind
+  readonly decision: ObservationDecision
+  readonly textHash: string
+  readonly findings: readonly ObservationFinding[]
+}
+
+export interface Verdict {
+  readonly at: string
+  readonly observationId: string
+  readonly findingIndex: number
+  readonly verdict: VerdictValue
+  readonly note?: string
+}
+
+export interface ObservationDraft {
+  readonly event: ObservationEvent
+  readonly sessionId: string
+  readonly cwd: string
+  readonly path?: string
+  readonly kind: LintKind
+  readonly decision: ObservationDecision
+  readonly text: string
+  readonly violations: readonly ReportViolation[]
+}
+
+const observationsDirectory = (): string => join(applicationStateDirectory(), "observations")
+
+const verdictsPath = (): string => join(applicationStateDirectory(), "verdicts.jsonl")
+
+function isFileError(cause: unknown, code: string): boolean {
+  return (
+    typeof cause === "object" && cause !== null && (cause as NodeJS.ErrnoException).code === code
+  )
+}
+
+async function appendJsonLine(path: string, value: unknown): Promise<void> {
+  await mkdir(applicationStateDirectory(), { recursive: true, mode: 0o700 })
+  const file = await open(path, "a", 0o600)
+  try {
+    await file.write(`${JSON.stringify(value)}\n`)
+  } finally {
+    await file.close()
+  }
+}
+
+export async function appendObservation(draft: ObservationDraft): Promise<void> {
+  if (process.env.SIMPLE_ENGLISH_OBSERVE === "0") return
+  const at = new Date().toISOString()
+  const directory = observationsDirectory()
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  const observation: Observation = {
+    id: randomUUID(),
+    at,
+    surface: "claude-code-hook",
+    event: draft.event,
+    sessionId: draft.sessionId,
+    cwd: draft.cwd,
+    ...(draft.path === undefined ? {} : { path: draft.path }),
+    kind: draft.kind,
+    decision: draft.decision,
+    textHash: `sha256:${createHash("sha256").update(draft.text).digest("hex")}`,
+    findings: draft.violations.map((violation, index) => ({
+      index,
+      ruleId: violation.ruleId,
+      severity: violation.severity,
+      message: violation.message,
+      snippet: violation.snippet,
+      line: violation.line,
+      column: violation.column,
+    })),
+  }
+  await appendJsonLine(join(directory, `${at.slice(0, 7)}.jsonl`), observation)
+}
+
+async function readJsonLines<T>(path: string): Promise<T[]> {
+  let text: string
+  try {
+    text = await readFile(path, "utf8")
+  } catch (cause) {
+    if (isFileError(cause, "ENOENT")) return []
+    throw cause
+  }
+  return text
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line, index) => {
+      try {
+        return JSON.parse(line) as T
+      } catch (cause) {
+        throw new Error(`invalid JSON on line ${index + 1} of ${path}: ${cause}`)
+      }
+    })
+}
+
+async function readObservations(): Promise<Observation[]> {
+  let files: string[]
+  try {
+    files = await readdir(observationsDirectory())
+  } catch (cause) {
+    if (isFileError(cause, "ENOENT")) return []
+    throw cause
+  }
+  const monthlyFiles = files.filter((file) => /^\d{4}-\d{2}\.jsonl$/u.test(file)).sort()
+  const records = await Promise.all(
+    monthlyFiles.map((file) => readJsonLines<Observation>(join(observationsDirectory(), file))),
+  )
+  return records.flat()
+}
+
+const findingKey = (observationId: string, findingIndex: number): string =>
+  `${observationId}\u0000${findingIndex}`
+
+async function latestVerdicts(): Promise<Map<string, Verdict>> {
+  const verdicts = await readJsonLines<Verdict>(verdictsPath())
+  return new Map(
+    verdicts.map((verdict) => [findingKey(verdict.observationId, verdict.findingIndex), verdict]),
+  )
+}
+
+async function appendVerdict(verdict: Verdict): Promise<void> {
+  await appendJsonLine(verdictsPath(), verdict)
+}
+
+function write(text: string): void {
+  process.stdout.write(text)
+}
+
+export async function reviewObservations(): Promise<void> {
+  const observations = await readObservations()
+  const verdicts = await latestVerdicts()
+  const unjudged = observations.flatMap((observation) =>
+    observation.findings.flatMap((finding) =>
+      verdicts.has(findingKey(observation.id, finding.index)) ? [] : [{ observation, finding }],
+    ),
+  )
+  if (unjudged.length === 0) {
+    write("No unjudged findings.\n")
+    return
+  }
+
+  const input = createInterface({ input: process.stdin, output: process.stdout })
+  const lines = input[Symbol.asyncIterator]()
+  let recorded = 0
+  try {
+    for (const { observation, finding } of unjudged) {
+      const location = observation.path ?? "assistant reply"
+      write(
+        `\n[${finding.ruleId}] ${finding.severity} at ${location}:${finding.line}:${finding.column}\n${finding.snippet}\n${finding.message}\n`,
+      )
+      let choice: string | undefined
+      while (choice === undefined) {
+        write("Verdict [t]rue, [f]alse, [s]kip, [q]uit: ")
+        const next = await lines.next()
+        if (next.done) return
+        const answer = next.value.trim().toLowerCase()
+        if (answer === "q" || answer === "quit") return
+        if (answer === "s" || answer === "skip") {
+          choice = "skip"
+        } else if (answer === "t" || answer === "true" || answer === "true-positive") {
+          choice = "true-positive"
+        } else if (answer === "f" || answer === "false" || answer === "false-positive") {
+          choice = "false-positive"
+        }
+      }
+      if (choice === "skip") continue
+
+      write("Note (optional): ")
+      const noteLine = await lines.next()
+      const note = noteLine.done ? "" : noteLine.value.trim()
+      await appendVerdict({
+        at: new Date().toISOString(),
+        observationId: observation.id,
+        findingIndex: finding.index,
+        verdict: choice as VerdictValue,
+        ...(note === "" ? {} : { note }),
+      })
+      recorded += 1
+      if (noteLine.done) return
+    }
+  } finally {
+    input.close()
+    write(`\nRecorded ${recorded} verdict${recorded === 1 ? "" : "s"}.\n`)
+  }
+}
+
+interface RuleStats {
+  fires: number
+  judged: number
+  falsePositives: number
+}
+
+export async function observationStats(): Promise<string> {
+  const observations = await readObservations()
+  const verdicts = await latestVerdicts()
+  const stats = new Map<string, RuleStats>()
+
+  for (const observation of observations) {
+    for (const finding of observation.findings) {
+      const rule = stats.get(finding.ruleId) ?? { fires: 0, judged: 0, falsePositives: 0 }
+      rule.fires += 1
+      const verdict = verdicts.get(findingKey(observation.id, finding.index))
+      if (verdict !== undefined) {
+        rule.judged += 1
+        if (verdict.verdict === "false-positive") rule.falsePositives += 1
+      }
+      stats.set(finding.ruleId, rule)
+    }
+  }
+
+  const cleanAllows = observations.filter(
+    (observation) => observation.decision === "allow" && observation.findings.length === 0,
+  ).length
+  const ruleIds = [...stats.keys()].sort()
+  const ruleWidth = Math.max("Rule".length, ...ruleIds.map((ruleId) => ruleId.length))
+  const rows = ruleIds.map((ruleId) => {
+    const rule = stats.get(ruleId) as RuleStats
+    const rate =
+      rule.judged === 0 ? "-" : `${((rule.falsePositives / rule.judged) * 100).toFixed(1)}%`
+    return `${ruleId.padEnd(ruleWidth)}  ${String(rule.fires).padStart(5)}  ${String(rule.judged).padStart(6)}  ${rate}`
+  })
+  return [
+    `Observations: ${observations.length}`,
+    `Clean allows: ${cleanAllows}`,
+    "",
+    `${"Rule".padEnd(ruleWidth)}  Fires  Judged  False-positive rate`,
+    ...rows,
+  ].join("\n")
+}

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
-import { homedir } from "node:os"
-import { isAbsolute, join } from "node:path"
+import { join } from "node:path"
+import { applicationStateDirectory } from "./state-directory.ts"
 
 export interface SessionControl {
   readonly enabled: boolean
@@ -22,12 +22,7 @@ const LOCK_RETRIES = 200
 const isFileError = (cause: unknown, code: string): boolean =>
   typeof cause === "object" && cause !== null && (cause as { code?: string }).code === code
 
-const stateRoot = (): string => {
-  const configured = process.env.XDG_STATE_HOME
-  return configured && isAbsolute(configured) ? configured : join(homedir(), ".local", "state")
-}
-
-const sessionsDirectory = (): string => join(stateRoot(), "simple-english", "sessions")
+const sessionsDirectory = (): string => join(applicationStateDirectory(), "sessions")
 
 const sessionKey = (sessionId: string): string =>
   createHash("sha256").update(sessionId).digest("hex")

--- a/src/cli/state-directory.ts
+++ b/src/cli/state-directory.ts
@@ -1,0 +1,9 @@
+import { homedir } from "node:os"
+import { isAbsolute, join } from "node:path"
+
+export function applicationStateDirectory(): string {
+  const configured = process.env.XDG_STATE_HOME
+  const root =
+    configured && isAbsolute(configured) ? configured : join(homedir(), ".local", "state")
+  return join(root, "simple-english")
+}

--- a/src/engine/lint.ts
+++ b/src/engine/lint.ts
@@ -375,7 +375,10 @@ export function lint(kind: LintKind, text: string, options: LintOptions = {}): L
           current,
           changedText(options.previousText, text).retained,
         )
-  const violations = findings.map((finding) => finding.violation)
+  const violations = findings.map(({ scope, violation }) => ({
+    ...violation,
+    snippet: text.slice(scope.startOffset, scope.endOffset),
+  }))
   return {
     violations,
     summary: {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -19,6 +19,10 @@ export interface Violation {
   readonly suggestion?: string
 }
 
+export interface ReportViolation extends Violation {
+  readonly snippet: string
+}
+
 export type SourceDialect = "general" | "shell"
 
 export interface LintOptions {
@@ -39,7 +43,7 @@ export interface LintOptions {
 }
 
 export interface LintReport {
-  readonly violations: readonly Violation[]
+  readonly violations: readonly ReportViolation[]
   readonly summary: {
     readonly total: number
     readonly hard: number

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -74,6 +74,8 @@ describe("simple-english CLI", () => {
           ruleId: "sentence-length",
           severity: "hard",
           message: expect.stringContaining("maximum is 25"),
+          snippet:
+            "This sentence is deliberately far too long because it keeps adding more and more filler words until the total word count clearly exceeds the configured maximum of twenty five.",
           line: 3,
           column: 1,
         },

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -239,6 +239,20 @@ describe("simple-english observation log", () => {
     expect(records[0]).toMatchObject({ decision: "allow", findings: [] })
   })
 
+  test("does not log commit denials without a static message", async () => {
+    const cwd = await makeTemp("ste-observe-project-")
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+
+    const result = await runHook(
+      preToolEvent(cwd, "Bash", { command: "git commit" }),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(JSON.parse(result.stdout).hookSpecificOutput.permissionDecision).toBe("deny")
+    await expect(readdir(join(xdgStateHome, "simple-english", "observations"))).rejects.toThrow()
+  })
+
   test("honors the observation kill switch", async () => {
     const cwd = await makeTemp("ste-observe-project-")
     const xdgStateHome = await makeTemp("ste-observe-state-")

--- a/test/cli/observe.test.ts
+++ b/test/cli/observe.test.ts
@@ -1,0 +1,378 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, test } from "vitest"
+import { runCli } from "./run-cli.ts"
+
+interface Finding {
+  readonly index: number
+  readonly ruleId: string
+  readonly severity: "hard" | "soft"
+  readonly message: string
+  readonly snippet: string
+  readonly line: number
+  readonly column: number
+}
+
+interface Observation {
+  readonly id: string
+  readonly at: string
+  readonly surface: "claude-code-hook"
+  readonly event: "write" | "edit" | "commit-message" | "reply"
+  readonly sessionId: string
+  readonly cwd: string
+  readonly path?: string
+  readonly kind: "prose-file" | "slash-source" | "hash-source" | "commit-message"
+  readonly decision: "allow" | "deny"
+  readonly textHash: string
+  readonly findings: readonly Finding[]
+}
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  )
+})
+
+async function makeTemp(prefix: string): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), prefix))
+  temporaryDirectories.push(path)
+  return path
+}
+
+function preToolEvent(
+  cwd: string,
+  toolName: "Write" | "Edit" | "Bash",
+  toolInput: object,
+  sessionId = "observe-session",
+): string {
+  return JSON.stringify({
+    session_id: sessionId,
+    transcript_path: join(cwd, "transcript.jsonl"),
+    cwd,
+    permission_mode: "default",
+    hook_event_name: "PreToolUse",
+    tool_name: toolName,
+    tool_input: toolInput,
+    tool_use_id: "tool-1",
+  })
+}
+
+function stopEvent(cwd: string, text: string, sessionId = "observe-session"): string {
+  return JSON.stringify({
+    session_id: sessionId,
+    transcript_path: join(cwd, "transcript.jsonl"),
+    cwd,
+    permission_mode: "default",
+    hook_event_name: "Stop",
+    stop_hook_active: false,
+    last_assistant_message: text,
+  })
+}
+
+async function runHook(raw: string, cwd: string, xdgStateHome: string, observe?: string) {
+  return runCli(["hook"], { stdin: raw, cwd, xdgStateHome, observe })
+}
+
+async function readObservations(xdgStateHome: string): Promise<Observation[]> {
+  const directory = join(xdgStateHome, "simple-english", "observations")
+  const files = (await readdir(directory)).sort()
+  const lines = await Promise.all(files.map((file) => readFile(join(directory, file), "utf8")))
+  return lines
+    .flatMap((text) => text.trim().split("\n"))
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Observation)
+}
+
+function observation(
+  overrides: Partial<Observation> & Pick<Observation, "id" | "findings">,
+): Observation {
+  return {
+    id: overrides.id,
+    at: overrides.at ?? "2026-08-04T10:00:00.000Z",
+    surface: "claude-code-hook",
+    event: overrides.event ?? "write",
+    sessionId: overrides.sessionId ?? "seed-session",
+    cwd: overrides.cwd ?? "/tmp/project",
+    path: overrides.path ?? "/tmp/project/notes.md",
+    kind: overrides.kind ?? "prose-file",
+    decision: overrides.decision ?? "deny",
+    textHash: overrides.textHash ?? `sha256:${"a".repeat(64)}`,
+    findings: overrides.findings,
+  }
+}
+
+function finding(index: number, ruleId: string): Finding {
+  return {
+    index,
+    ruleId,
+    severity: "hard",
+    message: `${ruleId} message`,
+    snippet: `${ruleId} snippet.`,
+    line: 1,
+    column: 1,
+  }
+}
+
+async function seedObservations(
+  xdgStateHome: string,
+  records: readonly Observation[],
+): Promise<void> {
+  const directory = join(xdgStateHome, "simple-english", "observations")
+  await mkdir(directory, { recursive: true })
+  await writeFile(
+    join(directory, "2026-08.jsonl"),
+    `${records.map((record) => JSON.stringify(record)).join("\n")}\n`,
+  )
+}
+
+describe("simple-english observation log", () => {
+  test("logs write, edit, commit-message, and reply decisions with snippets", async () => {
+    const cwd = await makeTemp("ste-observe-project-")
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+    await writeFile(
+      join(cwd, ".simple-english.json"),
+      JSON.stringify({ rules: { "dictionary-not-approved-word": "off" } }),
+    )
+    const editPath = join(cwd, "edit.md")
+    await writeFile(editPath, "Replace this sentence.")
+
+    const write = await runHook(
+      preToolEvent(cwd, "Write", {
+        file_path: join(cwd, "write.md"),
+        content: "This isn't permitted.",
+      }),
+      cwd,
+      xdgStateHome,
+    )
+    const edit = await runHook(
+      preToolEvent(cwd, "Edit", {
+        file_path: editPath,
+        old_string: "Replace this sentence.",
+        new_string: "Close the valve.",
+      }),
+      cwd,
+      xdgStateHome,
+    )
+    const commit = await runHook(
+      preToolEvent(cwd, "Bash", { command: `git commit -m "fix: This isn't permitted."` }),
+      cwd,
+      xdgStateHome,
+    )
+    await writeFile(
+      join(cwd, "transcript.jsonl"),
+      `${JSON.stringify({
+        type: "user",
+        uuid: "prompt-1",
+        message: { role: "user", content: "Check this text." },
+      })}\n`,
+    )
+    const reply = await runHook(
+      stopEvent(cwd, "It is important to note that the valve is open."),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(JSON.parse(write.stdout).hookSpecificOutput.permissionDecision).toBe("deny")
+    expect(JSON.parse(edit.stdout).hookSpecificOutput.permissionDecision).toBe("allow")
+    expect(JSON.parse(commit.stdout).hookSpecificOutput.permissionDecision).toBe("deny")
+    expect(JSON.parse(reply.stdout)).toEqual({})
+
+    const records = await readObservations(xdgStateHome)
+    expect(records.map((record) => record.event)).toEqual([
+      "write",
+      "edit",
+      "commit-message",
+      "reply",
+    ])
+    expect(records.map((record) => record.decision)).toEqual(["deny", "allow", "deny", "allow"])
+    expect(records[0]).toMatchObject({
+      surface: "claude-code-hook",
+      sessionId: "observe-session",
+      cwd,
+      path: join(cwd, "write.md"),
+      kind: "prose-file",
+    })
+    expect(records[0]?.id).toEqual(expect.any(String))
+    expect(records[0]?.at).toEqual(expect.any(String))
+    expect(records[0]?.textHash).toMatch(/^sha256:[0-9a-f]{64}$/u)
+    expect(records[0]?.findings[0]).toMatchObject({
+      index: 0,
+      ruleId: "contraction",
+      severity: "hard",
+      snippet: "This isn't permitted.",
+      line: 1,
+      column: 6,
+    })
+    expect(records[1]?.findings).toEqual([])
+    expect(records[2]?.findings[0]?.snippet).toBe("fix: This isn't permitted.")
+    expect(records[3]?.findings).toEqual([
+      expect.objectContaining({
+        index: 0,
+        ruleId: "hedging",
+        severity: "soft",
+        snippet: "It is important to note that the valve is open.",
+      }),
+    ])
+    expect(records[3]).not.toHaveProperty("path")
+  }, 15_000)
+
+  test("logs clean allows and leaves plain CLI runs silent", async () => {
+    const cwd = await makeTemp("ste-observe-project-")
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+
+    const clean = await runHook(
+      preToolEvent(cwd, "Write", {
+        file_path: join(cwd, "notes.md"),
+        content: "Close the valve.",
+      }),
+      cwd,
+      xdgStateHome,
+    )
+    await runCli([], { stdin: "This isn't permitted.", cwd, xdgStateHome })
+
+    expect(JSON.parse(clean.stdout).hookSpecificOutput.permissionDecision).toBe("allow")
+    const records = await readObservations(xdgStateHome)
+    expect(records).toHaveLength(1)
+    expect(records[0]).toMatchObject({ decision: "allow", findings: [] })
+  })
+
+  test("honors the observation kill switch", async () => {
+    const cwd = await makeTemp("ste-observe-project-")
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+
+    const result = await runHook(
+      preToolEvent(cwd, "Write", {
+        file_path: join(cwd, "notes.md"),
+        content: "Close the valve.",
+      }),
+      cwd,
+      xdgStateHome,
+      "0",
+    )
+
+    expect(JSON.parse(result.stdout).hookSpecificOutput.permissionDecision).toBe("allow")
+    await expect(readdir(join(xdgStateHome, "simple-english", "observations"))).rejects.toThrow()
+  })
+
+  test("keeps the hook decision unchanged when observation storage fails", async () => {
+    const cwd = await makeTemp("ste-observe-project-")
+    const writableState = await makeTemp("ste-observe-state-")
+    const blockedStateParent = await makeTemp("ste-observe-blocked-")
+    const blockedState = join(blockedStateParent, "state")
+    await mkdir(join(blockedState, "simple-english"), { recursive: true })
+    await writeFile(join(blockedState, "simple-english", "observations"), "not a directory")
+    const raw = preToolEvent(cwd, "Write", {
+      file_path: join(cwd, "notes.md"),
+      content: "This isn't permitted.",
+    })
+
+    const baseline = await runHook(raw, cwd, writableState, "0")
+    const failedLog = await runHook(raw, cwd, blockedState)
+
+    expect(failedLog).toEqual(baseline)
+  })
+
+  test("logs nothing for a disabled session", async () => {
+    const cwd = await makeTemp("ste-observe-project-")
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+    const disabled = await runCli(["session", "disabled-session", cwd, "off"], {
+      cwd,
+      xdgStateHome,
+    })
+
+    const result = await runHook(
+      preToolEvent(
+        cwd,
+        "Write",
+        { file_path: join(cwd, "notes.md"), content: "This isn't permitted." },
+        "disabled-session",
+      ),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(disabled.code).toBe(0)
+    expect(JSON.parse(result.stdout).hookSpecificOutput.permissionDecision).toBe("allow")
+    await expect(readdir(join(xdgStateHome, "simple-english", "observations"))).rejects.toThrow()
+  })
+
+  test("reviews unjudged findings and records notes while skips stay unjudged", async () => {
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+    await seedObservations(xdgStateHome, [
+      observation({ id: "observation-1", findings: [finding(0, "contraction")] }),
+      observation({ id: "observation-2", findings: [finding(0, "semicolon")] }),
+    ])
+
+    const result = await runCli(["observe", "review"], {
+      xdgStateHome,
+      stdin: "f\nKnown quoted text.\ns\n",
+    })
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain("contraction snippet.")
+    expect(result.stdout).toContain("semicolon snippet.")
+    const verdictLines = (
+      await readFile(join(xdgStateHome, "simple-english", "verdicts.jsonl"), "utf8")
+    )
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+    expect(verdictLines).toEqual([
+      expect.objectContaining({
+        observationId: "observation-1",
+        findingIndex: 0,
+        verdict: "false-positive",
+        note: "Known quoted text.",
+      }),
+    ])
+  })
+
+  test("aggregates stats by rule and uses the latest verdict", async () => {
+    const xdgStateHome = await makeTemp("ste-observe-state-")
+    await seedObservations(xdgStateHome, [
+      observation({
+        id: "observation-1",
+        findings: [finding(0, "contraction"), finding(1, "semicolon")],
+      }),
+      observation({ id: "observation-2", findings: [finding(0, "contraction")] }),
+      observation({ id: "observation-3", decision: "allow", findings: [] }),
+    ])
+    const stateDirectory = join(xdgStateHome, "simple-english")
+    await writeFile(
+      join(stateDirectory, "verdicts.jsonl"),
+      `${[
+        {
+          at: "2026-08-04T10:01:00.000Z",
+          observationId: "observation-1",
+          findingIndex: 0,
+          verdict: "false-positive",
+        },
+        {
+          at: "2026-08-04T10:02:00.000Z",
+          observationId: "observation-1",
+          findingIndex: 0,
+          verdict: "true-positive",
+        },
+        {
+          at: "2026-08-04T10:03:00.000Z",
+          observationId: "observation-2",
+          findingIndex: 0,
+          verdict: "false-positive",
+        },
+      ]
+        .map((record) => JSON.stringify(record))
+        .join("\n")}\n`,
+    )
+
+    const result = await runCli(["observe", "stats"], { xdgStateHome })
+
+    expect(result).toMatchObject({ code: 0, stderr: "" })
+    expect(result.stdout).toContain("Observations: 3")
+    expect(result.stdout).toContain("Clean allows: 1")
+    expect(result.stdout).toMatch(/contraction\s+2\s+2\s+50\.0%/u)
+    expect(result.stdout).toMatch(/semicolon\s+1\s+0\s+-/u)
+  })
+})

--- a/test/cli/run-cli.ts
+++ b/test/cli/run-cli.ts
@@ -22,6 +22,7 @@ export interface CliOptions {
   agentDir?: string
   preload?: string
   dictionaryPath?: string
+  observe?: string
 }
 
 export const makeTempDir = (): Promise<string> => mkdtemp(join(tmpdir(), "ste-cli-"))
@@ -37,6 +38,7 @@ export async function runCli(args: string[], options: CliOptions = {}): Promise<
     XDG_CONFIG_HOME: options.xdgConfigHome ?? join(home, ".config"),
     XDG_STATE_HOME: options.xdgStateHome ?? join(home, ".local", "state"),
     PI_CODING_AGENT_DIR: options.agentDir,
+    SIMPLE_ENGLISH_OBSERVE: options.observe,
     ...(options.dictionaryPath === undefined
       ? {}
       : { SIMPLE_ENGLISH_DICTIONARY: options.dictionaryPath }),

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -87,6 +87,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -104,6 +105,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -121,6 +123,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -147,6 +150,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -175,6 +179,7 @@ describe("lint prose-file: dictionary rule", () => {
         {
           ruleId: "dictionary-not-approved-word",
           severity: "hard",
+          snippet: expect.any(String),
           message: '"Betaword" is not in the approved-word list.',
           suggestions: [],
           line: 2,
@@ -193,6 +198,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -210,6 +216,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -226,6 +233,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -248,6 +256,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -317,6 +326,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -456,6 +466,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -485,6 +496,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -505,6 +517,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -521,6 +534,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -538,6 +552,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -557,6 +572,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -574,6 +590,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -632,6 +649,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -649,6 +667,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -671,6 +690,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"2" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -679,6 +699,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"target" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -687,6 +708,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 2,
@@ -704,6 +726,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"Betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -792,6 +815,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: '"betaword" is not in the approved-word list.',
         suggestions: [],
         line: 1,
@@ -821,6 +845,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "try", not "Attempt".',
         suggestions: ["try"],
         line: 1,
@@ -863,6 +888,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "before", not "prior to".',
         suggestions: ["before"],
         line: 2,
@@ -878,6 +904,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "to", not "in order to".',
         suggestions: ["to"],
         line: 1,
@@ -893,6 +920,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "to", not "in order to".',
         suggestions: ["to"],
         line: 1,
@@ -956,6 +984,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "about", not "approximately".',
         suggestions: ["about"],
         line: 6,
@@ -980,6 +1009,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "about", not "approximately".',
         suggestions: ["about"],
         line: 2,
@@ -998,6 +1028,7 @@ describe("lint prose-file: dictionary rule", () => {
       {
         ruleId: "dictionary-not-approved-word",
         severity: "hard",
+        snippet: expect.any(String),
         message: 'Use "advanced", not "state-of-the-art".',
         suggestions: ["advanced"],
         line: 1,


### PR DESCRIPTION
## Intent

Implement Linear ticket HUF-169 in the ste repository as a local observation log with human verdicts for hook-mode false positives. A false positive is always a human Verdict and never a machine inference. Log every enabled hook-mode lint decision, including clean allows, for write, edit, static commit-message, and reply checks. Include soft Findings and reply checks outside strict mode. Disabled sessions must log nothing. Plain CLI lint runs and the pi Adapter must stay silent. Each engine violation must expose the offending sentence or paragraph as a snippet, and this snippet field is the only pure Engine change. Record Observations after the hook decision so logging never changes the decision, and swallow all logging failures. Store local private JSONL globally under the XDG state directory, with monthly observations/YYYY-MM.jsonl files and one append-only verdicts.jsonl file. Use one O_APPEND line per write without locks so concurrent hooks do not corrupt records. Each Observation must include a unique id, ISO timestamp, claude-code-hook surface, event, session id, cwd, optional file path absent for replies, lint kind, allow or deny decision, SHA-256 text hash, and indexed Findings with rule id, severity, message, snippet, line, and column. Each Verdict must include its timestamp, Observation id, Finding index, true-positive or false-positive value, and optional note. The latest Verdict for a Finding wins. Logging is on by default, and SIMPLE_ENGLISH_OBSERVE=0 disables it. Add simple-english observe review to walk unjudged Findings through stdin with true-positive, false-positive, skip, quit, and optional-note choices. Add simple-english observe stats to report per-rule fire counts, judged counts, and false-positive rates among judged Findings, plus useful Observation denominators. Test only at the spawned CLI E2E seam with a hermetic XDG_STATE_HOME. Cover all four event types, logged snippets, clean allows, the kill switch, unchanged decisions when observation storage fails, review through stdin, seeded stats, latest-Verdict-wins, disabled sessions, and silence for plain CLI runs. Keep test fixtures outside Biome formatting. Preserve the approved ADR text exactly and document the user-facing commands and storage behavior.

## What Changed

- Log enabled hook lint decisions for write, edit, static commit-message, and reply checks to private monthly XDG JSONL files, including clean allows, soft findings, hashes, and snippets.
- Add `observe review` for append-only human verdicts and `observe stats` for per-rule false-positive reporting, with latest-verdict-wins semantics.
- Expose snippets in engine reports and document storage, privacy, failure behavior, commands, and the observation-log design.

## Risk Assessment

✅ Low: The change is well-bounded and satisfies the stated observation logging, verdict, statistics, privacy, and hook isolation requirements without new material issues.

## Testing

After inspecting the clean target worktree, targeted spawned CLI tests and a manual end-to-end workflow confirmed all four hook surfaces, snippets, clean allows, soft reply Findings, kill switch and disabled-session silence, failure-safe decisions, review, latest-verdict stats, plain CLI silence, and concurrent append integrity. No visual capture was applicable because the user surface is CLI and JSONL output.

<details>
<summary>Evidence: End-to-end hook, review, and stats transcript</summary>

```text
End-to-end observation workflow

$ simple-english hook  # write with a hard Finding
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project/write.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

$ simple-english hook  # clean edit allow
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}

$ simple-english hook  # static commit message with a hard Finding
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked commit for commit message:\n- line 1, column 11 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}

$ simple-english hook  # non-strict reply with a soft Finding
{}

$ inspect monthly observations (event, decision, path, Findings)
{
  "event": "write",
  "decision": "deny",
  "path": "/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project/write.md",
  "kind": "prose-file",
  "textHash": "sha256:e0f67caee25b39cf98631ad20cbf371ed2478bff03bde3c6a87e91a0347d641b",
  "findings": [
    {
      "index": 0,
      "ruleId": "contraction",
      "severity": "hard",
      "snippet": "This isn't permitted.",
      "line": 1,
      "column": 6
    }
  ]
}
{
  "event": "edit",
  "decision": "allow",
  "path": "/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project/edit.md",
  "kind": "prose-file",
  "textHash": "sha256:ae5d8ce7c750f7837f63073d28f152cc09ed329c28bc9d058d4c349da84bb559",
  "findings": []
}
{
  "event": "commit-message",
  "decision": "deny",
  "path": "/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project",
  "kind": "commit-message",
  "textHash": "sha256:26d3835f6e4db90dc61b2ec7937a5a66488c617fc1a336c2a73f876c0dd46c88",
  "findings": [
    {
      "index": 0,
      "ruleId": "contraction",
      "severity": "hard",
      "snippet": "fix: This isn't permitted.",
      "line": 1,
      "column": 11
    }
  ]
}
{
  "event": "reply",
  "decision": "allow",
  "kind": "prose-file",
  "textHash": "sha256:f389385b2b56ceebfc8f9e15b9e2a72abd45beff24603fd802330bae65832415",
  "findings": [
    {
      "index": 0,
      "ruleId": "hedging",
      "severity": "soft",
      "snippet": "It is important to note that the valve is open.",
      "line": 1,
      "column": 1
    }
  ]
}

$ printf clean text | simple-english  # plain lint must stay silent
Observation lines before plain lint: 4; after: 4

$ simple-english observe review  # f + note, t + no note, s

[contraction] hard at /tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project/write.md:1:6
This isn't permitted.
Do not use a contraction. Write the words in full. Found "isn't".
Verdict [t]rue, [f]alse, [s]kip, [q]uit: Note (optional): 
[contraction] hard at /tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project:1:11
fix: This isn't permitted.
Do not use a contraction. Write the words in full. Found "isn't".
Verdict [t]rue, [f]alse, [s]kip, [q]uit: Note (optional): 
[hedging] soft at assistant reply:1:1
It is important to note that the valve is open.
Do not hedge. Delete "it is important to note".
Verdict [t]rue, [f]alse, [s]kip, [q]uit: 
Recorded 2 verdicts.

$ verdicts.jsonl
{"at":"2026-08-04T04:48:23.649Z","observationId":"af430050-aeee-4035-8892-be2540374ab2","findingIndex":0,"verdict":"false-positive","note":"Quoted example from documentation."}
{"at":"2026-08-04T04:48:23.650Z","observationId":"f4dba1ef-86d2-4609-bb04-62dfc2b61bea","findingIndex":0,"verdict":"true-positive"}

$ simple-english observe stats
Observations: 4
Clean allows: 1

Rule         Fires  Judged  False-positive rate
contraction      2       2  50.0%
hedging          1       0  -
```
</details>
<details>
<summary>Evidence: Generated monthly Observation JSONL records</summary>

```text
{"id":"af430050-aeee-4035-8892-be2540374ab2","at":"2026-08-04T04:48:22.542Z","surface":"claude-code-hook","event":"write","sessionId":"evidence-session","cwd":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project","path":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project/write.md","kind":"prose-file","decision":"deny","textHash":"sha256:e0f67caee25b39cf98631ad20cbf371ed2478bff03bde3c6a87e91a0347d641b","findings":[{"index":0,"ruleId":"contraction","severity":"hard","message":"Do not use a contraction. Write the words in full. Found \"isn't\".","snippet":"This isn't permitted.","line":1,"column":6}]}
{"id":"b0989cbf-f6df-4925-8010-8ad386add42c","at":"2026-08-04T04:48:22.793Z","surface":"claude-code-hook","event":"edit","sessionId":"evidence-session","cwd":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project","path":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project/edit.md","kind":"prose-file","decision":"allow","textHash":"sha256:ae5d8ce7c750f7837f63073d28f152cc09ed329c28bc9d058d4c349da84bb559","findings":[]}
{"id":"f4dba1ef-86d2-4609-bb04-62dfc2b61bea","at":"2026-08-04T04:48:23.024Z","surface":"claude-code-hook","event":"commit-message","sessionId":"evidence-session","cwd":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project","path":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project","kind":"commit-message","decision":"deny","textHash":"sha256:26d3835f6e4db90dc61b2ec7937a5a66488c617fc1a336c2a73f876c0dd46c88","findings":[{"index":0,"ruleId":"contraction","severity":"hard","message":"Do not use a contraction. Write the words in full. Found \"isn't\".","snippet":"fix: This isn't permitted.","line":1,"column":11}]}
{"id":"f26e793e-0b80-413e-adab-161b40861d9e","at":"2026-08-04T04:48:23.246Z","surface":"claude-code-hook","event":"reply","sessionId":"evidence-session","cwd":"/tmp/no-mistakes-evidence/01KZ5GZY6FAAJZN1QNRS3X7XF1/project","kind":"prose-file","decision":"allow","textHash":"sha256:f389385b2b56ceebfc8f9e15b9e2a72abd45beff24603fd802330bae65832415","findings":[{"index":0,"ruleId":"hedging","severity":"soft","message":"Do not hedge. Delete \"it is important to note\".","snippet":"It is important to note that the valve is open.","line":1,"column":1}]}
```
</details>
<details>
<summary>Evidence: Human Verdict JSONL records</summary>

```text
{"at":"2026-08-04T04:48:23.649Z","observationId":"af430050-aeee-4035-8892-be2540374ab2","findingIndex":0,"verdict":"false-positive","note":"Quoted example from documentation."}
{"at":"2026-08-04T04:48:23.650Z","observationId":"f4dba1ef-86d2-4609-bb04-62dfc2b61bea","findingIndex":0,"verdict":"true-positive"}
```
</details>
<details>
<summary>Evidence: Concurrent append integrity check</summary>

```text
Concurrent hook processes: 24
Allow decisions returned: 24
Complete JSONL records: 24
Unique Observation ids: 24
All records have one clean Finding list: true
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `src/cli/hook.ts:651` - The intent requires &#34;every enabled hook-mode lint decision ... for ... static commit-message&#34; checks. This branch records a deny Observation for a dynamic or missing commit message before lint() runs, with the shell command as text and no Findings. Commands such as plain `git commit` therefore pollute Observation denominators with non-lint decisions. Return the deny without creating an Observation unless this broader behavior is explicitly intended.
- ⚠️ `src/cli/hook.ts:637` - Using `prepared.indexOf(violation.snippet)` always restores from the first matching occurrence. For `fix: This isn&#39;t permitted.\n\n:    This isn&#39;t permitted.`, metadata blanking makes both snippets identical, so the line-3 Finding is restored from offset 0 and logged with the wrong snippet. Select the occurrence containing the violation&#39;s absolute line and column, or preserve scope offsets.
- ⚠️ `src/cli/observation-log.ts:176` - Observation paths, snippets, and messages are arbitrary persisted text and are written directly to the terminal. A source comment or assistant reply containing ANSI or OSC control sequences will be replayed during `observe review`, allowing terminal manipulation such as clipboard replacement. Escape non-printing control characters before rendering review output.

🔧 Fix: Exclude non-lint commit denials from observations
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff and confirmed a clean worktree with `git status --short`.</code>
- <code>Ran `bun x vitest run test/cli/observe.test.ts test/cli/cli.test.ts -t &#39;simple-english observation log|--json emits a stable machine-readable report&#39;`.</code>
- <code>Manually exercised spawned CLI hook events for write, edit, static commit message, and non-strict reply using hermetic `XDG_STATE_HOME`, then reviewed verdicts and displayed stats.</code>
- `Verified a plain CLI lint did not change the Observation line count.`
- `Spawned 24 concurrent hook processes and validated complete JSONL records with unique Observation IDs.`
- <code>Confirmed observation writes remain isolated to hook mode with `rg -n &#34;appendObservation|observation-log&#34; src`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
