### PR TITLE
feat(engine): skip markup and data files in write and edit gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,13 @@ It is the default for standard input, extensionless paths, and file types that h
 
 `commit-message` checks the complete input as a commit message.
 
+A skipped path carries no check.
+These extensions skip every check: `.html`, `.htm`, `.css`, `.scss`, `.less`, `.json`, `.jsonc`, `.svg`, `.xml`, `.typ`, `.csv`, `.tsv`, and `.lock`.
+An extensionless path still uses `prose-file`.
+The Claude Code hook and the pi write and edit gates allow a skipped path with no lint and no observation record.
+The CLI prints one line that names a skipped file and exits 0.
+An explicit `--kind` flag forces a lint on a skipped file.
+
 File extension matching does not depend on letter case.
 Source kinds ignore comment markers inside supported string literal forms.
 All kinds preserve the original line and column.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ Soft violations can appear with exit code 0.
 
 ### CLI flags
 
-- `--json` writes one JSON report with `violations` and `summary` fields.
+- `--json` writes one JSON report with `violations`, `summary`, and `skipped` fields.
+  The `skipped` array is always present, and it is empty when no input was skipped.
   Each violation includes its offending sentence or paragraph as `snippet`.
 
 - `--config <path>` uses only that config file and disables config discovery.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Observation-write failures are silent and do not change the hook output or decis
 
 Enabled Hook mode logs every write, edit, static commit-message, and reply lint decision to the local XDG state directory.
 Observation logging is on by default, and the log includes clean allows and soft Findings.
-Plain lint runs, disabled hook sessions, and the pi Adapter do not write Observations.
+Plain lint runs, disabled hook sessions, skipped paths, and the pi Adapter do not write Observations.
 Set `SIMPLE_ENGLISH_OBSERVE=0` to stop observation logging.
 
 Monthly Observation files use `$XDG_STATE_HOME/simple-english/observations/YYYY-MM.jsonl`.
@@ -284,7 +284,7 @@ It is the default for standard input, extensionless paths, and file types that h
 A skipped path carries no check.
 These extensions skip every check: `.html`, `.htm`, `.css`, `.scss`, `.less`, `.json`, `.jsonc`, `.svg`, `.xml`, `.typ`, `.csv`, `.tsv`, and `.lock`.
 An extensionless path still uses `prose-file`.
-The Claude Code hook and the pi write and edit gates allow a skipped path with no lint and no observation record.
+The Claude Code hook and the pi write and edit gates allow a skipped path with no lint.
 The CLI prints one line that names a skipped file and exits 0.
 An explicit `--kind` flag forces a lint on a skipped file.
 

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -585,6 +585,9 @@ function textDecision(
   previousText?: string,
 ): HookEvaluation {
   const classification = classifyPath(path)
+  if (classification.skipped) {
+    return { output: allow() }
+  }
   const report = lint(classification.kind, text, {
     ...options,
     sourceDialect: classification.sourceDialect,

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -102,7 +102,7 @@ interface FileViolation {
 interface CliReport {
   readonly violations: readonly FileViolation[]
   readonly summary: { readonly total: number; readonly hard: number }
-  readonly skipped?: readonly string[]
+  readonly skipped: readonly string[]
 }
 
 const readStdin = Effect.promise(async () => {
@@ -123,7 +123,7 @@ const readInput = (path: string) =>
 
 const toCliReport = (
   reports: readonly { path: string; report: LintReport }[],
-  skipped: readonly string[] = [],
+  skipped: readonly string[],
 ): CliReport => {
   const violations = reports.flatMap(({ path, report }) =>
     report.violations.map((violation) => ({ file: path, ...violation })),
@@ -134,7 +134,7 @@ const toCliReport = (
       total: violations.length,
       hard: violations.filter((violation) => violation.severity === "hard").length,
     },
-    ...(skipped.length === 0 ? {} : { skipped }),
+    skipped,
   }
 }
 
@@ -143,7 +143,7 @@ const render = (report: CliReport, json: boolean): string => {
     return JSON.stringify(report, null, 2)
   }
   const lines = [
-    ...(report.skipped ?? []).map((path) => `${path}: skipped (non-prose extension)`),
+    ...report.skipped.map((path) => `${path}: skipped (non-prose extension)`),
     ...report.violations.map(
       (v) => `${v.file}:${v.line}:${v.column} [${v.severity}] ${v.ruleId} ${v.message}`,
     ),

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,7 +5,7 @@ import packageManifest from "../../package.json" with { type: "json" }
 import { loadConfig } from "../config/load.ts"
 import { loadConfiguredDictionary } from "../dictionary/configured.ts"
 import { loadRuleData } from "../dictionary/load.ts"
-import { classifyPath } from "../engine/kinds.ts"
+import { type PathClassification, classifyPath } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { LintKind, LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"
@@ -102,6 +102,7 @@ interface FileViolation {
 interface CliReport {
   readonly violations: readonly FileViolation[]
   readonly summary: { readonly total: number; readonly hard: number }
+  readonly skipped?: readonly string[]
 }
 
 const readStdin = Effect.promise(async () => {
@@ -120,7 +121,10 @@ const readInput = (path: string) =>
         catch: (cause) => new Error(`cannot read ${path}: ${cause}`),
       }).pipe(Effect.map((text) => ({ path, text })))
 
-const toCliReport = (reports: readonly { path: string; report: LintReport }[]): CliReport => {
+const toCliReport = (
+  reports: readonly { path: string; report: LintReport }[],
+  skipped: readonly string[] = [],
+): CliReport => {
   const violations = reports.flatMap(({ path, report }) =>
     report.violations.map((violation) => ({ file: path, ...violation })),
   )
@@ -130,6 +134,7 @@ const toCliReport = (reports: readonly { path: string; report: LintReport }[]): 
       total: violations.length,
       hard: violations.filter((violation) => violation.severity === "hard").length,
     },
+    ...(skipped.length === 0 ? {} : { skipped }),
   }
 }
 
@@ -137,9 +142,13 @@ const render = (report: CliReport, json: boolean): string => {
   if (json) {
     return JSON.stringify(report, null, 2)
   }
-  return report.violations
-    .map((v) => `${v.file}:${v.line}:${v.column} [${v.severity}] ${v.ruleId} ${v.message}`)
-    .join("\n")
+  const lines = [
+    ...(report.skipped ?? []).map((path) => `${path}: skipped (non-prose extension)`),
+    ...report.violations.map(
+      (v) => `${v.file}:${v.line}:${v.column} [${v.severity}] ${v.ruleId} ${v.message}`,
+    ),
+  ]
+  return lines.join("\n")
 }
 
 const args = process.argv.slice(2)
@@ -225,20 +234,29 @@ const lintProgram = Effect.gen(function* () {
       ? [{ path: "<stdin>", text: yield* readStdin }]
       : yield* Effect.forEach(paths, readInput)
 
+  const skippedPaths: string[] = []
+  const lintable: { path: string; text: string; classification: PathClassification }[] = []
+  for (const input of inputs) {
+    const classification = classifyPath(input.path)
+    if (kind === undefined && classification.skipped) {
+      skippedPaths.push(input.path)
+      continue
+    }
+    lintable.push({ ...input, classification })
+  }
+
   const report = toCliReport(
-    inputs.map(({ path, text }) => {
-      const classification = classifyPath(path)
-      return {
-        path,
-        report: lint(kind ?? classification.kind, text, {
-          ...config,
-          dictionary,
-          ruleData,
-          tagger,
-          sourceDialect: classification.sourceDialect,
-        }),
-      }
-    }),
+    lintable.map(({ path, text, classification }) => ({
+      path,
+      report: lint(kind ?? classification.kind, text, {
+        ...config,
+        dictionary,
+        ruleData,
+        tagger,
+        sourceDialect: classification.sourceDialect,
+      }),
+    })),
+    skippedPaths,
   )
 
   const output = render(report, json)

--- a/src/engine/kinds.ts
+++ b/src/engine/kinds.ts
@@ -25,9 +25,28 @@ const JAVASCRIPT_EXTENSIONS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs"])
 const NESTED_SLASH_EXTENSIONS = new Set(["rs", "swift", "kt", "scala"])
 const HASH_EXTENSIONS = new Set(["sh", "bash", "zsh", "py", "rb", "yaml", "yml", "toml", "pl"])
 
+// Markup and data extensions carry CSS rules, script, and structured data rather than prose,
+// so the writing rules would misread them as sentences (HUF-308).
+const SKIP_EXTENSIONS = new Set([
+  "html",
+  "htm",
+  "css",
+  "scss",
+  "less",
+  "json",
+  "jsonc",
+  "svg",
+  "xml",
+  "typ",
+  "csv",
+  "tsv",
+  "lock",
+])
+
 export interface PathClassification {
   readonly kind: LintKind
   readonly sourceDialect: SourceDialect
+  readonly skipped?: true
 }
 
 export const classifyPath = (path: string): PathClassification => {
@@ -36,6 +55,9 @@ export const classifyPath = (path: string): PathClassification => {
     return { kind: "prose-file", sourceDialect: "general" }
   }
   const extension = path.slice(dot + 1).toLowerCase()
+  if (SKIP_EXTENSIONS.has(extension)) {
+    return { kind: "prose-file", sourceDialect: "general", skipped: true }
+  }
   if (SLASH_EXTENSIONS.has(extension)) {
     const sourceDialect = JAVASCRIPT_EXTENSIONS.has(extension)
       ? "javascript"

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -353,6 +353,9 @@ function lintProposedText(
   previousText?: string,
 ): ToolCallEventResult | undefined {
   const classification = classifyPath(path)
+  if (classification.skipped) {
+    return undefined
+  }
   const report = lint(classification.kind, text, {
     ...state.config,
     dictionary: state.dictionary,

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -296,6 +296,32 @@ describe("simple-english CLI", () => {
     expect(result.stderr).toContain("nonsense")
   })
 
+  test("skips a known non-prose extension and exits 0", async () => {
+    const result = await runCli([join(fixturesPath, "skip.html")])
+
+    expect(result.code).toBe(0)
+    expect(result.stdout).toContain("skip.html")
+    expect(result.stdout).toContain("skipped")
+  })
+
+  test("--json on an all-skipped input keeps a valid report shape", async () => {
+    const result = await runCli(["--json", join(fixturesPath, "skip.html")])
+
+    expect(result.code).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual({
+      violations: [],
+      summary: { total: 0, hard: 0 },
+      skipped: [join(fixturesPath, "skip.html")],
+    })
+  })
+
+  test("--kind forces a lint on a skipped extension", async () => {
+    const result = await runCli(["--kind", "prose-file", join(fixturesPath, "skip.html")])
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("sentence-length")
+  })
+
   test("rejects --kind without a value with exit code 2", async () => {
     const result = await runCli(["--kind"], { stdin: "Short." })
 

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -81,6 +81,7 @@ describe("simple-english CLI", () => {
         },
       ],
       summary: { total: 1, hard: 1 },
+      skipped: [],
     })
   })
 
@@ -91,6 +92,7 @@ describe("simple-english CLI", () => {
     expect(JSON.parse(result.stdout)).toEqual({
       violations: [],
       summary: { total: 0, hard: 0 },
+      skipped: [],
     })
   })
 

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -945,6 +945,39 @@ describe("simple-english CLI hook mode", () => {
     expect(output.permissionDecisionReason?.match(/Suggested fix:/gu)).toHaveLength(3)
   })
 
+  test("allows a Write event for a skipped non-prose extension with no observation record", async () => {
+    const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const longLine = Array.from({ length: 40 }, (_, i) => `word${i}`).join(" ")
+    const content = `<style>a { color: red; background: blue; }</style>\n<!-- ${longLine}. -->`
+
+    const result = await runHook(
+      event(cwd, "Write", {
+        file_path: join(cwd, "page.html"),
+        content,
+      }),
+      cwd,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      xdgStateHome,
+    )
+
+    expect(result.code).toBe(0)
+    expect(decision(result.output)).toEqual({
+      hookEventName: "PreToolUse",
+      permissionDecision: "allow",
+    })
+    await expect(
+      readdir(join(xdgStateHome, "simple-english", "observations")).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+        throw error
+      }),
+    ).resolves.toEqual([])
+  })
+
   test("allows an Edit event when only untouched prose has a hard violation", async () => {
     const cwd = await makeProject({ rules: { "dictionary-not-approved-word": "off" } })
     const path = join(cwd, "notes.md")

--- a/test/engine/README.md
+++ b/test/engine/README.md
@@ -29,6 +29,15 @@ Cross-cutting Markdown masks use the same finding, clean, and boundary audit at 
 | GFM tables | Yes. `lints prose around a table at its original positions`. | Yes. `masks a valid multi-row GFM table from all prose rules`. | Yes. `does not mask table-like text with mismatched delimiter cells`. |
 | YAML frontmatter | Yes. `lints prose after frontmatter at its original position`. | Yes. `masks YAML frontmatter from all prose rules`. | Yes. `does not mask a thematic break in the middle of a document`. |
 
+## Content kind classification
+
+`classifyPath` in `src/engine/kinds.ts` chooses a lint kind from a path extension.
+The skip classification for markup and data extensions uses the same finding, clean, and boundary audit.
+
+| Feature | Finding | Clean | Boundary |
+| --- | --- | --- | --- |
+| Skip extension | Yes. `marks a .%s path as skipped`. | Yes. `does not skip a prose or source extension`. | Yes. `does not skip an extensionless path`; `matches a skip extension without regard to letter case`. |
+
 ## Engine options
 
 | Option | Finding | Clean | Boundary |

--- a/test/engine/kinds.test.ts
+++ b/test/engine/kinds.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest"
+import { classifyPath } from "../../src/engine/kinds.ts"
 import { lint } from "../../src/engine/lint.ts"
 
 const words = (n: number) => Array.from({ length: n }, (_, i) => `word${i + 1}`).join(" ")
@@ -539,5 +540,42 @@ describe("lint prose-file: hardened markdown stripping", () => {
     const text = `Run \`${words(30)}\\\` now.`
 
     expect(lint("prose-file", text).violations).toHaveLength(0)
+  })
+})
+
+describe("classifyPath: skip classification", () => {
+  test.each([
+    "html",
+    "htm",
+    "css",
+    "scss",
+    "less",
+    "json",
+    "jsonc",
+    "svg",
+    "xml",
+    "typ",
+    "csv",
+    "tsv",
+    "lock",
+  ])("marks a .%s path as skipped", (extension) => {
+    expect(classifyPath(`example.${extension}`)).toEqual({
+      kind: "prose-file",
+      sourceDialect: "general",
+      skipped: true,
+    })
+  })
+
+  test("matches a skip extension without regard to letter case", () => {
+    expect(classifyPath("styles.CSS").skipped).toBe(true)
+  })
+
+  test("does not skip an extensionless path", () => {
+    expect(classifyPath("Dockerfile").skipped).toBeUndefined()
+  })
+
+  test("does not skip a prose or source extension", () => {
+    expect(classifyPath("README.md").skipped).toBeUndefined()
+    expect(classifyPath("main.ts").skipped).toBeUndefined()
   })
 })

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -1137,6 +1137,21 @@ describe.sequential("pi extension wiring", () => {
     ).rejects.toThrow("[contraction]")
   })
 
+  test("allows writing a skipped non-prose extension without linting", async () => {
+    const { cwd, pi, context } = await startExtension()
+
+    await pi.executeTool(
+      "write",
+      "write-skip-1",
+      { path: "page.html", content: "<style>a { color: red; background: blue; }</style>" },
+      context,
+    )
+
+    expect(await readFile(join(cwd, "page.html"), "utf8")).toBe(
+      "<style>a { color: red; background: blue; }</style>",
+    )
+  })
+
   test("lints edits against the previous file and ignores unchanged violations", async () => {
     const { cwd, pi, context } = await startExtension()
     const path = join(cwd, "notes.md")

--- a/test/fixtures/skip.html
+++ b/test/fixtures/skip.html
@@ -1,0 +1,2 @@
+<style>a { color: red; background: blue; }</style>
+<p>word1 word2 word3 word4 word5 word6 word7 word8 word9 word10 word11 word12 word13 word14 word15 word16 word17 word18 word19 word20 word21 word22 word23 word24 word25 word26 word27 word28 word29 word30.</p>


### PR DESCRIPTION
## Intent

Captain's ask (2026-09-07): "can you check agent-simple-english and propose to me anything should be update", then "come out a plan discuss with me and rollout the propose changes from above".
The captain reviewed the plan and chose: "Dispatch A and B in parallel now". This task is item A.

Item A, in the captain's terms: skip markup and data files in the write and edit gates.
The write and edit gates lint every unknown file extension as prose, so CSS rules, script, and data inside html, css, json, svg, and typ files get sentence-length and semicolon checks.
The captain's own hook log from 2026-08-05 to 2026-09-07 shows 1,863 hard semicolon hits and 320 hard sentence-length hits on html, css, and typ files. 16 of 32 html writes, 27 of 45 typ writes, and 5 of 5 json writes were blocked. The blocked files were Lavish review pages, lesson pages, and Typst documents.

The fix the captain approved: add a skip classification for known non-prose extensions (html, htm, css, scss, less, json, jsonc, svg, xml, typ, csv, tsv, lock) and honor it in the Claude Code hook, the pi gated write and edit tools, and the CLI. Extensionless paths stay prose. The CLI reports a skipped file and exits 0, and an explicit --kind still forces a lint. Add regression tests at the engine, hook, pi, and CLI seams, and update the README content-kinds section and the test audit table. An html content kind that lints text nodes only is a separate later ticket (HUF-310), not part of this task.
Linear ticket: HUF-308.

## What Changed

- `classifyPath` in `src/engine/kinds.ts` now returns a `skipped` flag for known non-prose extensions (`html`, `htm`, `css`, `scss`, `less`, `json`, `jsonc`, `svg`, `xml`, `typ`, `csv`, `tsv`, `lock`). Extensionless paths still classify as `prose-file`.
- The Claude Code hook (`src/cli/hook.ts`) and the pi gated write and edit tools (`src/extension/index.ts`) allow a skipped path with no lint, so no Findings and no Observation record come from those files.
- The CLI (`src/cli/main.ts`) filters skipped inputs before lint, reports each one as `<path>: skipped (non-prose extension)`, adds a `skipped` array to the JSON report, and exits 0. An explicit `--kind` flag still forces a lint on a skipped file.
- Added regression tests at the engine, hook, pi, and CLI seams plus the `test/fixtures/skip.html` fixture, and updated the README content-kinds and CLI-flag sections with the test audit table.

## Risk Assessment

✅ Low: The change is a small, well-bounded extension-allowlist skip honored at all three existing classifyPath call sites, it matches the approved extension list exactly, and it carries genuine failing-before/passing-after regression tests at the engine, hook, pi, and CLI seams.

## Testing

I installed the missing dependencies, then ran the targeted engine, CLI, hook, and pi-extension tests that cover the new skip classification; all passed. To prove the regression direction I replayed the three new test files against a copy of base commit 20beae6, where 16 of the new assertions fail. For end-user evidence I drove the real CLI and the real Claude Code PreToolUse hook on a Lavish-style html review page, a css theme, a Typst lesson, and a json manifest at both commits: base denies every write with hard semicolon and sentence-length violations, and the target allows all four while still denying a markdown file with the same errors. I also confirmed the stable --json shape, the --kind override, and that extensionless paths stay prose. The change has no rendered UI surface, so CLI transcripts and raw hook decision JSON are the end-user-visible artifacts. Everything passed and I left no transient files in the worktree.

<details>
<summary>Evidence: Hook decisions: before vs after, Write of html/css/typ plus a markdown control</summary>

<code>--- review-page.html ---&#10;BEFORE (base 20beae6):&#10;{&#34;hookSpecificOutput&#34;:{&#34;hookEventName&#34;:&#34;PreToolUse&#34;,&#34;permissionDecision&#34;:&#34;deny&#34;,&#34;permissionDecisionReason&#34;:&#34;Writing rules blocked write for .../review-page.html:\n- line 1, column 1 [sentence-length]: Sentence has 92 words; the maximum is 25. ...&#10;&#10;AFTER (HUF-308):&#10;{&#34;hookSpecificOutput&#34;:{&#34;hookEventName&#34;:&#34;PreToolUse&#34;,&#34;permissionDecision&#34;:&#34;allow&#34;}}&#10;&#10;--- theme.css --- BEFORE: deny (6 hard semicolon hits) AFTER: allow&#10;--- lesson.typ --- BEFORE: deny (sentence-length + progressive + semicolon) AFTER: allow&#10;&#10;--- notes.md (prose still gated after the change) ---&#10;{&#34;hookSpecificOutput&#34;:{&#34;hookEventName&#34;:&#34;PreToolUse&#34;,&#34;permissionDecision&#34;:&#34;deny&#34;,&#34;permissionDecisionReason&#34;:&#34;Writing rules blocked write for .../notes.md:\n- line 1, column 10 [verb-progressive]... \n- line 1, column 34 [semicolon]...&#34;}}</code>

```text
=== Claude Code PreToolUse hook: Write of markup and data files ===
--- review-page.html ---
BEFORE (base 20beae6):
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/ste-hookcwd-LsIw/review-page.html:\n- line 1, column 1 [sentence-length]: Sentence has 92 words; the maximum is 25. Suggested fix: Split the sentence into shorter sentences.\n- line 7, column 28 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences.\n- line 7, column 43 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences.\n- line 7, column 62 [semicolon]: Do not use a semicolon. Write t

AFTER  (HUF-308):
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}


--- theme.css ---
BEFORE (base 20beae6):
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/ste-hookcwd-LsIw/theme.css:\n- line 1, column 21 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences.\n- line 1, column 39 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences.\n- line 1, column 59 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences.\n- line 1, column 78 [semicolon]: Do not use a semico

AFTER  (HUF-308):
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}


--- lesson.typ ---
BEFORE (base 20beae6):
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/ste-hookcwd-LsIw/lesson.typ:\n- line 1, column 1 [sentence-length]: Sentence has 26 words; the maximum is 25. Suggested fix: Split the sentence into shorter sentences.\n- line 7, column 13 [verb-progressive]: Use a simple tense. Do not use the progressive. Found: \"is reading\". Suggested fix: Use a permitted simple verb form.\n- line 7, column 35 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences.\n- line 7, column 53 [verb-progressive]: Use a simple tense. Do not 

AFTER  (HUF-308):
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}


--- notes.md (prose still gated after the change) ---
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/ste-hookcwd-LsIw/notes.md:\n- line 1, column 10 [verb-progressive]: Use a simple tense. Do not use the progressive. Found: \"is preparing\". Suggested fix: Use a permitted simple verb form.\n- line 1, column 34 [semicolon]: Do not use a semicolon. Write two sentences. Suggested fix: Replace the semicolon with a full stop and write two sentences."}}
```
</details>
<details>
<summary>Evidence: CLI on markup and data files, base commit (blocked)</summary>

<code>$ simple-english review-page.html ... (hard violations: 18) exit=1&#10;$ simple-english theme.css ... (hard violations: 6) exit=1&#10;$ simple-english lesson.typ ... (hard violations: 4) exit=1&#10;$ simple-english package-data.json ... (hard violations: 2) exit=1</code>

```text
=== BEFORE (base 20beae6) ===
$ simple-english review-page.html
review-page.html:1:1 [hard] sentence-length Sentence has 92 words; the maximum is 25.
review-page.html:7:28 [hard] semicolon Do not use a semicolon. Write two sentences.
review-page.html:7:43 [hard] semicolon Do not use a semicolon. Write two sentences.
review-page.html:7:62 [hard] semicolon Do not use a semicolon. Write two sentences.
review-page.html:8:23 [hard] semicolon Do not use a semicolon. Write two sentences.
review-page.html:8:46 [hard] semicolon Do not use a semicolon. Write two sentences.
review-page.html:8:64 [hard] semicolon Do not use a semicolon. Write two sentences.
review-page.html:8:150 [hard] semicolon Do not use a semicolon. Write two sentences.
... (hard violations: 18)  exit=1

$ simple-english theme.css
theme.css:1:21 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:1:39 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:1:59 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:1:78 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:2:29 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:2:47 [hard] semicolon Do not use a semicolon. Write two sentences.
... (hard violations: 6)  exit=1

$ simple-english lesson.typ
lesson.typ:1:1 [hard] sentence-length Sentence has 26 words; the maximum is 25.
lesson.typ:7:13 [hard] verb-progressive Use a simple tense. Do not use the progressive. Found: "is reading".
lesson.typ:7:35 [hard] semicolon Do not use a semicolon. Write two sentences.
lesson.typ:7:53 [hard] verb-progressive Use a simple tense. Do not use the progressive. Found: "been marking".
... (hard violations: 4)  exit=1

$ simple-english package-data.json
package-data.json:1:1 [hard] sentence-length Sentence has 46 words; the maximum is 25.
package-data.json:3:35 [soft] verb-passive Use the active voice, unless the actor is unknown. Found: "being used".
package-data.json:3:57 [hard] semicolon Do not use a semicolon. Write two sentences.
package-data.json:3:66 [soft] verb-passive Use the active voice, unless the actor is unknown. Found: "been published".
... (hard violations: 2)  exit=1
```
</details>
<details>
<summary>Evidence: CLI on the same files after the change (skipped, exit 0)</summary>

<code>$ simple-english review-page.html&#10;review-page.html: skipped (non-prose extension)&#10;... (hard violations: 0) exit=0&#10;&#10;$ simple-english theme.css&#10;theme.css: skipped (non-prose extension)&#10;... (hard violations: 0) exit=0&#10;&#10;$ simple-english lesson.typ&#10;lesson.typ: skipped (non-prose extension)&#10;... (hard violations: 0) exit=0&#10;&#10;$ simple-english package-data.json&#10;package-data.json: skipped (non-prose extension)&#10;... (hard violations: 0) exit=0</code>

```text
=== AFTER (HUF-308, b1fece1) ===
$ simple-english review-page.html
review-page.html: skipped (non-prose extension)
... (hard violations: 0)  exit=0

$ simple-english theme.css
theme.css: skipped (non-prose extension)
... (hard violations: 0)  exit=0

$ simple-english lesson.typ
lesson.typ: skipped (non-prose extension)
... (hard violations: 0)  exit=0

$ simple-english package-data.json
package-data.json: skipped (non-prose extension)
... (hard violations: 0)  exit=0
```
</details>
<details>
<summary>Evidence: Stable --json shape, --kind override, and extensionless path</summary>

<code>$ simple-english --json review-page.html theme.css&#10;{ &#34;violations&#34;: [], &#34;summary&#34;: {&#34;total&#34;: 0, &#34;hard&#34;: 0}, &#34;skipped&#34;: [&#34;review-page.html&#34;, &#34;theme.css&#34;] } exit=0&#10;&#10;$ simple-english --json notes.md # no skips: skipped is still present as []&#10;{ &#34;violations&#34;: [ ...3 entries... ], &#34;summary&#34;: {&#34;total&#34;: 3, &#34;hard&#34;: 2}, &#34;skipped&#34;: [] }&#10;&#10;$ simple-english --kind prose-file theme.css&#10;theme.css:1:21 [hard] semicolon Do not use a semicolon. Write two sentences. (6 hits) exit=1&#10;&#10;$ simple-english Dockerfile&#10;Dockerfile:1:10 [hard] verb-progressive ... Found: &#34;is preparing&#34;. exit=1</code>

```text
$ simple-english --json review-page.html theme.css   # all skipped
{
  "violations": [],
  "summary": {
    "total": 0,
    "hard": 0
  },
  "skipped": [
    "review-page.html",
    "theme.css"
  ]
}
exit=0

$ simple-english --json notes.md                      # no skips: skipped is still present as []
{
  "violations": [
    {
      "file": "notes.md",
      "ruleId": "verb-progressive",
      "severity": "hard",
      "message": "Use a simple tense. Do not use the progressive. Found: \"is preparing\".",
      "line": 1,
      "column": 10,
      "snippet": "The team is preparing the release; the checklist has been completed."
    },
    {
      "file": "notes.md",
      "ruleId": "semicolon",
      "severity": "hard",
      "message": "Do not use a semicolon. Write two sentences.",
      "line": 1,
      "column": 34,
      "snippet": "The team is preparing the release; the checklist has been completed."
    },
    {
      "file": "notes.md",
      "ruleId": "verb-passive",
      "severity": "soft",
      "message": "Use the active voice, unless the actor is unknown. Found: \"been completed\".",
      "line": 1,
      "column": 54,
      "snippet": "The team is preparing the release; the checklist has been completed."
    }
  ],
  "summary": {
    "total": 3,
    "hard": 2
  },
  "skipped": []
}

$ simple-english --kind prose-file theme.css          # explicit --kind forces the lint
theme.css:1:21 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:1:39 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:1:59 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:1:78 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:2:29 [hard] semicolon Do not use a semicolon. Write two sentences.
theme.css:2:47 [hard] semicolon Do not use a semicolon. Write two sentences.
exit=1

$ simple-english Dockerfile                           # extensionless path stays prose
Dockerfile:1:10 [hard] verb-progressive Use a simple tense. Do not use the progressive. Found: "is preparing".
exit=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"fde0801d7804464e7505092b681a8412879d98ec","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/cli/main.ts:237` - Classification runs after the file read: `readInput` loads every path (including a large .lock or .json) before the skip filter drops it, and the hook&#39;s Edit branch reads the previous file and computes the proposed edit before `textDecision` skips. Beyond the wasted read, an unreadable skipped path fails the CLI with exit 2 instead of being reported as skipped. Low impact; classify the path before reading if you want the skip to be truly free.
- ℹ️ `src/cli/main.ts:137` - The `skipped` field is emitted only when non-empty (`...(skipped.length === 0 ? {} : { skipped })`), so the --json report shape varies between runs. The intent only requires that the CLI report a skipped file and exit 0; a narrower form is to keep the JSON shape fixed (always emit the array) or leave skip reporting to the text renderer only. Author&#39;s call, since either choice changes machine-readable output.

🔧 Fix: fix(cli): always emit skipped array in json report
1 info still open:

- ℹ️ `src/engine/kinds.ts:58` - A skipped path still reports kind &#34;prose-file&#34;, so the skip is advisory: any consumer that reads classification.kind without checking classification.skipped silently lints the file as prose again. All three current call sites (src/cli/hook.ts:588, src/extension/index.ts:356, src/cli/main.ts:240) check the flag, so no reachable defect exists today. Noting it only as a shape that invites a future miss; a discriminated return would make the skip impossible to ignore, but that is a broader refactor and not needed for this change.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` (node_modules were absent in the worktree)</code>
- <code>`bun run test -- test/engine/kinds.test.ts` (83 passed, includes the new `classifyPath: skip classification` suite)</code>
- <code>`bun run test -- test/cli/cli.test.ts` (36 passed, includes the three new skip/--json/--kind CLI cases)</code>
- `bun run test -- test/cli/hook.test.ts -t "skipped non-prose"`
- <code>`bun run test -- test/extension/extension.test.ts -t &#34;skipped non-prose&#34;` (pi gated-write seam via the stubbed ExtensionAPI)</code>
- <code>Regression direction: copied the three new test files onto a `git archive` of base 20beae6 and re-ran them - 16 of the new assertions fail at base, all pass at b1fece1</code>
- <code>Manual CLI transcript: ran `bun src/cli/main.ts &lt;file&gt;` on a Lavish-style review-page.html, theme.css, lesson.typ, and package-data.json at both base and target, capturing hard-violation counts and exit codes</code>
- <code>Manual hook transcript: piped real PreToolUse Write payloads (`bun src/cli/main.ts hook`) for review-page.html, theme.css, lesson.typ, and a control notes.md at both base and target</code>
- <code>Manual CLI checks for `--json` shape stability (skipped present as `[]`), `--kind prose-file` forcing a lint on theme.css (exit 1), and an extensionless `Dockerfile` still linting as prose (exit 1)</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/release-verification.md:86` - The captured `simple-english --json README.md` sample output shows only `violations` and `summary`, so it no longer matches the current report shape, which always emits `skipped`. The file is a dated historical record of the HUF-142 release checks from 2026-07-31, and it already states that its captured commands and output predate later changes. I left it unchanged because a record of a past run should stay verbatim. If the team prefers this file to track current behavior, it needs a refresh at the next release verification.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
