### PR TITLE
fix(cli): sort imports for Biome 2 organize-imports rule

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -5,7 +5,7 @@ import packageManifest from "../../package.json" with { type: "json" }
 import { loadConfig } from "../config/load.ts"
 import { loadConfiguredDictionary } from "../dictionary/configured.ts"
 import { loadRuleData } from "../dictionary/load.ts"
-import { type PathClassification, classifyPath } from "../engine/kinds.ts"
+import { classifyPath, type PathClassification } from "../engine/kinds.ts"
 import { lint } from "../engine/lint.ts"
 import type { LintKind, LintReport } from "../engine/types.ts"
 import { TaggerService, WinkTaggerLive } from "../tagger/wink.ts"


### PR DESCRIPTION
## Intent

Captain standing order: lint and test failures get fixed when seen, and every PR runs the full validation pipeline. Context (2026-09-07): two approved PRs on agent-simple-english merged one minute apart. https://github.com/jyooi/agent-simple-english/pull/46 moved the linter to Biome 2. https://github.com/jyooi/agent-simple-english/pull/45 was checked against the old Biome 1.9 base and was green there. After it merged onto main, CI run 34079533547 failed bun run lint with one error: src/cli/main.ts:8:1 assist/source/organizeImports, because Biome 2 sorts classifyPath before type PathClassification. Typecheck and tests never ran in that job. The fix the captain standing order requires: make main green again with the Biome 2 safe fix, and nothing more. Linear ticket: HUF-312.

## What Changed

- Reorder the named import in `src/cli/main.ts` so `classifyPath` precedes `type PathClassification`, matching the Biome 2 `assist/source/organizeImports` safe fix.
- No runtime behavior changes. This restores a green `bun run lint` on main after #45 and #46 merged in sequence (HUF-312).

## Risk Assessment

✅ Low: The change reorders two named specifiers in one import statement with no semantic effect, matching the intent's single required fix and adding nothing else.

## Testing

Reproduced the reported Biome 2 organizeImports failure on the base commit, confirmed the target commit lints clean with the same Biome 2.5.12, and ran the typecheck and CLI E2E tests that the failed CI job never reached. All pass. The diff contains only the safe import reorder, so the "nothing more" constraint holds. No UI surface is involved, so no visual artifact applies. Worktree left clean.

<details>
<summary>Evidence: Lint transcript: failure on base, clean on target</summary>

<code>== base f83aa212: bun run lint ==&#10;src/cli/main.ts:8:1 assist/source/organizeImports FIXABLE&#10;× Sort the imported names.&#10;&gt; 8 │ import { type PathClassification, classifyPath } from &#34;../engine/kinds.ts&#34;&#10;i Safe fix: Organize imports and exports (Biome)&#10;Found 1 error.&#10;exit 1&#10;== target caa9145e: bun run lint ==&#10;Checked 86 files in 42ms. No fixes applied.&#10;exit 0</code>

```text
== biome version ==
Version: 2.5.12

== base f83aa212: bun run lint ==
$ biome check .
src/cli/main.ts:8:1 assist/source/organizeImports  FIXABLE  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × Sort the imported names.
  
     6 │ import { loadConfiguredDictionary } from "../dictionary/configured.ts"
     7 │ import { loadRuleData } from "../dictionary/load.ts"
   > 8 │ import { type PathClassification, classifyPath } from "../engine/kinds.ts"
       │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     9 │ import { lint } from "../engine/lint.ts"
    10 │ import type { LintKind, LintReport } from "../engine/types.ts"
  
  i Safe fix: Organize imports and exports (Biome)
  
      6   6 │   import { loadConfiguredDictionary } from "../dictionary/configured.ts"
      7   7 │   import { loadRuleData } from "../dictionary/load.ts"
      8     │ - import·{·type·PathClassification,·classifyPath·}·from·"../engine/kinds.ts"
          8 │ + import·{·classifyPath,·type·PathClassification·}·from·"../engine/kinds.ts"
      9   9 │   import { lint } from "../engine/lint.ts"
     10  10 │   import type { LintKind, LintReport } from "../engine/types.ts"
  

Checked 86 files in 43ms. No fixes applied.
Found 1 error.
check ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  × Some errors were emitted while running checks.
  

error: script "lint" exited with code 1
exit 1
== target caa9145e: bun run lint ==
$ biome check .
Checked 86 files in 42ms. No fixes applied.
exit 0
```
</details>
<details>
<summary>Evidence: Typecheck and CLI E2E tests on target</summary>

<code>$ tsc --noEmit&#10;exit 0&#10;$ vitest run test/cli&#10;Test Files 4 passed (4)&#10;Tests 121 passed (121)&#10;exit 0</code>

```text
== bun run typecheck ==
$ tsc --noEmit
exit 0
== bun run test -- test/cli ==
$ vitest run test/cli

 RUN  v5.0.0 ~/.no-mistakes/worktrees/5b49eff34526/01M1WYWZX83SFKZ83G0Y5PVZVB


 Test Files  4 passed (4)
      Tests  121 passed (121)
   Start at  11:35:42
   Duration  19.30s (tests 99%, transform 1%)

exit 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"caa9145e147648158517a1661b15df496ced799d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff f83aa212 caa9145e` - confirmed the only change is the import reorder in src/cli/main.ts</code>
- <code>`bun run lint` with the base-commit src/cli/main.ts restored - reproduced the exact CI error (organizeImports at 8:1, exit 1) under Biome 2.5.12</code>
- <code>`bun run lint` on the target commit - clean, 86 files checked, exit 0</code>
- <code>`bun run typecheck` on the target commit - exit 0</code>
- <code>`bun run test -- test/cli` (CLI E2E via spawned bun src/cli/main.ts) - 4 files, 121 tests passed</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
