### PR TITLE
fix(cli): toggle enforcement with bare session commands

### DIFF
--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -9,6 +9,7 @@ import {
   getSessionControl,
   setSessionEnabled,
   setSessionStrict,
+  toggleSessionEnabled,
 } from "./session-state.ts"
 
 const USAGE = "Usage: /ase [on|off|status|strict|strict off]"
@@ -29,6 +30,12 @@ const readControl = (sessionId: string) =>
 const updateEnabled = (sessionId: string, enabled: boolean) =>
   Effect.tryPromise({
     try: () => setSessionEnabled(sessionId, enabled),
+    catch: (cause) => new Error(`cannot update session state: ${cause}`),
+  })
+
+const toggleEnabled = (sessionId: string) =>
+  Effect.tryPromise({
+    try: () => toggleSessionEnabled(sessionId),
     catch: (cause) => new Error(`cannot update session state: ${cause}`),
   })
 
@@ -70,12 +77,9 @@ export function runSessionCommand(args: readonly string[]): Effect.Effect<string
   }
   const command = commandParts.join(" ").trim().toLowerCase()
   if (command === "") {
-    return Effect.gen(function* () {
-      const control = yield* readControl(sessionId)
-      const enabled = !control.enabled
-      yield* updateEnabled(sessionId, enabled)
-      return `Writing-rule enforcement ${enabled ? "enabled" : "disabled"}.`
-    })
+    return toggleEnabled(sessionId).pipe(
+      Effect.map((enabled) => `Writing-rule enforcement ${enabled ? "enabled" : "disabled"}.`),
+    )
   }
   if (command === "status") return status(sessionId, cwd)
   if (command === "on") {

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -69,6 +69,14 @@ export function runSessionCommand(args: readonly string[]): Effect.Effect<string
     return Effect.fail(new Error(USAGE))
   }
   const command = commandParts.join(" ").trim().toLowerCase()
+  if (command === "") {
+    return Effect.gen(function* () {
+      const control = yield* readControl(sessionId)
+      const enabled = !control.enabled
+      yield* updateEnabled(sessionId, enabled)
+      return `Writing-rule enforcement ${enabled ? "enabled" : "disabled"}.`
+    })
+  }
   if (command === "status") return status(sessionId, cwd)
   if (command === "on") {
     return updateEnabled(sessionId, true).pipe(Effect.as("Writing-rule enforcement enabled."))

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -147,15 +147,26 @@ export async function getSessionControl(sessionId: string): Promise<SessionContr
   })
 }
 
+const setEnabled = (state: SessionState, enabled: boolean): SessionState => ({
+  ...state,
+  enabled,
+  strict: enabled ? state.strict : false,
+  ...(enabled || state.pendingFeedback === undefined ? {} : { pendingFeedback: undefined }),
+})
+
 export async function setSessionEnabled(sessionId: string, enabled: boolean): Promise<void> {
   await withStateLock(sessionId, async () => {
     const state = currentState(await readState(sessionId))
-    await writeState(sessionId, {
-      ...state,
-      enabled,
-      strict: enabled ? state.strict : false,
-      ...(enabled || state.pendingFeedback === undefined ? {} : { pendingFeedback: undefined }),
-    })
+    await writeState(sessionId, setEnabled(state, enabled))
+  })
+}
+
+export async function toggleSessionEnabled(sessionId: string): Promise<boolean> {
+  return withStateLock(sessionId, async () => {
+    const state = currentState(await readState(sessionId))
+    const enabled = !state.enabled
+    await writeState(sessionId, setEnabled(state, enabled))
+    return enabled
   })
 }
 

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -276,6 +276,32 @@ describe("simple-english CLI hook mode", () => {
     ).resolves.toMatchObject({ version: 3, enabled: true, strict: false })
   })
 
+  test("applies concurrent bare toggles atomically", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const results = await Promise.all(
+      Array.from({ length: 6 }, () => runSessionCommand("session-1", cwd, "", xdgStateHome)),
+    )
+
+    expect(results).toHaveLength(6)
+    expect(results.every(({ code }) => code === 0)).toBe(true)
+    expect(
+      results.filter(({ stdout }) => stdout === "Writing-rule enforcement disabled.\n"),
+    ).toHaveLength(3)
+    expect(
+      results.filter(({ stdout }) => stdout === "Writing-rule enforcement enabled.\n"),
+    ).toHaveLength(3)
+    const files = await stateFiles(xdgStateHome)
+    expect(files).toHaveLength(1)
+    await expect(
+      readFile(join(xdgStateHome, "simple-english", "sessions", files[0] as string), "utf8").then(
+        JSON.parse,
+      ),
+    ).resolves.toMatchObject({ version: 3, enabled: true, strict: false })
+  }, 15_000)
+
   test("starts a new session in enabled non-strict mode", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -252,6 +252,30 @@ describe("simple-english CLI hook mode", () => {
     expect(enabledState).toMatchObject({ version: 3, enabled: true, strict: false })
   }, 15_000)
 
+  test("toggles enforcement with empty and whitespace-only commands", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const disabled = await runSessionCommand("session-1", cwd, "", xdgStateHome)
+    const files = await stateFiles(xdgStateHome)
+    expect(disabled).toMatchObject({ code: 0, stdout: "Writing-rule enforcement disabled.\n" })
+    expect(files).toHaveLength(1)
+    await expect(
+      readFile(join(xdgStateHome, "simple-english", "sessions", files[0] as string), "utf8").then(
+        JSON.parse,
+      ),
+    ).resolves.toMatchObject({ version: 3, enabled: false, strict: false })
+
+    const enabled = await runSessionCommand("session-1", cwd, "   ", xdgStateHome)
+    expect(enabled).toMatchObject({ code: 0, stdout: "Writing-rule enforcement enabled.\n" })
+    await expect(
+      readFile(join(xdgStateHome, "simple-english", "sessions", files[0] as string), "utf8").then(
+        JSON.parse,
+      ),
+    ).resolves.toMatchObject({ version: 3, enabled: true, strict: false })
+  })
+
   test("starts a new session in enabled non-strict mode", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))


### PR DESCRIPTION
## Intent

Make the bare /ase Claude Code session command toggle writing-rule enforcement, as README.md documents. Read the current enabled state for that session and set the opposite state. Empty and whitespace-only arguments must disable enabled sessions or enable disabled sessions, exit zero, and use the same messages as explicit on and off commands. Preserve all behavior and messages for status, on, off, strict, strict on, and strict off. Unknown commands must still print usage and exit nonzero. The bare toggle must control all enforcement and must not act as a separate strict-mode toggle. Add a regression test that covers both toggle directions and fails on the prior code. Do not change README.md because it already documents this behavior. Check the pi Adapter for parity, but leave it unchanged because its bare command already toggles enforcement.

## What Changed

- Make empty and whitespace-only session commands atomically toggle all enforcement for the selected session.
- Return the existing enabled or disabled message after each toggle.
- Add CLI regression coverage for both directions and concurrent toggles.

## Risk Assessment

✅ Low: The atomic toggle uses the session lock, keeps existing state transitions, and adds focused coverage for both directions and concurrent calls.

## Testing

After locked dependency setup, focused CLI and pi tests passed, and an end-to-end transcript confirmed toggles, preserved messages, strict reset, and invalid-command handling.

<details>
<summary>Evidence: Claude Code /ase bare-toggle end-to-end transcript</summary>

```text
Claude Code /ase bare-toggle end-to-end transcript
A violating Write request shows whether enforcement is active.

$ Write with default session state
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/no-mistakes-evidence/01KZ83Z5XGB1CJF0VWS9K973T9/evidence-notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn’t\". Suggested fix: Write the contracted words in full."}}
exit=0

$ /ase
Writing-rule enforcement disabled.
exit=0

$ Write after bare /ase
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}
exit=0

$ /ase <whitespace-only>
Writing-rule enforcement enabled.
exit=0

$ Write after whitespace-only /ase
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/no-mistakes-evidence/01KZ83Z5XGB1CJF0VWS9K973T9/evidence-notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn’t\". Suggested fix: Write the contracted words in full."}}
exit=0

$ /ase strict on
Writing-rule strict mode enabled.
exit=0

$ /ase (from strict mode)
Writing-rule enforcement disabled.
exit=0

$ /ase status
Mode: disabled
Rules: 9 hard, 3 soft, 0 off
Dictionary: loaded
exit=0

$ Write after bare /ase disabled strict mode
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}
exit=0

$ /ase (enable again)
Writing-rule enforcement enabled.
exit=0

$ /ase status (strict must remain off)
Mode: enabled
Rules: 9 hard, 3 soft, 0 off
Dictionary: loaded
exit=0

$ /ase off
Writing-rule enforcement disabled.
exit=0

$ /ase on
Writing-rule enforcement enabled.
exit=0

$ /ase strict
Writing-rule strict mode enabled.
exit=0

$ /ase status (strict)
Mode: strict
Rules: 9 hard, 3 soft, 0 off
Dictionary: loaded
exit=0

$ /ase strict off
Writing-rule strict mode disabled.
exit=0

$ /ase unknown
Usage: /ase [on|off|status|strict|strict off]
exit=2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/cli/session-command.ts:74` - Two bare commands at the same time can both read enabled and both write disabled, so the second command does not toggle. Add one atomic session-state toggle function.

🔧 Fix: Make bare session toggles atomic
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial focused CLI test command failed because `vitest` was absent.</code>
- <code>`bun install --frozen-lockfile` restored locked project dependencies.</code>
- `bun run test -- test/cli/hook.test.ts -t 'toggles enforcement with empty and whitespace-only commands|applies concurrent bare toggles atomically|disables every hook gate for only the selected session and enables it again|reports session mode, rule counts, and dictionary state|blocks one strict Stop, then allows the clean rewrite Stop|records deferred feedback from an active Stop after strict mode is off|rejects an invalid session command without changing state'`
- `bun run test -- test/extension/extension.test.ts -t 'toggles write, edit, commit, and reply enforcement for the session|turns strict mode off and restores normal assistant replies'`
- <code>Ran `bun src/cli/main.ts session` and `bun src/cli/main.ts hook` through default, bare, whitespace, strict, explicit, status, and unknown command states.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
