### PR TITLE
refactor(schema): extract shared Effect ParseError formatting helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Parent spec lives in Linear HUF-130.
 
 - Pure functional core: `src/engine/` is synchronous, and `src/engine/lint.ts` orchestrates it.
   Effect stays at boundaries such as CLI IO, config loading, and schema validation and loading.
+  Format Schema decode failures through `src/schema/parse-error.ts` only, so the planned Effect v4 migration changes one file.
 - New rules must register their id in `src/engine/rules/registry.ts`; the config schema derives valid rule names from it, so unregistered ids are rejected in user config.
 - Three primary test seams cover product behavior: pure engine API (`test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), and extension wiring via a stubbed ExtensionAPI double. Never run pi itself in tests.
 - Rule-accuracy tests grow first at the pure engine seam. Each lint rule must have direct finding, clean, and boundary cases listed in `test/engine/README.md`.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,8 +1,12 @@
-import { Effect, type ParseResult, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import type { RuleDataExtensions } from "../dictionary/rule-data.ts"
 import { type RuleId, ruleIds } from "../engine/rules/registry.ts"
 import type { RuleSetting } from "../engine/types.ts"
-import { formatParseErrorIssues, formatParseErrorTree } from "../schema/parse-error.ts"
+import {
+  formatParseErrorIssues,
+  formatParseErrorTree,
+  type ParseError,
+} from "../schema/parse-error.ts"
 
 export interface SteConfig {
   readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
@@ -63,7 +67,7 @@ export class ConfigError extends Error {
   readonly _tag = "ConfigError"
 }
 
-const formatError = (error: ParseResult.ParseError, source: string): string => {
+const formatError = (error: ParseError, source: string): string => {
   // Optional fields decode as `T | undefined` unions, so every failure also
   // reports a useless "Expected undefined" branch; drop those.
   const issues = formatParseErrorIssues(error).filter(

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,7 +1,8 @@
-import { Effect, ParseResult, Schema } from "effect"
+import { Effect, type ParseResult, Schema } from "effect"
 import type { RuleDataExtensions } from "../dictionary/rule-data.ts"
 import { type RuleId, ruleIds } from "../engine/rules/registry.ts"
 import type { RuleSetting } from "../engine/types.ts"
+import { formatParseErrorIssues, formatParseErrorTree } from "../schema/parse-error.ts"
 
 export interface SteConfig {
   readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
@@ -65,7 +66,7 @@ export class ConfigError extends Error {
 const formatError = (error: ParseResult.ParseError, source: string): string => {
   // Optional fields decode as `T | undefined` unions, so every failure also
   // reports a useless "Expected undefined" branch; drop those.
-  const issues = ParseResult.ArrayFormatter.formatErrorSync(error).filter(
+  const issues = formatParseErrorIssues(error).filter(
     (issue) => !issue.message.startsWith("Expected undefined"),
   )
   const lines = [
@@ -78,7 +79,7 @@ const formatError = (error: ParseResult.ParseError, source: string): string => {
   const detail =
     lines.length > 0
       ? lines.map((line) => `  ${line}`).join("\n")
-      : `  ${ParseResult.TreeFormatter.formatErrorSync(error)}`
+      : `  ${formatParseErrorTree(error)}`
   return `invalid config in ${source}:\n${detail}`
 }
 

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { Effect, ParseResult, Schema } from "effect"
+import { Effect, type ParseResult, Schema } from "effect"
+import { formatParseErrorIssues } from "../schema/parse-error.ts"
 import type { RuleData, RuleDataExtensions, RuleDataId } from "./rule-data.ts"
 import {
   type ApprovedWordList,
@@ -35,7 +36,7 @@ export class DictionaryLoadError extends Error {
 }
 
 const formatParseError = (error: ParseResult.ParseError): string => {
-  const issue = ParseResult.ArrayFormatter.formatErrorSync(error)[0]
+  const issue = formatParseErrorIssues(error)[0]
   if (issue === undefined) {
     return "invalid dictionary data"
   }

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { Effect, type ParseResult, Schema } from "effect"
-import { formatParseErrorIssues } from "../schema/parse-error.ts"
+import { Effect, Schema } from "effect"
+import { formatParseErrorIssues, type ParseError } from "../schema/parse-error.ts"
 import type { RuleData, RuleDataExtensions, RuleDataId } from "./rule-data.ts"
 import {
   type ApprovedWordList,
@@ -35,7 +35,7 @@ export class DictionaryLoadError extends Error {
   }
 }
 
-const formatParseError = (error: ParseResult.ParseError): string => {
+const formatParseError = (error: ParseError): string => {
   const issue = formatParseErrorIssues(error)[0]
   if (issue === undefined) {
     return "invalid dictionary data"

--- a/src/schema/parse-error.ts
+++ b/src/schema/parse-error.ts
@@ -3,16 +3,18 @@ import { ParseResult } from "effect"
 // This isolates the Effect v3 `ParseResult` module calls, which Effect v4
 // removes, so the later migration changes only this file.
 
+export type ParseError = ParseResult.ParseError
+
 export interface ParseErrorIssue {
   readonly path: ReadonlyArray<string | number>
   readonly message: string
 }
 
-export const formatParseErrorIssues = (error: ParseResult.ParseError): ParseErrorIssue[] =>
+export const formatParseErrorIssues = (error: ParseError): ParseErrorIssue[] =>
   ParseResult.ArrayFormatter.formatErrorSync(error).map((issue) => ({
     path: issue.path as ReadonlyArray<string | number>,
     message: issue.message,
   }))
 
-export const formatParseErrorTree = (error: ParseResult.ParseError): string =>
+export const formatParseErrorTree = (error: ParseError): string =>
   ParseResult.TreeFormatter.formatErrorSync(error)

--- a/src/schema/parse-error.ts
+++ b/src/schema/parse-error.ts
@@ -1,0 +1,18 @@
+import { ParseResult } from "effect"
+
+// This isolates the Effect v3 `ParseResult` module calls, which Effect v4
+// removes, so the later migration changes only this file.
+
+export interface ParseErrorIssue {
+  readonly path: ReadonlyArray<string | number>
+  readonly message: string
+}
+
+export const formatParseErrorIssues = (error: ParseResult.ParseError): ParseErrorIssue[] =>
+  ParseResult.ArrayFormatter.formatErrorSync(error).map((issue) => ({
+    path: issue.path as ReadonlyArray<string | number>,
+    message: issue.message,
+  }))
+
+export const formatParseErrorTree = (error: ParseResult.ParseError): string =>
+  ParseResult.TreeFormatter.formatErrorSync(error)


### PR DESCRIPTION
## Intent

Captain's ask (2026-09-07): "come out a plan to migrate agent-simple-english from effect v3 to effect v4 latest rc". The captain reviewed the plan and chose approach B: migrate when Effect 4.0.0 stable ships, in v0.5.0. The captain then said "go" to start the two preparation PRs now.
This task is preparation wave 0B. It runs on Effect v3 and changes no behavior. src/config/schema.ts (formatError, lines 65 to 83) and src/dictionary/load.ts (formatParseError, lines 37 to 48) each call ParseResult.ArrayFormatter and ParseResult.TreeFormatter directly. Effect v4 removes the ParseResult module. One shared helper that owns the Effect-facing part turns the later migration into a one-body swap.
Linear ticket: HUF-315. The sibling task HUF-314 touches src/config/schema.ts at the same time, in the schema fields only, so a rebase may be needed before merge.

## What Changed

- Add `src/schema/parse-error.ts`, which wraps the Effect v3 `ParseResult` module. It exports a `ParseError` type alias, a `ParseErrorIssue` shape, `formatParseErrorIssues`, and `formatParseErrorTree`.
- Replace the direct `ParseResult.ArrayFormatter` and `ParseResult.TreeFormatter` calls in `src/config/schema.ts` and `src/dictionary/load.ts` with the shared helper. Error output is unchanged.
- Note in `AGENTS.md` that Schema decode failures must format through the helper only, so the planned Effect v4 migration changes one file.

## Risk Assessment

✅ Low: Pure non-behavioral extraction of two formatter calls into one helper, every ParseResult reference now lives in a single file as the intent requires, and both call sites produce identical strings.

## Testing

Ran the targeted config schema and CLI config test files, which cover both refactored formatting paths, and all passed. Then exercised the CLI end-to-end with an invalid config file and two invalid dictionary files at both the base and target commits, and the error text and exit codes matched byte for byte, so the helper extraction changes no user-visible behavior. No UI surface is involved, so no visual artifact applies.

<details>
<summary>Evidence: CLI parse error transcript at target commit (invalid config, invalid dictionary entry, invalid dictionary shape)</summary>

<code>== bad-config: {&#34;rules&#34;:{&#34;sentence-length&#34;:&#34;warn&#34;},&#34;maxSentenceWords&#34;:&#34;25&#34;}&#10;invalid config in &lt;tmp&gt;/bad-config/.simple-english.json:&#10;rules.sentence-length: must be &#34;hard&#34;, &#34;soft&#34;, or &#34;off&#34;, got &#34;warn&#34;&#10;maxSentenceWords: must be a positive integer, got &#34;25&#34;&#10;exit=2&#10;== bad-dict: {&#34;approvedWordsPath&#34;:&#34;approved-words.json&#34;}&#10;Cannot load STE dictionary from &lt;tmp&gt;/bad-dict/approved-words.json: approvedWords[0]: Expected a string matching the pattern ^[\p{L}\p{N}]+(?:[&#39;’‐‑-][\p{L}\p{N}]+)*$, actual &#34;two words&#34;&#10;exit=2&#10;== bad-dict-tree: {&#34;approvedWordsPath&#34;:&#34;approved-words.json&#34;}&#10;Cannot load STE dictionary from &lt;tmp&gt;/bad-dict-tree/approved-words.json: invalid dictionary data: Expected { ... }, actual []&#10;exit=2</code>

```text
== bad-config: {"rules":{"sentence-length":"warn"},"maxSentenceWords":"25"}
invalid config in <tmp>/bad-config/.simple-english.json:
  rules.sentence-length: must be "hard", "soft", or "off", got "warn"
  maxSentenceWords: must be a positive integer, got "25"
exit=2
== bad-dict: {"approvedWordsPath":"approved-words.json"}
Cannot load STE dictionary from <tmp>/bad-dict/approved-words.json: approvedWords[0]: Expected a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$, actual "two words"
exit=2
== bad-dict-tree: {"approvedWordsPath":"approved-words.json"}
Cannot load STE dictionary from <tmp>/bad-dict-tree/approved-words.json: invalid dictionary data: Expected { readonly formatVersion: 1; readonly source: { readonly name: NonEmptyTrimmedString; readonly repository: NonEmptyTrimmedString; readonly commit: NonEmptyTrimmedString; readonly path: NonEmptyTrimmedString }; readonly approvedWords: readonly [NonEmptyTrimmedString & a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$, ...NonEmptyTrimmedString & a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$[]] }, actual []
exit=2
```
</details>
<details>
<summary>Evidence: Same transcript at base commit 3e42246</summary>

```text
== bad-config: {"rules":{"sentence-length":"warn"},"maxSentenceWords":"25"}
invalid config in <tmp>/bad-config/.simple-english.json:
  rules.sentence-length: must be "hard", "soft", or "off", got "warn"
  maxSentenceWords: must be a positive integer, got "25"
exit=2
== bad-dict: {"approvedWordsPath":"approved-words.json"}
Cannot load STE dictionary from <tmp>/bad-dict/approved-words.json: approvedWords[0]: Expected a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$, actual "two words"
exit=2
== bad-dict-tree: {"approvedWordsPath":"approved-words.json"}
Cannot load STE dictionary from <tmp>/bad-dict-tree/approved-words.json: invalid dictionary data: Expected { readonly formatVersion: 1; readonly source: { readonly name: NonEmptyTrimmedString; readonly repository: NonEmptyTrimmedString; readonly commit: NonEmptyTrimmedString; readonly path: NonEmptyTrimmedString }; readonly approvedWords: readonly [NonEmptyTrimmedString & a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$, ...NonEmptyTrimmedString & a string matching the pattern ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$[]] }, actual []
exit=2
```
</details>
<details>
<summary>Evidence: diff of base vs target CLI stderr</summary>

`IDENTICAL: base and target stderr match byte for byte`

```text
IDENTICAL: base and target stderr match byte for byte
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"983d9f2bf29b2749d23bf501308c1713a5b1069a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/config/schema.ts:66` - Both call sites still import `type ParseResult` from &#34;effect&#34; to annotate `error: ParseResult.ParseError` (src/config/schema.ts:1,66 and src/dictionary/load.ts:4,38). Effect v4 removes the ParseResult module, so the stated goal that the migration becomes a one-body swap in src/schema/parse-error.ts does not hold: the type reference will break compilation in three files, not one. Remedy: export a `ParseError` type alias from src/schema/parse-error.ts (`export type ParseError = ParseResult.ParseError`) and import that alias in both callers, dropping the `effect` ParseResult import there. Non-behavioral.

🔧 Fix: export ParseError alias from parse-error helper
1 info still open:

- ℹ️ `src/schema/parse-error.ts:15` - `issue.path as ReadonlyArray&lt;string | number&gt;` narrows Effect&#39;s `ReadonlyArray&lt;PropertyKey&gt;` and silently drops `symbol` from the declared type. Runtime output is unchanged because both callers already stringify segments, and schema paths for JSON config and dictionary data never contain symbols. No action needed; noting the cast so the v4 swap keeps the same contract.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun run test -- test/config/schema.test.ts test/cli/config.test.ts` (32 tests: readable config decode errors and CLI exit 2 with file, key, and value named; invalid approved-word list names `approvedWords[0]`)</code>
- <code>Manual E2E: ran `bun src/cli/main.ts` at the target commit against three synthetic projects (invalid config with two bad fields, dictionary with a multi-word entry, dictionary file that is an empty array) and captured stderr and exit codes</code>
- <code>Manual E2E: extracted the base commit with `git archive 3e42246`, ran the same three cases, and diffed stderr against the target output (identical)</code>
- <code>`grep -rn ParseResult src/` confirms the only remaining Effect ParseResult reference is in src/schema/parse-error.ts</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
