### PR TITLE
chore: prepare v0.4.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "simple-english",
       "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "author": {
         "name": "JIA YI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-simple-english",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Intent

Captain's decision on the 2026-09-07 plan page: Prepare v0.4.0 once every approved wave landed on main. The captain runs the smoke pass before the tag.

Every approved wave landed on main today: https://github.com/jyooi/agent-simple-english/pull/46 (toolchain: Biome 2, Vitest 5, node types 26, pi 0.85.1, CI on Bun 1.4.0), https://github.com/jyooi/agent-simple-english/pull/45 (skip markup and data files in the write and edit gates), https://github.com/jyooi/agent-simple-english/pull/47 (Biome 2 import-order fix), and https://github.com/jyooi/agent-simple-english/pull/48 (new html content kind that lints text nodes only, with suppression directives found through the HTML parser).

This task is the version-bump PR only. The tag, the GitHub release, the npm publish, and the plugin reinstall are the captain's steps after the captain's manual smoke pass. Do not tag, do not publish, do not create a release.

Linear ticket: HUF-311.

## What Changed

- Bump the package version from 0.3.1 to 0.4.0 in `package.json`.
- Bump the plugin version from 0.3.1 to 0.4.0 in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
- No tag, GitHub release, or npm publish is part of this change. Those remain manual steps after the smoke pass.

## Risk Assessment

✅ Low: The change bumps the version string from 0.3.1 to 0.4.0 in package.json, plugin.json, and marketplace.json consistently, with no stale references elsewhere, no lockfile version field to update, no tag or release created, and the base commit already includes all four approved PRs named in the intent.

## Testing

I diffed the change, ran the CLI --version E2E test, and manually exercised every user-visible version surface: the CLI, npm pack, and both Claude plugin manifests all report 0.4.0, with no v0.4.0 tag or release present. A lint smoke run on a sample file confirms the CLI still works at this commit. During the run the worktree node_modules was emptied by an external process, so I restored it with a frozen-lockfile install, which left bun.lock unchanged. Everything passed.

<details>
<summary>Evidence: v0.4.0 on every version surface: CLI, npm pack, plugin manifests, no tag</summary>

<code>$ bun src/cli/main.ts --version&#10;0.4.0&#10;&#10;$ npm pack --dry-run --json | jq &#34;.[0] | {name, version, filename}&#34;&#10;{&#10;&#34;name&#34;: &#34;agent-simple-english&#34;,&#10;&#34;version&#34;: &#34;0.4.0&#34;,&#10;&#34;filename&#34;: &#34;agent-simple-english-0.4.0.tgz&#34;&#10;}&#10;&#10;$ jq .version package.json .claude-plugin/plugin.json; jq &#34;.plugins[0].version&#34; .claude-plugin/marketplace.json&#10;&#34;0.4.0&#34;&#10;&#34;0.4.0&#34;&#10;&#34;0.4.0&#34;&#10;&#10;$ git tag --list &#34;v0.4.0&#34;; git ls-remote --tags origin | grep -c v0.4.0&#10;0</code>

```text
$ bun src/cli/main.ts --version
0.4.0

$ npm pack --dry-run --json | jq ".[0] | {name, version, filename}"
{
  "name": "agent-simple-english",
  "version": "0.4.0",
  "filename": "agent-simple-english-0.4.0.tgz"
}

$ jq .version package.json .claude-plugin/plugin.json; jq ".plugins[0].version" .claude-plugin/marketplace.json
"0.4.0"
"0.4.0"
"0.4.0"

$ git tag --list "v0.4.0"; gh-axi release list (v0.4.0 must not exist)
0
```
</details>
<details>
<summary>Evidence: CLI lint smoke at v0.4.0</summary>

<code>$ bun src/cli/main.ts --version&#10;0.4.0&#10;&#10;$ cat sample.md&#10;We can&#39;t do this; it&#39;s been tested.&#10;$ bun src/cli/main.ts sample.md&#10;sample.md:1:4 [hard] contraction Do not use a contraction. Write the words in full. Found &#34;can&#39;t&#34;.&#10;sample.md:1:17 [hard] semicolon Do not use a semicolon. Write two sentences.&#10;sample.md:1:19 [hard] contraction Do not use a contraction. Write the words in full. Found &#34;it&#39;s&#34;.&#10;sample.md:1:24 [soft] verb-passive Use the active voice, unless the actor is unknown. Found: &#34;been tested&#34;.&#10;exit=1</code>

```text
$ bun src/cli/main.ts --version
0.4.0

$ cat sample.md
We can't do this; it's been tested.
$ bun src/cli/main.ts sample.md
sample.md:1:4 [hard] contraction Do not use a contraction. Write the words in full. Found "can't".
sample.md:1:17 [hard] semicolon Do not use a semicolon. Write two sentences.
sample.md:1:19 [hard] contraction Do not use a contraction. Write the words in full. Found "it's".
sample.md:1:24 [soft] verb-passive Use the active voice, unless the actor is unknown. Found: "been tested".
exit=1
```
</details>

## Release notes for v0.4.0

## Changes

- The write and edit gates now skip markup and data files. The list covers html, htm, css, scss, less, json, jsonc, svg, xml, typ, csv, tsv, and lock.
- HTML and HTM files now have their own content kind. The kind checks visible text only. It ignores style, script, comments, and attributes, and it honors suppression directives.
- The CLI now reports skipped files in its output, and it accepts a `--kind html` flag.
- The toolchain now uses Biome 2, Vitest 5, and node types 26. The pi pin moves to 0.85.1, and CI runs on Bun 1.4.0.

**Full changelog**: https://github.com/jyooi/agent-simple-english/compare/v0.3.1...v0.4.0

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0517a6c430a1116a6f85d800f95c7baa8aed535c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 3038fa6..0517a6c` confirms only the three version lines changed</code>
- <code>`bun src/cli/main.ts --version` prints 0.4.0</code>
- <code>`npm pack --dry-run --json` reports name agent-simple-english, version 0.4.0, filename agent-simple-english-0.4.0.tgz</code>
- <code>`jq .version package.json .claude-plugin/plugin.json` and `jq &#39;.plugins[0].version&#39; .claude-plugin/marketplace.json` all print 0.4.0</code>
- <code>`git tag --list v0.4.0` and `git ls-remote --tags origin | grep v0.4.0` return nothing, so no tag was created</code>
- <code>`bun install --frozen-lockfile` succeeds and leaves bun.lock unchanged (git status clean)</code>
- <code>`bunx vitest run test/cli/cli.test.ts -t version` passes (the --version E2E test that spawns the CLI)</code>
- `Manual CLI lint smoke on a sample Markdown file reports contraction, semicolon, and passive-voice violations with exit code 1`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

