### PR TITLE
refactor: migrate from Effect v3 to 4.0.0-rc.112

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,13 @@ Parent spec lives in Linear HUF-130.
 
 - Pure functional core: `src/engine/` is synchronous, and `src/engine/lint.ts` orchestrates it.
   Effect stays at boundaries such as CLI IO, config loading, and schema validation and loading.
-  Format Schema decode failures through `src/schema/parse-error.ts` only, and import `NonEmptyTrimmedString` from `src/schema/primitives.ts` instead of `Schema`, so the planned Effect v4 migration changes one file per seam.
+  Format Schema decode failures through `src/schema/parse-error.ts` only, and import `NonEmptyTrimmedString` from `src/schema/primitives.ts` instead of `Schema`, so a later Schema change touches one file per seam.
+- `effect` is pinned to the exact version `4.0.0-rc.112`, with no caret.
+  A release candidate can still make a narrow breaking change, and the Schema module moves most.
+  Every bump needs a full re-verification of the config and dictionary error text.
+- Effect v4 omits the rejected value from a schema issue unless the parse options set `reportInput: true`.
+  A static `message` annotation also drops that value, so use the `expected` annotation per check.
+  A v4 annotation binds to one AST node, not to a whole schema chain.
 - New rules must register their id in `src/engine/rules/registry.ts`; the config schema derives valid rule names from it, so unregistered ids are rejected in user config.
 - Three primary test seams cover product behavior: pure engine API (`test/engine/`), CLI E2E via spawned `bun src/cli/main.ts` (`test/cli/`), and extension wiring via a stubbed ExtensionAPI double. Never run pi itself in tests.
 - Rule-accuracy tests grow first at the pure engine seam. Each lint rule must have direct finding, clean, and boundary cases listed in `test/engine/README.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
-AGENTS.md
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,1 @@
-<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
-@AGENTS.md
+AGENTS.md

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@lezer/html": "^1.3.12",
         "@lezer/markdown": "^1.7.2",
-        "effect": "^3.14.0",
+        "effect": "4.0.0-rc.112",
         "micromark": "^4.0.2",
         "micromark-extension-frontmatter": "^2.0.0",
         "micromark-extension-gfm-table": "^2.1.1",
@@ -213,6 +213,18 @@
 
     "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4", "", { "os": "linux", "cpu": "arm" }, "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
+
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
     "@protobufjs/base64": ["@protobufjs/base64@1.1.2", "", {}, "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="],
@@ -303,8 +315,6 @@
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
-
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
@@ -355,13 +365,15 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
-    "effect": ["effect@3.22.1", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-TNoXushmPOBAjJlthF5d2QwnX2xBPEtcNJr5XKNKbRLbDvBcOYkXlYDfvGfSA0zriwLFuCll5MDtNMAdZL17PQ=="],
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
     "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
 
@@ -373,7 +385,7 @@
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
-    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
@@ -481,11 +493,17 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "msgpackr": ["msgpackr@2.1.0", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-p/pBCVO63CsvvpkomUnNNag6+n38rULuDA6HHe70o2gtC8ODI52foF/4ko2qQcp6OiErJXTmrZeXmsGGHsIQNQ=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
+
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
@@ -507,7 +525,7 @@
 
     "protobufjs": ["protobufjs@7.6.5", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
-    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@lezer/html": "^1.3.12",
     "@lezer/markdown": "^1.7.2",
-    "effect": "^3.14.0",
+    "effect": "4.0.0-rc.112",
     "micromark": "^4.0.2",
     "micromark-extension-frontmatter": "^2.0.0",
     "micromark-extension-gfm-table": "^2.1.1",

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -715,7 +715,7 @@ function recordEvaluation(event: HookEvent, evaluation: HookEvaluation): Effect.
       }),
     catch: () => undefined,
   }).pipe(
-    Effect.catchAll(() => Effect.void),
+    Effect.catch(() => Effect.void),
     Effect.as(evaluation.output),
   )
 }
@@ -760,14 +760,14 @@ export function runHookMode(raw: string): Effect.Effect<HookOutput, never, Tagge
               return yield* recordEvaluation(event, evaluation)
             })
           }),
-          Effect.catchAll((error) =>
+          Effect.catch((error) =>
             Effect.succeed(
               event.hookEventName === "PreToolUse"
                 ? nonBlockingWarning(error.message)
                 : nonBlockingError(error.message),
             ),
           ),
-          Effect.catchAllCause((cause) =>
+          Effect.catchCause((cause) =>
             Effect.succeed(
               event.hookEventName === "PreToolUse"
                 ? hookInternalFailure(cause)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { readFile } from "node:fs/promises"
-import { Effect, Either } from "effect"
+import { Effect, Result } from "effect"
 import packageManifest from "../../package.json" with { type: "json" }
 import { loadConfig } from "../config/load.ts"
 import { loadConfiguredDictionary } from "../dictionary/configured.ts"
@@ -220,20 +220,20 @@ const lintProgram = Effect.gen(function* () {
     )
   }
   const config = yield* loadConfig(configPath)
-  const loadedDictionary = yield* Effect.either(
+  const loadedDictionary = yield* Effect.result(
     loadConfiguredDictionary(config, process.cwd(), process.env.SIMPLE_ENGLISH_DICTIONARY),
   )
-  const loadedRuleData = yield* Effect.either(loadRuleData(config.ruleDataExtensions))
-  if (Either.isLeft(loadedDictionary) && config.approvedWordsPath !== undefined) {
-    return yield* Effect.fail(loadedDictionary.left)
+  const loadedRuleData = yield* Effect.result(loadRuleData(config.ruleDataExtensions))
+  if (Result.isFailure(loadedDictionary) && config.approvedWordsPath !== undefined) {
+    return yield* Effect.fail(loadedDictionary.failure)
   }
-  const dictionary = Either.getOrUndefined(loadedDictionary)
-  const ruleData = Either.getOrUndefined(loadedRuleData)
-  if (Either.isLeft(loadedDictionary)) {
-    yield* Effect.sync(() => console.error(loadedDictionary.left.message))
+  const dictionary = Result.getOrUndefined(loadedDictionary)
+  const ruleData = Result.getOrUndefined(loadedRuleData)
+  if (Result.isFailure(loadedDictionary)) {
+    yield* Effect.sync(() => console.error(loadedDictionary.failure.message))
   }
-  if (Either.isLeft(loadedRuleData)) {
-    yield* Effect.sync(() => console.error(loadedRuleData.left.message))
+  if (Result.isFailure(loadedRuleData)) {
+    yield* Effect.sync(() => console.error(loadedRuleData.failure.message))
   }
   const inputs =
     paths.length === 0

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -164,7 +164,7 @@ const hookProgram = Effect.gen(function* () {
   console.log(JSON.stringify(output))
   return 0
 }).pipe(
-  Effect.catchAllCause((cause) =>
+  Effect.catchCause((cause) =>
     Effect.sync(() => {
       console.log(JSON.stringify(hookInternalFailure(cause)))
       return 0
@@ -282,7 +282,7 @@ const program: Effect.Effect<number, Error> =
         : lintProgram.pipe(Effect.provide(WinkTaggerLive))
 
 const handled = program.pipe(
-  Effect.catchAll((error) =>
+  Effect.catch((error) =>
     Effect.sync(() => {
       console.error(error.message)
       return 2

--- a/src/cli/session-command.ts
+++ b/src/cli/session-command.ts
@@ -1,5 +1,5 @@
 import { resolve } from "node:path"
-import { Effect, Either } from "effect"
+import { Effect, Result } from "effect"
 import { formatFailedStatusSummary, formatStatusSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import { loadConfiguredDictionary } from "../dictionary/configured.ts"
@@ -48,25 +48,25 @@ const updateStrict = (sessionId: string, strict: boolean) =>
 function status(sessionId: string, cwd: string): Effect.Effect<string, Error> {
   return Effect.gen(function* () {
     const control = yield* readControl(sessionId)
-    const configResult = yield* Effect.either(loadConfig(undefined, cwd))
-    if (Either.isLeft(configResult)) {
-      return formatFailedStatusSummary(modeName(control), configResult.left.message)
+    const configResult = yield* Effect.result(loadConfig(undefined, cwd))
+    if (Result.isFailure(configResult)) {
+      return formatFailedStatusSummary(modeName(control), configResult.failure.message)
     }
     const dictionaryPath = process.env.SIMPLE_ENGLISH_DICTIONARY
-    const dictionaryResult = yield* Effect.either(
+    const dictionaryResult = yield* Effect.result(
       Effect.all({
         dictionary: loadConfiguredDictionary(
-          configResult.right,
+          configResult.success,
           cwd,
           dictionaryPath === undefined ? undefined : resolve(cwd, dictionaryPath),
         ),
-        ruleData: loadRuleData(configResult.right.ruleDataExtensions, cwd),
+        ruleData: loadRuleData(configResult.success.ruleDataExtensions, cwd),
       }),
     )
-    const dictionary: DictionaryState = Either.isRight(dictionaryResult)
+    const dictionary: DictionaryState = Result.isSuccess(dictionaryResult)
       ? "loaded"
-      : `failed (${dictionaryResult.left.message})`
-    return formatStatusSummary(configResult.right, modeName(control), dictionary)
+      : `failed (${dictionaryResult.failure.message})`
+    return formatStatusSummary(configResult.success, modeName(control), dictionary)
   })
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -17,51 +17,45 @@ export interface SteConfig {
   readonly approvedWordsPath?: string
 }
 
-const RuleSettingSchema = Schema.Literal("hard", "soft", "off").annotations({
-  message: (issue) => ({
-    message: `must be "hard", "soft", or "off", got ${JSON.stringify(issue.actual)}`,
-    override: true,
-  }),
+const RuleSettingSchema = Schema.Literals(["hard", "soft", "off"]).annotate({
+  expected: '"hard", "soft", or "off"',
 })
 
-const RulesSchema = Schema.partial(
-  Schema.Struct(Object.fromEntries(ruleIds.map((id) => [id, RuleSettingSchema]))),
+const RulesSchema = Schema.Struct(
+  Object.fromEntries(ruleIds.map((id) => [id, Schema.optionalKey(RuleSettingSchema)])),
 )
 
-const MaxSentenceWordsSchema = Schema.Int.pipe(Schema.positive()).annotations({
-  message: (issue) => ({
-    message: `must be a positive integer, got ${JSON.stringify(issue.actual)}`,
-    override: true,
-  }),
-})
-
-const ExemptBlockQuotesSchema = Schema.Boolean.annotations({
-  message: (issue) => ({
-    message: `must be a boolean, got ${JSON.stringify(issue.actual)}`,
-    override: true,
-  }),
-})
-
-const RuleDataExtensionsSchema = Schema.partial(
-  Schema.Struct({
-    "phrasal-verb": Schema.Array(NonEmptyTrimmedString),
-    hedging: Schema.Array(NonEmptyTrimmedString),
-    marketing: Schema.Array(NonEmptyTrimmedString),
-    "adjectival-participle": Schema.Array(NonEmptyTrimmedString),
-  }),
+// One refinement over Unknown, rather than Number plus two checks, so that a
+// wrong type and a wrong number both report the same text and the value.
+const MaxSentenceWordsSchema = Schema.Unknown.pipe(
+  Schema.refine(
+    (value): value is number => typeof value === "number" && Number.isInteger(value) && value > 0,
+    { expected: "a positive integer" },
+  ),
 )
+
+const ExemptBlockQuotesSchema = Schema.Boolean
+
+const RuleDataExtensionsSchema = Schema.Struct({
+  "phrasal-verb": Schema.optionalKey(Schema.Array(NonEmptyTrimmedString)),
+  hedging: Schema.optionalKey(Schema.Array(NonEmptyTrimmedString)),
+  marketing: Schema.optionalKey(Schema.Array(NonEmptyTrimmedString)),
+  "adjectival-participle": Schema.optionalKey(Schema.Array(NonEmptyTrimmedString)),
+})
 
 const SteConfigSchema = Schema.Struct({
-  rules: Schema.optional(RulesSchema),
-  maxSentenceWords: Schema.optional(MaxSentenceWordsSchema),
-  exemptBlockQuotes: Schema.optional(ExemptBlockQuotesSchema),
-  ruleDataExtensions: Schema.optional(RuleDataExtensionsSchema),
-  approvedWordsPath: Schema.optional(NonEmptyTrimmedString),
+  rules: Schema.optionalKey(RulesSchema),
+  maxSentenceWords: Schema.optionalKey(MaxSentenceWordsSchema),
+  exemptBlockQuotes: Schema.optionalKey(ExemptBlockQuotesSchema),
+  ruleDataExtensions: Schema.optionalKey(RuleDataExtensionsSchema),
+  approvedWordsPath: Schema.optionalKey(NonEmptyTrimmedString),
 })
 
-const decodeUnknown = Schema.decodeUnknown(SteConfigSchema, {
+const decodeUnknown = Schema.decodeUnknownEffect(SteConfigSchema, {
   onExcessProperty: "error",
   errors: "all",
+  // v4 omits the rejected value from an issue unless this option is on.
+  reportInput: true,
 })
 
 export class ConfigError extends Error {
@@ -69,11 +63,7 @@ export class ConfigError extends Error {
 }
 
 const formatError = (error: ParseError, source: string): string => {
-  // Optional fields decode as `T | undefined` unions, so every failure also
-  // reports a useless "Expected undefined" branch; drop those.
-  const issues = formatParseErrorIssues(error).filter(
-    (issue) => !issue.message.startsWith("Expected undefined"),
-  )
+  const issues = formatParseErrorIssues(error)
   const lines = [
     ...new Set(
       issues.map(

--- a/src/dictionary/load.ts
+++ b/src/dictionary/load.ts
@@ -49,15 +49,15 @@ const formatParseError = (error: ParseError): string => {
   return path === "" ? `invalid dictionary data: ${issue.message}` : `${path}: ${issue.message}`
 }
 
-const decodeDictionary = Schema.decode(Schema.parseJson(DictionarySchema), {
-  onExcessProperty: "error",
-  errors: "all",
-})
+// v4 omits the rejected value from an issue unless reportInput is on.
+const decodeOptions = { onExcessProperty: "error", errors: "all", reportInput: true } as const
 
-const decodeApprovedWordList = Schema.decode(Schema.parseJson(ApprovedWordListSchema), {
-  onExcessProperty: "error",
-  errors: "all",
-})
+const decodeDictionary = Schema.decodeEffect(Schema.fromJsonString(DictionarySchema), decodeOptions)
+
+const decodeApprovedWordList = Schema.decodeEffect(
+  Schema.fromJsonString(ApprovedWordListSchema),
+  decodeOptions,
+)
 
 const readDictionaryFile = (
   path: string,

--- a/src/dictionary/schema.ts
+++ b/src/dictionary/schema.ts
@@ -9,9 +9,9 @@ const DictionarySourceSchema = Schema.Struct({
   path: NonEmptyTrimmedString,
 })
 
-const DictionaryFormSchema = NonEmptyTrimmedString.pipe(Schema.pattern(DICTIONARY_FORM_PATTERN))
+const DictionaryFormSchema = NonEmptyTrimmedString.check(Schema.isPattern(DICTIONARY_FORM_PATTERN))
 
-const DictionaryWordSchema = NonEmptyTrimmedString.pipe(Schema.pattern(DICTIONARY_WORD_PATTERN))
+const DictionaryWordSchema = NonEmptyTrimmedString.check(Schema.isPattern(DICTIONARY_WORD_PATTERN))
 
 const DictionaryEntrySchema = Schema.Struct({
   unapproved: Schema.NonEmptyArray(DictionaryFormSchema),

--- a/src/schema/parse-error.ts
+++ b/src/schema/parse-error.ts
@@ -1,20 +1,32 @@
-import { ParseResult } from "effect"
+import { Schema, SchemaIssue } from "effect"
 
-// This isolates the Effect v3 `ParseResult` module calls, which Effect v4
-// removes, so the later migration changes only this file.
+// This isolates the Effect v4 `SchemaIssue` formatter calls, so a later
+// Schema change touches only this file.
 
-export type ParseError = ParseResult.ParseError
+export type ParseError = Schema.SchemaError
 
 export interface ParseErrorIssue {
   readonly path: ReadonlyArray<string | number>
   readonly message: string
 }
 
+const formatIssues = SchemaIssue.makeFormatterStandardSchemaV1()
+const formatTree = SchemaIssue.makeFormatterDefault()
+
+// A Standard Schema path segment is either a raw key or a `{ key }` wrapper,
+// and symbol keys never appear in this package's schemas.
+const pathSegments = (
+  path: ReadonlyArray<PropertyKey | { readonly key: PropertyKey }> | undefined,
+): ReadonlyArray<string | number> =>
+  (path ?? []).map((segment) => {
+    const key = typeof segment === "object" ? segment.key : segment
+    return typeof key === "number" ? key : String(key)
+  })
+
 export const formatParseErrorIssues = (error: ParseError): ParseErrorIssue[] =>
-  ParseResult.ArrayFormatter.formatErrorSync(error).map((issue) => ({
-    path: issue.path as ReadonlyArray<string | number>,
+  formatIssues(error.issue).issues.map((issue) => ({
+    path: pathSegments(issue.path),
     message: issue.message,
   }))
 
-export const formatParseErrorTree = (error: ParseError): string =>
-  ParseResult.TreeFormatter.formatErrorSync(error)
+export const formatParseErrorTree = (error: ParseError): string => formatTree(error.issue)

--- a/src/schema/parse-error.ts
+++ b/src/schema/parse-error.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaIssue } from "effect"
+import { type Schema, SchemaIssue } from "effect"
 
 // This isolates the Effect v4 `SchemaIssue` formatter calls, so a later
 // Schema change touches only this file.

--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -2,4 +2,6 @@ import { Schema } from "effect"
 
 // Effect v4 has no NonEmptyTrimmedString schema.
 // Every call site imports this alias, so the definition stays in one file.
-export const NonEmptyTrimmedString = Schema.Trimmed.check(Schema.isNonEmpty())
+export const NonEmptyTrimmedString = Schema.Trimmed.check(
+  Schema.isNonEmpty({ expected: "a non-empty string" }),
+)

--- a/src/schema/primitives.ts
+++ b/src/schema/primitives.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect"
 
-// Effect v4 removes Schema.NonEmptyTrimmedString.
-// Every call site imports this alias so the v4 migration changes one line.
-export const NonEmptyTrimmedString = Schema.NonEmptyTrimmedString
+// Effect v4 has no NonEmptyTrimmedString schema.
+// Every call site imports this alias, so the definition stays in one file.
+export const NonEmptyTrimmedString = Schema.Trimmed.check(Schema.isNonEmpty())

--- a/src/tagger/wink.ts
+++ b/src/tagger/wink.ts
@@ -31,7 +31,7 @@ export function makeWinkTagger(): Tagger {
   }
 }
 
-export class TaggerService extends Context.Tag("TaggerService")<TaggerService, Tagger>() {}
+export class TaggerService extends Context.Service<TaggerService, Tagger>()("TaggerService") {}
 
 const makeLazyWinkTagger = (): Tagger => {
   let tagger: Tagger | undefined

--- a/test/config/schema.test.ts
+++ b/test/config/schema.test.ts
@@ -2,12 +2,12 @@ import { Effect } from "effect"
 import { describe, expect, test } from "vitest"
 import { decodeConfig } from "../../src/config/schema.ts"
 
-const decode = (input: unknown) => Effect.runSync(Effect.either(decodeConfig(input, "test.json")))
+const decode = (input: unknown) => Effect.runSync(Effect.result(decodeConfig(input, "test.json")))
 
 const expectDecodeError = (input: unknown): string => {
   const result = decode(input)
-  expect(result._tag).toBe("Left")
-  return result._tag === "Left" ? result.left.message : ""
+  expect(result._tag).toBe("Failure")
+  return result._tag === "Failure" ? result.failure.message : ""
 }
 
 describe("config schema", () => {
@@ -22,9 +22,9 @@ describe("config schema", () => {
       },
     })
 
-    expect(result._tag).toBe("Right")
-    if (result._tag === "Right") {
-      expect(result.right).toEqual({
+    expect(result._tag).toBe("Success")
+    if (result._tag === "Success") {
+      expect(result.success).toEqual({
         rules: { "sentence-length": "soft" },
         maxSentenceWords: 20,
         exemptBlockQuotes: true,
@@ -39,12 +39,12 @@ describe("config schema", () => {
   test("decodes an empty config", () => {
     const result = decode({})
 
-    expect(result._tag).toBe("Right")
+    expect(result._tag).toBe("Success")
   })
 
   test("accepts every severity setting for the dictionary rule", () => {
     for (const setting of ["hard", "soft", "off"]) {
-      expect(decode({ rules: { "dictionary-not-approved-word": setting } })._tag).toBe("Right")
+      expect(decode({ rules: { "dictionary-not-approved-word": setting } })._tag).toBe("Success")
     }
   })
 
@@ -78,8 +78,8 @@ describe("config schema", () => {
   })
 
   test("exemptBlockQuotes must be a boolean", () => {
-    expect(decode({ exemptBlockQuotes: true })._tag).toBe("Right")
-    expect(decode({ exemptBlockQuotes: false })._tag).toBe("Right")
+    expect(decode({ exemptBlockQuotes: true })._tag).toBe("Success")
+    expect(decode({ exemptBlockQuotes: false })._tag).toBe("Success")
 
     for (const bad of ["true", 1, null]) {
       const message = expectDecodeError({ exemptBlockQuotes: bad })
@@ -103,7 +103,7 @@ describe("config schema", () => {
   })
 
   test("a non-object config is rejected", () => {
-    expect(decode("hard")._tag).toBe("Left")
-    expect(decode(null)._tag).toBe("Left")
+    expect(decode("hard")._tag).toBe("Failure")
+    expect(decode(null)._tag).toBe("Failure")
   })
 })


### PR DESCRIPTION
## Intent

Migrate agent-simple-english from Effect v3 to the current Effect v4 release candidate. The plan scout recommended waiting for the stable release, and the captain first chose that. The captain then overrode it: "actually i dont plan to wait effect 4 stable ship i dont mind to ship rc version". So the decision is approach A: migrate now to the exact current release candidate, 4.0.0-rc.112. Release placement stays v0.5.0. The version bump to 0.5.0 and the release are separate later steps, not part of this task. Linear ticket HUF-316.

Two preparation PRs already landed, so src/schema/primitives.ts owns the non-empty trimmed string schema (PR 51) and src/schema/parse-error.ts owns parse-error formatting (PR 50). The migration therefore changes one file per seam there.

The scout proved feasibility on 4.0.0-rc.112. Installing it gives 86 type errors from 14 root causes. A port of the config schema with its error formatter passed all 30 assertions in test/config/schema.test.ts, as did a port of the tagger service.

The scout's module-by-module rewrite table names every v3 call site beside its v4 replacement.
Effect: Effect.either becomes Effect.result. Effect.catchAll becomes Effect.catch. Effect.catchAllCause becomes Effect.catchCause. Effect.tryPromise, Effect.gen, and about 60 other Effect functions stay unchanged.
Either becomes Result: the import changes, Either.isLeft becomes Result.isFailure, Either.isRight becomes Result.isSuccess, Either.getOrUndefined becomes Result.getOrUndefined, the .left field becomes .failure, the .right field becomes .success, and the _tag values "Left" and "Right" become "Failure" and "Success".
Schema: Schema.NonEmptyTrimmedString becomes Schema.Trimmed with an isNonEmpty check. Schema.partial becomes per-field Schema.optionalKey. Schema.pattern becomes an isPattern check. Schema.positive becomes an isGreaterThan(0) check. Schema.parseJson becomes Schema.fromJsonString. Schema.decodeUnknown becomes Schema.decodeUnknownEffect. Schema.decode becomes Schema.decodeEffect. Multi-value Schema.Literal becomes Schema.Literals. The .annotations({message: fn}) function form becomes .annotate with a static annotation.
ParseResult: the module does not exist in v4. ParseResult.ParseError becomes Schema.SchemaError. ParseResult.ArrayFormatter becomes SchemaIssue.makeFormatterStandardSchemaV1. ParseResult.TreeFormatter becomes SchemaIssue.makeFormatterDefault. SchemaError exposes .issue, not .cause as the official migration guide states. The guide also omits the annotation change entirely.
Context: Context.Tag becomes Context.Service. Layer.sync and the yield* call sites stay unchanged.
Cause: Cause.Cause and Cause.pretty stay unchanged.

The annotation change is the one that alters user-facing text. In v4 the message annotation is a static string, so the function form that appended the rejected value has no replacement. A v4 annotation binds to one AST node, not to a whole schema chain, so each check needs its own annotation. The expected annotation restores the value, rendering as "Expected <text>, got <value>".

User-facing config and dictionary error messages must keep naming the offending key and the rejected value. The captain values quality and long-term maintainability over development cost.

## What Changed

- Pin `effect` to the exact version `4.0.0-rc.112` and rename the v3 call sites in the CLI and tagger: `Either` becomes `Result`, `catchAll` and `catchAllCause` become `catch` and `catchCause`, and `TaggerService` extends `Context.Service`.
- Port the config and dictionary schemas to the v4 Schema API: `optionalKey` per field, `Literals`, `isPattern` and `isNonEmpty` checks, `fromJsonString` with `decodeEffect`, and static `expected` annotations plus `reportInput: true` so error messages still name the offending key and the rejected value.
- Replace the removed `ParseResult` formatters in `src/schema/parse-error.ts` with `SchemaIssue` formatters over `SchemaError.issue`, and record the version pin and annotation rules in `AGENTS.md`.

## Risk Assessment

✅ Low: The fix round is a two-file mechanical change that restores the CLAUDE.md symlink byte-for-byte to the base commit and adds one verified expected annotation, and the rest of the migration was already reviewed in round 1 with no further defects found.

## Testing

Verified the effect pin at 4.0.0-rc.112 and the restored CLAUDE.md symlink, ran the config, dictionary, CLI, and extension Vitest seams, and drove the spawned CLI with malformed config, dictionary, and approved word list files. All tests passed and every user-facing error named the key and the rejected value, with the non-empty check reading "Expected a non-empty string, got \"\"".

<details>
<summary>Evidence: CLI transcript: invalid config error text on Effect v4</summary>

<code>$ simple-english doc.md (invalid config)&#10;invalid config in .simple-english.json:&#10;typo: Unexpected key with value 1&#10;rules.sentence-length: Expected &#34;hard&#34;, &#34;soft&#34;, or &#34;off&#34;, got &#34;loud&#34;&#10;maxSentenceWords: Expected a positive integer, got 0&#10;exemptBlockQuotes: Expected boolean, got &#34;yes&#34;&#10;ruleDataExtensions.hedging.1: Expected a non-empty string, got &#34;&#34;&#10;approvedWordsPath: Expected a non-empty string, got &#34;&#34;&#10;exit=2</code>

```text
$ cat .simple-english.json
{"rules":{"sentence-length":"loud"},"maxSentenceWords":0,"exemptBlockQuotes":"yes","approvedWordsPath":"","ruleDataExtensions":{"hedging":["ok",""]},"typo":1}

$ simple-english doc.md   (invalid config)
invalid config in /tmp/tmp.Y9LLX5xN9K/.simple-english.json:
  typo: Unexpected key with value 1
  rules.sentence-length: Expected "hard", "soft", or "off", got "loud"
  maxSentenceWords: Expected a positive integer, got 0
  exemptBlockQuotes: Expected boolean, got "yes"
  ruleDataExtensions.hedging.1: Expected a non-empty string, got ""
  approvedWordsPath: Expected a non-empty string, got ""
exit=2

$ cat bad-dict.json
{"sources":[{"name":"x","path":"y"}],"entries":[{"unapproved":["Bad Form!"],"approved":["fine"]}]}

$ SIMPLE_ENGLISH_DICTIONARY=bad-dict.json simple-english doc.md   (valid empty config, invalid dictionary)
Cannot load STE dictionary from bad-dict.json: sources: Unexpected key with value [{"name":"x","path":"y"}]
exit=0

$ simple-english doc.md   (valid config, bundled dictionary, sentence with a violation)
doc.md:1:1 [hard] contraction Do not use a contraction. Write the words in full. Found "We're".
exit=1
```
</details>
<details>
<summary>Evidence: CLI transcript: invalid dictionary and approved word list error text</summary>

<code>Cannot load STE dictionary from empty-name.json: source.name: Expected a string with no leading or trailing whitespace, got &#34; &#34;&#10;Cannot load STE dictionary from bad-version.json: formatVersion: Expected 1, got 2&#10;Cannot load STE dictionary from words.json: approvedWords[1]: Expected a string matching the RegExp ..., got &#34;not a word&#34;&#10;exit=2</code>

```text
$ cat bad-form.json
{"formatVersion":1,"source":{"name":"x","repository":"r","commit":"c","path":"p"},"entries":[{"unapproved":["Bad Form!"],"suggestions":["fine"]}]}
$ SIMPLE_ENGLISH_DICTIONARY=bad-form.json simple-english doc.md
Cannot load STE dictionary from bad-form.json: entries[0].unapproved[0]: Expected a string matching the RegExp ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*(?:[	 ]+[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*)*$, got "Bad Form!"
exit=0

$ cat empty-name.json
{"formatVersion":1,"source":{"name":"  ","repository":"r","commit":"c","path":"p"},"entries":[]}
$ SIMPLE_ENGLISH_DICTIONARY=empty-name.json simple-english doc.md
Cannot load STE dictionary from empty-name.json: source.name: Expected a string with no leading or trailing whitespace, got "  "
exit=0

$ cat bad-version.json
{"formatVersion":2,"source":{"name":"x","repository":"r","commit":"c","path":"p"},"entries":[]}
$ SIMPLE_ENGLISH_DICTIONARY=bad-version.json simple-english doc.md
Cannot load STE dictionary from bad-version.json: formatVersion: Expected 1, got 2
exit=0

$ cat words.json
{"formatVersion":1,"source":{"name":"x","repository":"r","commit":"c","path":"p"},"approvedWords":["fine","not a word"]}
$ cat .simple-english.json
{"approvedWordsPath":"words.json"}
$ simple-english doc.md   (approvedWordsPath set, so a bad word list is fatal)
Cannot load STE dictionary from /tmp/tmp.nn34cLcLBm/words.json: approvedWords[1]: Expected a string matching the RegExp ^[\p{L}\p{N}]+(?:['\u2019\u2010\u2011-][\p{L}\p{N}]+)*$, got "not a word"
exit=2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"34533fcb3519919f14948648580d91ce17608691","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `CLAUDE.md:2` - Commit 103b5ab replaces the CLAUDE.md symlink to AGENTS.md with a two-line pointer file that uses the `@AGENTS.md` import. The intent covers the Effect v3 to v4 migration only, and no stated requirement needs this change to the repo&#39;s instruction wiring. It also changes how non-Claude hosts that read CLAUDE.md see the file: a symlink gave them the full AGENTS.md text, while the import line is Claude-specific syntax. Recommend dropping this hunk from the branch, or confirming the swap is wanted as a separate change.
- ℹ️ `src/schema/primitives.ts:5` - The v4 default text for an empty string in NonEmptyTrimmedString is `Expected a value with a length of at least 1, got &#34;&#34;`, while v3 said `a non empty string`. The key and value still appear, so the intent is met, but the wording is less clear to a config author. Passing `{ expected: &#34;a non-empty string&#34; }` to `Schema.isNonEmpty()` in src/schema/primitives.ts restores the plain wording in one place (verified on rc.112: it renders as `Expected a non-empty string, got &#34;&#34;`). This is user-facing text, so it needs the author&#39;s decision.

🔧 Fix: restore CLAUDE.md symlink and plain non-empty string wording
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` and checked `node_modules/effect/package.json` reports version 4.0.0-rc.112</code>
- <code>`ls -la CLAUDE.md` confirms the file is a symlink to AGENTS.md</code>
- <code>`bunx vitest run test/config test/dictionary test/cli/config.test.ts test/cli/cli.test.ts test/cli/hook.test.ts test/cli/observe.test.ts test/extension` (9 files pass)</code>
- <code>Manual CLI run with an invalid .simple-english.json (bad severity, maxSentenceWords 0, non-boolean, empty strings, unknown key) via `bun src/cli/main.ts doc.md`, captured to cli-error-transcript.txt</code>
- `Manual CLI runs with invalid dictionary files through SIMPLE_ENGLISH_DICTIONARY (bad form pattern, whitespace name, wrong formatVersion) and an invalid approved word list through approvedWordsPath, captured to cli-dictionary-error-transcript.txt`
- `Manual CLI lint of a sentence with a contraction using the bundled dictionary, confirming exit code 1 and the violation output`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
