### PR TITLE
refactor(schema): alias Schema.NonEmptyTrimmedString behind a local primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Parent spec lives in Linear HUF-130.
 
 - Pure functional core: `src/engine/` is synchronous, and `src/engine/lint.ts` orchestrates it.
   Effect stays at boundaries such as CLI IO, config loading, and schema validation and loading.
-  Format Schema decode failures through `src/schema/parse-error.ts` only, so the planned Effect v4 migration changes one file.
+  Format Schema decode failures through `src/schema/parse-error.ts` only, and import `NonEmptyTrimmedString` from `src/schema/primitives.ts` instead of `Schema`, so the planned Effect v4 migration changes one file per seam.
 - New rules must register their id in `src/engine/rules/registry.ts`; the config schema derives valid rule names from it, so unregistered ids are rejected in user config.
 - Three primary test seams cover product behavior: pure engine API (`test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), and extension wiring via a stubbed ExtensionAPI double. Never run pi itself in tests.
 - Rule-accuracy tests grow first at the pure engine seam. Each lint rule must have direct finding, clean, and boundary cases listed in `test/engine/README.md`.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -7,6 +7,7 @@ import {
   formatParseErrorTree,
   type ParseError,
 } from "../schema/parse-error.ts"
+import { NonEmptyTrimmedString } from "../schema/primitives.ts"
 
 export interface SteConfig {
   readonly rules?: Partial<Readonly<Record<RuleId, RuleSetting>>>
@@ -43,10 +44,10 @@ const ExemptBlockQuotesSchema = Schema.Boolean.annotations({
 
 const RuleDataExtensionsSchema = Schema.partial(
   Schema.Struct({
-    "phrasal-verb": Schema.Array(Schema.NonEmptyTrimmedString),
-    hedging: Schema.Array(Schema.NonEmptyTrimmedString),
-    marketing: Schema.Array(Schema.NonEmptyTrimmedString),
-    "adjectival-participle": Schema.Array(Schema.NonEmptyTrimmedString),
+    "phrasal-verb": Schema.Array(NonEmptyTrimmedString),
+    hedging: Schema.Array(NonEmptyTrimmedString),
+    marketing: Schema.Array(NonEmptyTrimmedString),
+    "adjectival-participle": Schema.Array(NonEmptyTrimmedString),
   }),
 )
 
@@ -55,7 +56,7 @@ const SteConfigSchema = Schema.Struct({
   maxSentenceWords: Schema.optional(MaxSentenceWordsSchema),
   exemptBlockQuotes: Schema.optional(ExemptBlockQuotesSchema),
   ruleDataExtensions: Schema.optional(RuleDataExtensionsSchema),
-  approvedWordsPath: Schema.optional(Schema.NonEmptyTrimmedString),
+  approvedWordsPath: Schema.optional(NonEmptyTrimmedString),
 })
 
 const decodeUnknown = Schema.decodeUnknown(SteConfigSchema, {

--- a/src/dictionary/schema.ts
+++ b/src/dictionary/schema.ts
@@ -1,25 +1,22 @@
 import { Schema } from "effect"
+import { NonEmptyTrimmedString } from "../schema/primitives.ts"
 import { DICTIONARY_FORM_PATTERN, DICTIONARY_WORD_PATTERN } from "./form.ts"
 
 const DictionarySourceSchema = Schema.Struct({
-  name: Schema.NonEmptyTrimmedString,
-  repository: Schema.NonEmptyTrimmedString,
-  commit: Schema.NonEmptyTrimmedString,
-  path: Schema.NonEmptyTrimmedString,
+  name: NonEmptyTrimmedString,
+  repository: NonEmptyTrimmedString,
+  commit: NonEmptyTrimmedString,
+  path: NonEmptyTrimmedString,
 })
 
-const DictionaryFormSchema = Schema.NonEmptyTrimmedString.pipe(
-  Schema.pattern(DICTIONARY_FORM_PATTERN),
-)
+const DictionaryFormSchema = NonEmptyTrimmedString.pipe(Schema.pattern(DICTIONARY_FORM_PATTERN))
 
-const DictionaryWordSchema = Schema.NonEmptyTrimmedString.pipe(
-  Schema.pattern(DICTIONARY_WORD_PATTERN),
-)
+const DictionaryWordSchema = NonEmptyTrimmedString.pipe(Schema.pattern(DICTIONARY_WORD_PATTERN))
 
 const DictionaryEntrySchema = Schema.Struct({
   unapproved: Schema.NonEmptyArray(DictionaryFormSchema),
-  suggestions: Schema.NonEmptyArray(Schema.NonEmptyTrimmedString),
-  partsOfSpeech: Schema.optional(Schema.NonEmptyArray(Schema.NonEmptyTrimmedString)),
+  suggestions: Schema.NonEmptyArray(NonEmptyTrimmedString),
+  partsOfSpeech: Schema.optional(Schema.NonEmptyArray(NonEmptyTrimmedString)),
 })
 
 export const DictionarySchema = Schema.Struct({

--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -1,0 +1,5 @@
+import { Schema } from "effect"
+
+// Effect v4 removes Schema.NonEmptyTrimmedString.
+// Every call site imports this alias so the v4 migration changes one line.
+export const NonEmptyTrimmedString = Schema.NonEmptyTrimmedString

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -95,6 +95,13 @@ describe("config schema", () => {
     }
   })
 
+  test("ruleDataExtensions entries must be non-empty strings", () => {
+    for (const bad of ["", "   "]) {
+      const message = expectDecodeError({ ruleDataExtensions: { hedging: [bad] } })
+      expect(message).toContain("hedging")
+    }
+  })
+
   test("a non-object config is rejected", () => {
     expect(decode("hard")._tag).toBe("Left")
     expect(decode(null)._tag).toBe("Left")

--- a/test/dictionary/schema.test.ts
+++ b/test/dictionary/schema.test.ts
@@ -1,0 +1,76 @@
+import { Schema } from "effect"
+import { describe, expect, test } from "vitest"
+import { ApprovedWordListSchema, decodeDictionaryData } from "../../src/dictionary/schema.ts"
+
+const source = {
+  name: "ASD-STE100",
+  repository: "https://example.com/ste",
+  commit: "abc123",
+  path: "dictionary.json",
+}
+
+const validDictionary = {
+  formatVersion: 1,
+  source,
+  entries: [{ unapproved: ["utilize"], suggestions: ["use"], partsOfSpeech: ["verb"] }],
+}
+
+const decodeApprovedWords = Schema.decodeUnknownSync(ApprovedWordListSchema, { errors: "all" })
+
+describe("dictionary schema", () => {
+  test("decodes a valid dictionary", () => {
+    expect(decodeDictionaryData(validDictionary)).toEqual(validDictionary)
+  })
+
+  test("decodes a valid approved-word list", () => {
+    const list = { formatVersion: 1, source, approvedWords: ["use", "remove"] }
+    expect(decodeApprovedWords(list)).toEqual(list)
+  })
+
+  test("rejects blank strings in every source field", () => {
+    for (const field of ["name", "repository", "commit", "path"] as const) {
+      for (const bad of ["", "   "]) {
+        expect(() =>
+          decodeDictionaryData({ ...validDictionary, source: { ...source, [field]: bad } }),
+        ).toThrow(field)
+      }
+    }
+  })
+
+  test("rejects blank suggestions and parts of speech", () => {
+    for (const bad of ["", "  "]) {
+      expect(() =>
+        decodeDictionaryData({
+          ...validDictionary,
+          entries: [{ unapproved: ["utilize"], suggestions: [bad] }],
+        }),
+      ).toThrow("suggestions")
+      expect(() =>
+        decodeDictionaryData({
+          ...validDictionary,
+          entries: [{ unapproved: ["utilize"], suggestions: ["use"], partsOfSpeech: [bad] }],
+        }),
+      ).toThrow("partsOfSpeech")
+    }
+  })
+
+  test("rejects blank unapproved forms and approved words", () => {
+    for (const bad of ["", "  "]) {
+      expect(() =>
+        decodeDictionaryData({
+          ...validDictionary,
+          entries: [{ unapproved: [bad], suggestions: ["use"] }],
+        }),
+      ).toThrow("unapproved")
+      expect(() => decodeApprovedWords({ formatVersion: 1, source, approvedWords: [bad] })).toThrow(
+        "approvedWords",
+      )
+    }
+  })
+
+  test("rejects strings with surrounding whitespace", () => {
+    expect(() =>
+      decodeDictionaryData({ ...validDictionary, source: { ...source, name: " ASD " } }),
+    ).toThrow("name")
+  })
+})


### PR DESCRIPTION
## Intent

Captain's ask (2026-09-07): "come out a plan to migrate agent-simple-english from effect v3 to effect v4 latest rc". The captain reviewed the plan and chose approach B: migrate when Effect 4.0.0 stable ships, in v0.5.0. The captain then said "go" to start the two preparation PRs now. This task is preparation wave 0A. It runs on Effect v3 and changes no behavior. Schema.NonEmptyTrimmedString appears at 13 call sites in src/config/schema.ts and src/dictionary/schema.ts. Effect v4 removes that export. One local definition used at all 13 sites turns the later migration into a one-line change. Linear ticket: HUF-314. The sibling task HUF-315 touches src/config/schema.ts at the same time, in its formatter function only, so a rebase may be needed before merge.

## What Changed

- Add `src/schema/primitives.ts`, which exports a local `NonEmptyTrimmedString` alias for `Schema.NonEmptyTrimmedString`, and switch all 13 call sites in `src/config/schema.ts` and `src/dictionary/schema.ts` to import it. Decode behavior is unchanged.
- Add `test/dictionary/schema.test.ts` to pin dictionary and approved-word list decoding, including rejection of blank strings, and add a config schema test that rejects blank `ruleDataExtensions` entries.
- Update the architecture rules in `AGENTS.md` to require the new primitives import so the Effect v4 migration changes one file per seam.

## Risk Assessment

✅ Low: The change re-exports the identical Schema.NonEmptyTrimmedString value from a new module and swaps all 13 call sites to the alias, so decode behavior, error messages, and types are unchanged and no usage of the removed export remains.

## Testing

Ran the config schema, new dictionary schema, and CLI config E2E tests, and drove the simple-english CLI manually with blank and valid configs; all pass and decode errors and lint output are unchanged.

<details>
<summary>Evidence: CLI transcript: blank config values rejected, valid config lints</summary>

<code>$ simple-english --config blank.json doc.md (approvedWordsPath is whitespace only)&#10;invalid config in blank.json:&#10;approvedWordsPath: Expected a string with no leading or trailing whitespace, actual &#34; &#34;&#10;exit=2&#10;&#10;$ simple-english --config blank-ext.json doc.md (ruleDataExtensions.hedging has an empty path)&#10;invalid config in blank-ext.json:&#10;ruleDataExtensions.hedging.0: Expected a non empty string, actual &#34;&#34;&#10;exit=2&#10;&#10;$ simple-english --config valid.json doc.md (valid config still lints with the bundled dictionary)&#10;doc.md:1:13 [hard] dictionary-not-approved-word Use &#34;use&#34;, not &#34;utilize&#34;.&#10;exit=1</code>

```text
$ simple-english --config blank.json doc.md   (approvedWordsPath is whitespace only)
invalid config in blank.json:
  approvedWordsPath: Expected a string with no leading or trailing whitespace, actual "   "
exit=2

$ simple-english --config blank-ext.json doc.md   (ruleDataExtensions.hedging has an empty path)
invalid config in blank-ext.json:
  ruleDataExtensions.hedging.0: Expected a non empty string, actual ""
exit=2

$ simple-english --config valid.json doc.md   (valid config still lints with the bundled dictionary)
doc.md:1:13 [hard] dictionary-not-approved-word Use "use", not "utilize".
exit=1
```
</details>
<details>
<summary>Evidence: Verbose vitest log for schema and CLI config tests</summary>

```text
 RUN  v5.0.0 ~/.no-mistakes/worktrees/5b49eff34526/01M1X35R8FPKYB7TTGZC4R0JNE
 ✓ test/config/schema.test.ts > config schema > decodes a full valid config 3ms
 ✓ test/config/schema.test.ts > config schema > decodes an empty config 0ms
 ✓ test/config/schema.test.ts > config schema > accepts every severity setting for the dictionary rule 0ms
 ✓ test/config/schema.test.ts > config schema > a typo'd rule name produces a readable error naming the bad key 2ms
 ✓ test/config/schema.test.ts > config schema > an invalid severity value produces a readable error naming the value 1ms
 ✓ test/config/schema.test.ts > config schema > an unknown top-level key produces a readable error naming the key 0ms
 ✓ test/config/schema.test.ts > config schema > maxSentenceWords must be a positive integer 1ms
 ✓ test/config/schema.test.ts > config schema > exemptBlockQuotes must be a boolean 1ms
 ✓ test/config/schema.test.ts > config schema > approvedWordsPath must be a non-empty string 1ms
 ✓ test/config/schema.test.ts > config schema > ruleDataExtensions entries must be non-empty strings 1ms
 ✓ test/config/schema.test.ts > config schema > a non-object config is rejected 1ms
 ✓ test/dictionary/schema.test.ts > dictionary schema > decodes a valid dictionary 2ms
 ✓ test/dictionary/schema.test.ts > dictionary schema > decodes a valid approved-word list 1ms
 ✓ test/dictionary/schema.test.ts > dictionary schema > rejects blank strings in every source field 6ms
 ✓ test/dictionary/schema.test.ts > dictionary schema > rejects blank suggestions and parts of speech 3ms
 ✓ test/dictionary/schema.test.ts > dictionary schema > rejects blank unapproved forms and approved words 2ms
 ✓ test/dictionary/schema.test.ts > dictionary schema > rejects strings with surrounding whitespace 1ms
 ✓ test/cli/config.test.ts > simple-english CLI config > a configured approved-word list permits listed words and flags absent words 426ms
 ✓ test/cli/config.test.ts > simple-english CLI config > an invalid approved-word list exits 2 and names the invalid item 148ms
 ✓ test/cli/config.test.ts > simple-english CLI config > a missing approved-word list exits 2 and names the path 165ms
 ✓ test/cli/config.test.ts > simple-english CLI config > a unreadable approved-word list exits 2 and names the path 149ms
 ✓ test/cli/config.test.ts > simple-english CLI config > project config changes the sentence word cap 200ms
 ✓ test/cli/config.test.ts > simple-english CLI config > project config exempts block quotes from wording rules 200ms
 ✓ test/cli/config.test.ts > simple-english CLI config > global config in the XDG config directory applies 202ms
 ✓ test/cli/config.test.ts > simple-english CLI config > XDG_CONFIG_HOME sets the global config directory 198ms
 ✓ test/cli/config.test.ts > simple-english CLI config > legacy pi project and global configs apply when new configs are absent 188ms
 ✓ test/cli/config.test.ts > simple-english CLI config > PI_CODING_AGENT_DIR sets the legacy global fallback directory 194ms
 ✓ test/cli/config.test.ts > simple-english CLI config > new locations replace legacy locations at each config level 194ms
 ✓ test/cli/config.test.ts > simple-english CLI config > project config deep-merges over global with project winning per key 213ms
 ✓ test/cli/config.test.ts > simple-english CLI config > a rule set to off in project config is suppressed 197ms
 ✓ test/cli/config.test.ts > simple-english CLI config > project config extends rule data without replacing bundled entries 188ms
 ✓ test/cli/config.test.ts > simple-english CLI config > reports extension failures as rule data 199ms
 ✓ test/cli/config.test.ts > simple-english CLI config > --config points at an explicit file and ignores discovered configs 197ms
 ✓ test/cli/config.test.ts > simple-english CLI config > an invalid config file exits 2 with a readable error naming the file and key 153ms
 ✓ test/cli/config.test.ts > simple-english CLI config > a config file with malformed JSON exits 2 naming the file 147ms
 ✓ test/cli/config.test.ts > simple-english CLI config > a missing explicit --config file exits 2 naming the path 154ms
 ✓ test/cli/config.test.ts > simple-english CLI config > --config without a path exits 2 with a usage error 144ms
 ✓ test/cli/config.test.ts > simple-english CLI config > rejects an option token as a --config path 166ms
 ✓ test/cli/config.test.ts > simple-english CLI config > defaults apply when no config files exist 195ms
 Test Files  3 passed (3)
      Tests  39 passed (39)
   Start at  12:57:11
   Duration  4.33s (tests 91%, import 7%, transform 3%)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"24708959671450afb2b791d11f9331e77798dc7d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 3e42246..050b4c7` review plus `grep` confirming zero remaining direct `Schema.NonEmptyTrimmedString` uses outside `src/schema/primitives.ts`</code>
- <code>`bun run test test/config/schema.test.ts test/cli/config.test.ts test/engine/dictionary.test.ts` (3 files, all passing)</code>
- <code>Manual CLI E2E via `bun src/cli/main.ts`: whitespace-only `approvedWordsPath` rejected with exit 2; blank `ruleDataExtensions.hedging` entry rejected with exit 2; valid `approvedWordsPath` accepted and the list drives approved-word lint (exit 0 / exit 1)</code>
- <code>Manual CLI E2E via `SIMPLE_ENGLISH_DICTIONARY`: dictionary with blank suggestion rejected with the trimmed-string message; same dictionary with a real suggestion accepted and produces the replacement finding</code>
- <code>Verified the exit-0 soft failure for an invalid replacement dictionary is pre-existing in `src/cli/main.ts` at the base commit</code>

✅ No issues found.
- <code>`grep -rn &#34;Schema.NonEmptyTrimmedString&#34; src` confirms only src/schema/primitives.ts references the Effect export</code>
- <code>`bunx vitest run test/dictionary/schema.test.ts test/config/schema.test.ts test/cli/config.test.ts` (39 tests, all pass)</code>
- <code>New `test/dictionary/schema.test.ts`: valid dictionary and approved-word list decode; blank strings rejected in every source field, suggestions, partsOfSpeech, unapproved forms, approvedWords; surrounding whitespace rejected</code>
- <code>New case in `test/config/schema.test.ts`: ruleDataExtensions entries must be non-empty strings</code>
- <code>Manual CLI run: `bun src/cli/main.ts --config &lt;file&gt; doc.md` with whitespace-only approvedWordsPath, empty ruleDataExtensions path, and a valid config</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

✅ No issues found.
</details>
