### PR TITLE
chore: prepare v0.2.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "simple-english",
       "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "JIA YI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-simple-english",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Intent

Release the merged Jiti JSON module interop fix as agent-simple-english v0.2.1. Prepare a patch version across the npm package and Claude plugin manifests, validate tests, lint, typechecking, and the publishable tarball through isolated CLI and pi installation checks, then publish the release to GitHub and npm.

## What Changed

- Bumped the package version from 0.2.0 to 0.2.1 in `package.json` to ship the previously merged Jiti JSON module interop fix as a patch release.
- Bumped the matching plugin version in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so all three manifests agree on 0.2.1, as confirmed by the pipeline's version consistency check.
- No source changes; the pipeline validated the release commit with the full test suite (701 tests), an `npm pack` tarball install, isolated CLI and pi-style installation checks, and a regression repro of the pre-fix decode failure.

## Risk Assessment

✅ Low: The change is a minimal, consistent three-file version bump from 0.2.0 to 0.2.1 with no code changes, no stale version references, and the intended Jiti fix already merged at the base commit.

## Testing

Ran the full Vitest suite (701 tests pass) on the release commit, verified 0.2.1 across all three manifests, packed the publishable tarball, and demonstrated it end-to-end in isolated installs: the CLI reports 0.2.1 and lints with bundled dictionaries from a prod-only install, and a pi-style install loads the extension through Jiti with all dictionaries decoding, including a repro showing the pre-fix decode fails under Jiti while the shipped fix succeeds; lint/typecheck were skipped per gate rules (CI covers them) and publishing itself is a post-gate step (npm still shows 0.2.0).

<details>
<summary>Evidence: Version consistency across manifests and packed tarball</summary>

<code>package.json: 0.2.1&#10;.claude-plugin/plugin.json: 0.2.1&#10;.claude-plugin/marketplace.json (simple-english plugin): 0.2.1&#10;npm pack: agent-simple-english-0.2.1.tgz version: 0.2.1 files: 61&#10;installed package.json: 0.2.1&#10;installed plugin.json: 0.2.1</code>

```text
$ node -p versions across manifests (worktree, target commit f8d6b9a)
package.json:              0.2.1
.claude-plugin/plugin.json: 0.2.1
.claude-plugin/marketplace.json (simple-english plugin): 0.2.1

$ npm pack (tarball details)
filename: agent-simple-english-0.2.1.tgz  version: 0.2.1  files: 61  unpacked: 296.6 kB

--- versions from the INSTALLED tarball (npm install --omit=dev agent-simple-english-0.2.1.tgz) ---
installed package.json:     0.2.1
installed plugin.json:      0.2.1
```
</details>
<details>
<summary>Evidence: CLI transcript from installed 0.2.1 tarball (prod-only install)</summary>

<code>$ simple-english --version&#10;0.2.1&#10;&#10;$ simple-english sample.md&#10;sample.md:1:3 [hard] dictionary-not-approved-word Use &#34;use&#34;, not &#34;Utilization&#34;.&#10;sample.md:3:20 [hard] dictionary-not-approved-word Use &#34;use&#34;, not &#34;utilize&#34;.&#10;sample.md:3:40 [hard] dictionary-not-approved-word Use &#34;to&#34;, not &#34;in order to&#34;.&#10;sample.md:3:52 [hard] phrasal-verb Do not use a phrasal verb. Use &#34;do&#34;, not &#34;carry out&#34;.&#10;sample.md:4:23 [soft] marketing Do not use marketing language. Delete &#34;world-class&#34;.&#10;exit code: 1</code>

```text
# CLI from installed 0.2.1 tarball (npm install --omit=dev agent-simple-english-0.2.1.tgz)

$ cat sample.md
# Utilization guide

We should probably utilize the new API in order to carry out the migration.
It is very unique and world-class.

$ simple-english --version
0.2.1

$ simple-english sample.md
sample.md:1:3 [hard] dictionary-not-approved-word Use "use", not "Utilization".
sample.md:3:20 [hard] dictionary-not-approved-word Use "use", not "utilize".
sample.md:3:40 [hard] dictionary-not-approved-word Use "to", not "in order to".
sample.md:3:52 [hard] phrasal-verb Do not use a phrasal verb. Use "do", not "carry out".
sample.md:4:23 [soft] marketing Do not use marketing language. Delete "world-class".
exit code: 1
```
</details>
<details>
<summary>Evidence: pi-style Jiti extension load + pre-fix vs fixed decode repro</summary>

<code>pi extension entry loaded through Jiti: function&#10;bundled dictionaries decoded: phrasal-verb(11 entries), hedging(1 entries), marketing(1 entries), adjectival-participle(1 entries)&#10;&#10;v0.2.0-style decode fails under Jiti: &lt;schema rejection&gt;&#10;v0.2.1 decode (spread copy, the shipped fix): succeeds</code>

```text
# pi-style install check: tarball installed with --omit=dev, host peers @earendil-works/pi-coding-agent@0.83.0 + typebox@1.3.7, extension loaded through Jiti 2.7.0

$ node load-extension.mjs
pi extension entry loaded through Jiti: function
bundled dictionaries decoded: phrasal-verb(11 entries), hedging(1 entries), marketing(1 entries), adjectival-participle(1 entries)

$ node prefix-repro.mjs   # v0.2.0 decode path vs shipped v0.2.1 fix
v0.2.0-style decode fails under Jiti: { readonly formatVersion: 1; readonly source: { readonly name: NonEmptyTrimmedString; readonly repository: NonEmptyTrimmedString; readonly commit: NonEmptyTrimmed
v0.2.1 decode (spread copy, the shipped fix): succeeds
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun run test` (Vitest, 701 tests / 26 files, all pass on the release commit)</code>
- <code>Version consistency check across `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` (all 0.2.1)</code>
- <code>`npm pack` -&gt; agent-simple-english-0.2.1.tgz, installed with `npm install --omit=dev` into an isolated dir</code>
- <code>Installed-tarball CLI: `bun node_modules/agent-simple-english/src/cli/main.ts --version` reports 0.2.1; linting a sample file fires bundled-dictionary rules and exits 1 on hard violations</code>
- `pi-style install check: tarball + pinned host peers (@earendil-works/pi-coding-agent@0.83.0, typebox@1.3.7), extension entry loaded through Jiti 2.7.0 and all four bundled dictionaries decoded`
- `Pre-fix regression repro in the same harness: v0.2.0-style decode of the raw Jiti JSON module throws a schema rejection; the shipped spread-copy decode succeeds`
- <code>Read-only `npm view agent-simple-english versions` (0.2.1 not yet published, consistent with pre-publish gating)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
