### PR TITLE
fix(dictionary): support Jiti JSON module interop

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@biomejs/biome": "^1.9.4",
         "@earendil-works/pi-coding-agent": "0.83.0",
         "@types/node": "^22.0.0",
+        "jiti": "2.7.0",
         "typebox": "1.3.7",
         "typescript": "^5.8.0",
         "vitest": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@biomejs/biome": "^1.9.4",
     "@earendil-works/pi-coding-agent": "0.83.0",
     "@types/node": "^22.0.0",
+    "jiti": "2.7.0",
     "typebox": "1.3.7",
     "typescript": "^5.8.0",
     "vitest": "^3.0.0"

--- a/src/dictionary/bundled-rule-data.ts
+++ b/src/dictionary/bundled-rule-data.ts
@@ -5,9 +5,12 @@ import phrasalVerbs from "./data/phrasal-verbs.json" with { type: "json" }
 import type { RuleData } from "./rule-data.ts"
 import { decodeDictionaryData } from "./schema.ts"
 
+// Jiti adds a non-enumerable default property that strict schema validation rejects.
+const decodeBundledDictionary = (data: object) => decodeDictionaryData({ ...data })
+
 export const BUNDLED_RULE_DATA: RuleData = {
-  "phrasal-verb": decodeDictionaryData(phrasalVerbs),
-  hedging: decodeDictionaryData(hedging),
-  marketing: decodeDictionaryData(marketing),
-  "adjectival-participle": decodeDictionaryData(adjectivalParticiples),
+  "phrasal-verb": decodeBundledDictionary(phrasalVerbs),
+  hedging: decodeBundledDictionary(hedging),
+  marketing: decodeBundledDictionary(marketing),
+  "adjectival-participle": decodeBundledDictionary(adjectivalParticiples),
 }

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1,7 +1,8 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 import { ExtensionRunner, createExtensionRuntime } from "@earendil-works/pi-coding-agent"
 import type { AutocompleteItem } from "@earendil-works/pi-tui"
+import { createJiti } from "jiti/static"
 import { afterEach, describe, expect, test, vi } from "vitest"
 import simpleEnglishExtension from "../../src/extension/index.ts"
 
@@ -398,7 +399,15 @@ describe.sequential("pi extension wiring", () => {
       "@earendil-works/pi-coding-agent": "*",
       typebox: "*",
     })
-    expect(manifest.devDependencies).toMatchObject({ typebox: "1.3.7" })
+    expect(manifest.devDependencies).toMatchObject({ jiti: "2.7.0", typebox: "1.3.7" })
+  })
+
+  test("loads the extension entry with Jiti", async () => {
+    const jiti = createJiti(import.meta.url, { moduleCache: false })
+
+    await expect(
+      jiti.import(resolve("src/extension/index.ts"), { default: true }),
+    ).resolves.toEqual(expect.any(Function))
   })
 
   test("injects a grouped rule summary that reflects merged active settings", async () => {


### PR DESCRIPTION
## Intent

Fix agent-simple-english so pi starts successfully when the package extension loads through Jiti. Preserve strict dictionary schema validation, add a regression test that reproduces the real Jiti JSON-module interop shape, validate the publishable package through pi's managed npm installation flow, and raise a pull request with the fix.

## What Changed

- Copy bundled JSON data into plain objects before strict schema validation so pi can import the extension through Jiti.
- Add Jiti as a test dependency and verify the extension entry import with its JSON-module interop behavior.

## Risk Assessment

✅ Low: The narrow fix removes only Jiti's wrapper property while retaining strict validation for all JSON fields.

## Testing

No baseline results were supplied. Focused tests passed. Pi installed the tarball, started RPC mode, registered `/ste`, and reported the dictionary as loaded.

<details>
<summary>Evidence: Pi extension end-to-end summary</summary>

<code>RPC startup: success&#10;Extension command: ste&#10;Extension source: npm:agent-simple-english@0.2.0&#10;Status command: success&#10;Mode: enabled&#10;Rules: 9 hard, 3 soft, 0 off&#10;Dictionary: loaded</code>

```text
RPC startup: success
Extension command: ste
Extension source: npm:agent-simple-english@0.2.0
Installed entry: /home/jyooi/.no-mistakes/worktrees/3bbfcc275f38/01KZ6JPN5ZN6G653VZ4MEP6B3J/.pi-managed-test/npm/node_modules/agent-simple-english/src/extension/index.ts
Status command: success
Mode: enabled
Rules: 9 hard, 3 soft, 0 off
Dictionary: loaded
```
</details>
<details>
<summary>Evidence: Pi managed npm installation transcript</summary>

```text
Installing npm:agent-simple-english@0.2.0...

added 45 packages, and audited 46 packages in 2s

28 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Installed npm:agent-simple-english@0.2.0

Installed package manifest:
{
  "name": "agent-simple-english",
  "version": "0.2.0",
  "extension": "./src/extension/index.ts",
  "hasJitiDependency": false
}
```
</details>
- Evidence: Publishable npm tarball (local file: <code>/tmp/no-mistakes-evidence/01KZ6JPN5ZN6G653VZ4MEP6B3J/agent-simple-english-0.2.0.tgz</code>)
<details>
<summary>Evidence: Publishable package content check</summary>

```text
package/package.json
package/src/dictionary/data/adjectival-participles.json
package/src/dictionary/data/hedging.json
package/src/dictionary/data/marketing.json
package/src/dictionary/data/phrasal-verbs.json
package/src/dictionary/data/pi-ste.json
package/src/extension/index.ts
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` for test setup</code>
- `bunx vitest run test/extension/extension.test.ts -t 'loads the extension entry with Jiti'`
- `bunx vitest run test/cli/cli.test.ts -t 'reports an unknown-property dictionary and continues other rules'`
- <code>`npm pack --pack-destination /tmp/no-mistakes-evidence/01KZ6JPN5ZN6G653VZ4MEP6B3J` and tarball content inspection</code>
- <code>`pi install npm:agent-simple-english@0.2.0` with an isolated agent directory and a local npm wrapper for the new tarball</code>
- <code>Pi RPC startup with `get_commands` and `/ste status`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
