### PR TITLE
chore: prepare v0.3.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "simple-english",
       "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "author": {
         "name": "JIA YI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-simple-english",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Intent

Prepare agent-simple-english v0.3.1 after the CLI fix reached main. Update all package and Claude plugin version manifests from 0.3.0 to 0.3.1, verify the npm package, run project checks, push the release branch, and open a release preparation PR. Publishing remains a separate local user action because npm requires browser-based two-factor authentication.

## What Changed

- Bumped the package version in `package.json` from 0.3.0 to 0.3.1.
- Bumped the matching Claude plugin manifests, `.claude-plugin/plugin.json` and the `simple-english` entry in `.claude-plugin/marketplace.json`, to 0.3.1 so all three version surfaces agree.
- Version-manifest change only; no engine, CLI, or adapter behavior is touched. The release picks up the CLI enforcement-toggle fix already merged in f1beaa9. Pipeline verification covered the full Vitest suite (703 tests), `npm pack`/`publish --dry-run`, a clean-consumer install of the packed 0.3.1 tarball, and `claude plugin validate`. Publishing to npm stays a separate local action because it needs browser-based two-factor authentication.

## Risk Assessment

✅ Low: The change is three mechanical version-string bumps from 0.3.0 to 0.3.1 across the package and Claude plugin manifests, matching the established release-commit pattern with no other version references, lockfile drift, or behavioral code touched.

## Testing

I installed dependencies (absent in the worktree) and ran the full Vitest suite, which passes at 703 tests, then verified the release intent at the product level rather than by unit tests alone: npm pack and publish dry runs resolve agent-simple-english@0.3.1, and installing that tarball into a clean consumer project produced a working 0.3.1 CLI that reports its version, flags three hard dictionary violations with exit code 1 on a sample README, and toggles enforcement from a bare session command, which demonstrates the shipped artifact really carries the #43 CLI fix this release exists for. Manifest consistency is confirmed by grep (no 0.3.0 anywhere, including the lockfile), `claude plugin validate`, and `claude plugin tag --dry-run`, which independently checks plugin.json against the marketplace entry; `npm view` shows 0.3.1 is still unpublished, matching the intent that publishing stays a separate user action. Evidence is CLI transcripts and manifest/dry-run output because every surface this change touches is a terminal CLI and JSON version manifests, with no rendered UI to screenshot. Per the testing rules I did not run Biome or tsc, and I did not push the branch or open the PR since those are later pipeline steps; no failures or flakiness surfaced.

<details>
<summary>Evidence: End-user transcript: installed agent-simple-english@0.3.1 from npm tarball</summary>

<code>$ npm ls agent-simple-english&#10;`-- agent-simple-english@0.3.1&#10;&#10;$ simple-english --version&#10;0.3.1&#10;&#10;$ cat README.md&#10;# Notes&#10;&#10;We utilize the pump in order to commence the operation.&#10;&#10;$ simple-english README.md&#10;README.md:3:4 [hard] dictionary-not-approved-word Use &#34;use&#34;, not &#34;utilize&#34;.&#10;README.md:3:21 [hard] dictionary-not-approved-word Use &#34;to&#34;, not &#34;in order to&#34;.&#10;README.md:3:33 [hard] dictionary-not-approved-word Use &#34;start&#34;, not &#34;commence&#34;.&#10;exit: 1&#10;&#10;# The 0.3.1 release carries the CLI fix from #43: a bare /ase command toggles enforcement.&#10;$ simple-english session session-1 $PWD &#39;&#39; # bare /ase&#10;Writing-rule enforcement disabled.&#10;$ simple-english session session-1 $PWD &#39; &#39; # whitespace-only /ase&#10;Writing-rule enforcement enabled.&#10;$ simple-english session session-1 $PWD status&#10;Mode: enabled&#10;Rules: 9 hard, 3 soft, 0 off&#10;Dictionary: loaded</code>

```text
# End-user transcript: installed agent-simple-english@0.3.1 (from npm tarball)

$ npm ls agent-simple-english
consumer@1.0.0 /private/tmp/ase-release-check.bHv7yU/consumer
`-- agent-simple-english@0.3.1


$ simple-english --version
0.3.1

$ cat README.md
# Notes

We utilize the pump in order to commence the operation.
$ simple-english README.md
README.md:3:4 [hard] dictionary-not-approved-word Use "use", not "utilize".
README.md:3:21 [hard] dictionary-not-approved-word Use "to", not "in order to".
README.md:3:33 [hard] dictionary-not-approved-word Use "start", not "commence".
exit: 1

# The 0.3.1 release carries the CLI fix from #43: a bare /ase command toggles enforcement.
$ simple-english session session-1 $PWD ''      # bare /ase
Writing-rule enforcement disabled.
$ simple-english session session-1 $PWD '   '   # whitespace-only /ase
Writing-rule enforcement enabled.
$ simple-english session session-1 $PWD status
Mode: enabled
Rules: 9 hard, 3 soft, 0 off
Dictionary: loaded
```
</details>
<details>
<summary>Evidence: Version manifests, plugin validation, and registry state</summary>

<code>$ grep -rn &#39;&#34;version&#34;&#39; package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json&#10;.claude-plugin/plugin.json:4: &#34;version&#34;: &#34;0.3.1&#34;,&#10;package.json:3: &#34;version&#34;: &#34;0.3.1&#34;,&#10;.claude-plugin/marketplace.json:14: &#34;version&#34;: &#34;0.3.1&#34;,&#10;&#10;$ claude plugin validate .&#10;✔ Validation passed&#10;&#10;$ claude plugin tag . --dry-run # checks plugin.json and marketplace entry agree&#10;Plugin: simple-english&#10;Version: 0.3.1 (from plugin.json)&#10;Marketplace entry: plugins[0] in .claude-plugin/marketplace.json (version: 0.3.1)&#10;Tag: simple-english--v0.3.1&#10;✔ Dry run — would create tag simple-english--v0.3.1 at HEAD&#10;&#10;$ npm view agent-simple-english versions # 0.3.1 not yet published (separate user action)&#10;[ &#39;0.1.0&#39;, &#39;0.2.0&#39;, &#39;0.2.1&#39;, &#39;0.3.0&#39; ]</code>

```text
# Version manifests at v0.3.1

$ grep -rn '"version"' package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
.claude-plugin/plugin.json:4:  "version": "0.3.1",
package.json:3:  "version": "0.3.1",
14:      "version": "0.3.1",

$ grep -rn '0\.3\.0' . (excluding node_modules) -> no matches

$ claude plugin validate .
Validating marketplace manifest: /Users/jyooi/.no-mistakes/worktrees/0610e6f987b5/01KZ8588K22GD0DGN1KWY31Z7M/.claude-plugin/marketplace.json

✔ Validation passed

$ claude plugin tag . --dry-run   # checks plugin.json and marketplace entry agree
Plugin:  simple-english
Version: 0.3.1 (from plugin.json)
Marketplace entry: plugins[0] in /Users/jyooi/.no-mistakes/worktrees/0610e6f987b5/01KZ8588K22GD0DGN1KWY31Z7M/.claude-plugin/marketplace.json (version: 0.3.1)
Tag:     simple-english--v0.3.1

✔ Dry run — would create tag simple-english--v0.3.1 at HEAD in /Users/jyooi/.no-mistakes/worktrees/0610e6f987b5/01KZ8588K22GD0DGN1KWY31Z7M
  git -C /Users/jyooi/.no-mistakes/worktrees/0610e6f987b5/01KZ8588K22GD0DGN1KWY31Z7M tag -a simple-english--v0.3.1 -m "simple-english 0.3.1"
  git -C /Users/jyooi/.no-mistakes/worktrees/0610e6f987b5/01KZ8588K22GD0DGN1KWY31Z7M push origin refs/tags/simple-english--v0.3.1

$ npm view agent-simple-english versions   # 0.3.1 not yet published (separate user action)
[ '0.1.0', '0.2.0', '0.2.1', '0.3.0' ]
```
</details>
<details>
<summary>Evidence: npm publish dry run for 0.3.1</summary>

<code>$ npm publish --dry-run&#10;npm notice name: agent-simple-english&#10;npm notice version: 0.3.1&#10;npm notice filename: agent-simple-english-0.3.1.tgz&#10;npm notice package size: 72.2 kB&#10;npm notice total files: 61&#10;+ agent-simple-english@0.3.1</code>

```text
$ npm publish --dry-run
npm notice
npm notice package: agent-simple-english@0.3.1
npm notice Tarball Contents
npm notice 632B .claude-plugin/marketplace.json
npm notice 421B .claude-plugin/plugin.json
npm notice 1.1kB LICENSE
npm notice 22.0kB README.md
npm notice 926B THIRD_PARTY_NOTICES.md
npm notice 371B commands/ase.md
npm notice 1.1kB hooks/hooks.json
npm notice 2.0kB package.json
npm notice 14.0kB src/adapter/commit-message.ts
npm notice 1.8kB src/adapter/feedback.ts
npm notice 4.4kB src/adapter/rule-summary.ts
npm notice 25.7kB src/cli/hook.ts
npm notice 8.6kB src/cli/main.ts
npm notice 8.5kB src/cli/observation-log.ts
npm notice 3.8kB src/cli/session-command.ts
npm notice 7.6kB src/cli/session-state.ts
npm notice 328B src/cli/state-directory.ts
npm notice 3.2kB src/config/load.ts
npm notice 737B src/config/merge.ts
npm notice 3.1kB src/config/schema.ts
npm notice 843B src/dictionary/bundled-rule-data.ts
npm notice 600B src/dictionary/configured.ts
npm notice 306B src/dictionary/data/adjectival-participles.json
npm notice 527B src/dictionary/data/hedging.json
npm notice 900B src/dictionary/data/marketing.json
npm notice 1.7kB src/dictionary/data/phrasal-verbs.json
npm notice 5.2kB src/dictionary/data/pi-ste.json
npm notice 322B src/dictionary/form.ts
npm notice 4.4kB src/dictionary/load.ts
npm notice 3.8kB src/dictionary/README.md
npm notice 378B src/dictionary/rule-data.ts
npm notice 1.5kB src/dictionary/schema.ts
npm notice 501B src/engine/case-fold.ts
npm notice 18.5kB src/engine/comments.ts
npm notice 5.7kB src/engine/diff-match.ts
npm notice 9.7kB src/engine/diff.ts
npm notice 764B src/engine/identifiers.ts
npm notice 1.6kB src/engine/kinds.ts
npm notice 17.3kB src/engine/lint.ts
npm notice 4.6kB src/engine/markdown-syntax.ts
npm notice 22.0kB src/engine/markdown.ts
npm notice 4.4kB src/engine/paragraphs.ts
npm notice 1.9kB src/engine/phrase-matcher.ts
npm notice 811B src/engine/rules/contraction.ts
npm notice 9.6kB src/engine/rules/dictionary.ts
npm notice 1.0kB src/engine/rules/hedging.ts
npm notice 4.3kB src/engine/rules/marketing.ts
npm notice 773B src/engine/rules/paragraph-length.ts
npm notice 1.7kB src/engine/rules/phrasal-verb.ts
npm notice 321B src/engine/rules/registry.ts
npm notice 404B src/engine/rules/semicolon.ts
npm notice 691B src/engine/rules/sentence-length.ts
npm notice 3.5kB src/engine/rules/verb-form.ts
npm notice 376B src/engine/scan.ts
npm notice 19.4kB src/engine/sentences.ts
npm notice 5.3kB src/engine/suppression.ts
npm notice 194B src/engine/tagger.ts
npm notice 163B src/engine/tokens.ts
npm notice 1.7kB src/engine/types.ts
npm notice 27.6kB src/extension/index.ts
npm notice 1.5kB src/tagger/wink.ts
npm notice Tarball Details
npm notice name: agent-simple-english
npm notice version: 0.3.1
npm notice filename: agent-simple-english-0.3.1.tgz
npm notice package size: 72.2 kB
npm notice unpacked size: 297.4 kB
npm notice shasum: 33b18c8ed83b07842f3f50c9ca9dd68c30c4ca79
npm notice integrity: sha512-SgD0yc2fR7f/Y[...]hlVttpCvw0teA==
npm notice total files: 61
npm notice
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ agent-simple-english@0.3.1
```
</details>
<details>
<summary>Evidence: npm pack dry run file listing</summary>

```text
npm notice
npm notice package: agent-simple-english@0.3.1
npm notice Tarball Contents
npm notice 632B .claude-plugin/marketplace.json
npm notice 421B .claude-plugin/plugin.json
npm notice 1.1kB LICENSE
npm notice 22.0kB README.md
npm notice 926B THIRD_PARTY_NOTICES.md
npm notice 371B commands/ase.md
npm notice 1.1kB hooks/hooks.json
npm notice 2.0kB package.json
npm notice 14.0kB src/adapter/commit-message.ts
npm notice 1.8kB src/adapter/feedback.ts
npm notice 4.4kB src/adapter/rule-summary.ts
npm notice 25.7kB src/cli/hook.ts
npm notice 8.6kB src/cli/main.ts
npm notice 8.5kB src/cli/observation-log.ts
npm notice 3.8kB src/cli/session-command.ts
npm notice 7.6kB src/cli/session-state.ts
npm notice 328B src/cli/state-directory.ts
npm notice 3.2kB src/config/load.ts
npm notice 737B src/config/merge.ts
npm notice 3.1kB src/config/schema.ts
npm notice 843B src/dictionary/bundled-rule-data.ts
npm notice 600B src/dictionary/configured.ts
npm notice 306B src/dictionary/data/adjectival-participles.json
npm notice 527B src/dictionary/data/hedging.json
npm notice 900B src/dictionary/data/marketing.json
npm notice 1.7kB src/dictionary/data/phrasal-verbs.json
npm notice 5.2kB src/dictionary/data/pi-ste.json
npm notice 322B src/dictionary/form.ts
npm notice 4.4kB src/dictionary/load.ts
npm notice 3.8kB src/dictionary/README.md
npm notice 378B src/dictionary/rule-data.ts
npm notice 1.5kB src/dictionary/schema.ts
npm notice 501B src/engine/case-fold.ts
npm notice 18.5kB src/engine/comments.ts
npm notice 5.7kB src/engine/diff-match.ts
npm notice 9.7kB src/engine/diff.ts
npm notice 764B src/engine/identifiers.ts
npm notice 1.6kB src/engine/kinds.ts
npm notice 17.3kB src/engine/lint.ts
npm notice 4.6kB src/engine/markdown-syntax.ts
npm notice 22.0kB src/engine/markdown.ts
npm notice 4.4kB src/engine/paragraphs.ts
npm notice 1.9kB src/engine/phrase-matcher.ts
npm notice 811B src/engine/rules/contraction.ts
npm notice 9.6kB src/engine/rules/dictionary.ts
npm notice 1.0kB src/engine/rules/hedging.ts
npm notice 4.3kB src/engine/rules/marketing.ts
npm notice 773B src/engine/rules/paragraph-length.ts
npm notice 1.7kB src/engine/rules/phrasal-verb.ts
npm notice 321B src/engine/rules/registry.ts
npm notice 404B src/engine/rules/semicolon.ts
npm notice 691B src/engine/rules/sentence-length.ts
npm notice 3.5kB src/engine/rules/verb-form.ts
npm notice 376B src/engine/scan.ts
npm notice 19.4kB src/engine/sentences.ts
npm notice 5.3kB src/engine/suppression.ts
npm notice 194B src/engine/tagger.ts
npm notice 163B src/engine/tokens.ts
npm notice 1.7kB src/engine/types.ts
npm notice 27.6kB src/extension/index.ts
npm notice 1.5kB src/tagger/wink.ts
npm notice Tarball Details
npm notice name: agent-simple-english
npm notice version: 0.3.1
npm notice filename: agent-simple-english-0.3.1.tgz
npm notice package size: 72.2 kB
npm notice unpacked size: 297.4 kB
npm notice shasum: 33b18c8ed83b07842f3f50c9ca9dd68c30c4ca79
npm notice integrity: sha512-SgD0yc2fR7f/Y[...]hlVttpCvw0teA==
npm notice total files: 61
npm notice
agent-simple-english-0.3.1.tgz
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` (bun 1.3.11; deps were absent in the worktree)</code>
- <code>`bun run test` - full Vitest suite, 703 tests / 26 files pass</code>
- <code>`bun src/cli/main.ts --version` and `--help` in the worktree</code>
- <code>`npm pack --dry-run` and `npm publish --dry-run` - confirms name/version/filename agent-simple-english-0.3.1.tgz, 61 files</code>
- <code>`npm pack --pack-destination &lt;tmp&gt;` then `npm install --omit=dev &lt;tmp&gt;/agent-simple-english-0.3.1.tgz` into a clean consumer project, then ran `./node_modules/.bin/simple-english --version` (prints 0.3.1)</code>
- <code>Extracted the packed tarball and grepped `package/package.json` and `package/.claude-plugin/plugin.json` - both 0.3.1</code>
- `Manual end-user run of the installed 0.3.1 binary against a README with STE violations - 3 hard findings, exit code 1`
- <code>Manual run of the installed 0.3.1 binary for the #43 fix: `simple-english session session-1 &lt;cwd&gt; &#39;&#39;` and `&#39; &#39;` toggle enforcement off/on, `status` reports mode and rule counts</code>
- <code>`grep -rn &#39;0\.3\.0&#39;` across the tree and `grep -n &#39;0\.3\.[01]&#39; bun.lock` - no stale version references</code>
- <code>`claude plugin validate .` and `claude plugin validate .claude-plugin/marketplace.json`</code>
- <code>`claude plugin tag . --dry-run` - confirms plugin.json and marketplace entry agree at 0.3.1</code>
- <code>`npm view agent-simple-english versions` - registry latest is 0.3.0, so 0.3.1 is unpublished</code>
- <code>`git status --porcelain` - worktree clean after testing; removed the temporary pack/install directory</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `README.md:527` - The repository has no CHANGELOG.md or release-notes surface, so v0.3.1 ships with no user-facing record of what changed relative to v0.3.0 (the underlying CLI enforcement-toggle fix in f1beaa9). This is a pre-existing gap rather than staleness introduced by this change, and the placement policy forbids creating a new documentation surface merely to close a perceived gap, so I made no edit. Worth a separate decision by the maintainer: either adopt a CHANGELOG.md owned as the release-history document, or rely on GitHub release notes generated from the commit history, which keeps the fact generated from its authoritative source instead of hand-copied into prose.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
