### PR TITLE
chore: prepare v0.5.0 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "simple-english",
       "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "author": {
         "name": "JIA YI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-simple-english",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Intent

Captain's ask (2026-09-07): "prepare v0.5.0".
This release carries the Effect v3 to v4 migration and its two preparation refactors, all merged on main today:
- https://github.com/jyooi/agent-simple-english/pull/51 aliases the non-empty trimmed string schema behind src/schema/primitives.ts.
- https://github.com/jyooi/agent-simple-english/pull/50 moves parse-error formatting into src/schema/parse-error.ts.
- https://github.com/jyooi/agent-simple-english/pull/52 pins effect at the exact version 4.0.0-rc.112 and ports every call site: Either to Result, three Effect renames, the v4 Schema API (optionalKey, Literals, isPattern and isNonEmpty checks, fromJsonString with decodeEffect), static expected annotations plus reportInput: true so error messages keep naming the offending key and the rejected value, and SchemaIssue formatters in place of the removed ParseResult module.
The captain chose to ship the release candidate rather than wait for Effect 4.0.0 stable.
This task is the version-bump PR only. The tag, the GitHub release, the npm publish, and the plugin update are the captain's steps after the captain's manual smoke pass. Do not tag, do not publish, do not create a release.
Linear ticket: HUF-318.

## What Changed

- Bump the `version` field in `package.json` from 0.4.0 to 0.5.0.
- Bump the plugin `version` in `.claude-plugin/plugin.json` and the `simple-english` entry in `.claude-plugin/marketplace.json` from 0.4.0 to 0.5.0.
- No source, test, or dependency changes. The tag, GitHub release, and npm publish remain manual steps after this PR (HUF-318).

## Risk Assessment

✅ Low: A three-line version bump identical in shape to the prior release-prep commit, with no remaining stale version references and no forbidden tag, publish, or release actions in the branch.

## Testing

Verified the version bump end to end: a frozen-lockfile install succeeds with effect pinned at 4.0.0-rc.112, the CLI reports 0.5.0 via --version, the three manifests agree, real lint runs and config-error output behave correctly, and the targeted CLI and config schema test files pass. No tag, release, or publish was performed.

<details>
<summary>Evidence: CLI --version and lint smoke transcript</summary>

<code>$ bun src/cli/main.ts --version&#10;0.5.0&#10;exit=0&#10;&#10;package.json / plugin.json / marketplace.json versions: 0.5.0 0.5.0 0.5.0&#10;&#10;$ bun src/cli/main.ts /tmp/smoke.md&#10;/tmp/smoke.md:1:9 [hard] verb-progressive Use a simple tense. Do not use the progressive. Found: &#34;been working&#34;.&#10;exit=1&#10;&#10;$ bun src/cli/main.ts /tmp/clean.md&#10;exit=0</code>

```text
$ bun src/cli/main.ts --version
0.5.0
exit=0

$ node -e "console.log(require(\"./package.json\").version, require(\"./.claude-plugin/plugin.json\").version, require(\"./.claude-plugin/marketplace.json\").plugins[0].version)"
0.5.0 0.5.0 0.5.0

$ printf "We have been working on it and it does not work.\n" > /tmp/smoke.md; bun src/cli/main.ts /tmp/smoke.md
/tmp/smoke.md:1:9 [hard] verb-progressive Use a simple tense. Do not use the progressive. Found: "been working".
exit=1

$ printf "This sentence is clean.\n" > /tmp/clean.md; bun src/cli/main.ts /tmp/clean.md
exit=0
```
</details>
<details>
<summary>Evidence: CLI config error text after Effect v4 migration</summary>

<code>invalid config in /tmp/bad-config.json:&#10;rules.not-a-rule: Unexpected key with value &#34;hard&#34;&#10;exit=2</code>

```text
$ printf "{\"rules\":{\"not-a-rule\":\"hard\"}}" > /tmp/bad-config.json; bun src/cli/main.ts --config /tmp/bad-config.json /tmp/clean.md
invalid config in /tmp/bad-config.json:
  rules.not-a-rule: Unexpected key with value "hard"
exit=2
```
</details>
<details>
<summary>Evidence: Vitest CLI E2E run</summary>

```text

 RUN  v5.0.0 ~/.no-mistakes/worktrees/5b49eff34526/01M1X7V0BM82318SZF68R7F013


 Test Files  1 passed (1)
      Tests  39 passed (39)
   Start at  14:11:46
   Duration  6.14s (tests 99%, transform 1%)
```
</details>

## Release notes for v0.5.0

## Changes

- The package now runs on Effect 4.0.0-rc.112, pinned to that exact version. This release tracks an Effect release candidate, not a stable Effect 4.0.0.
- Config and dictionary error messages still name the offending setting and the rejected value. Effect v4 supplies slightly reworded default text for some checks, such as "Expected boolean, got "yes"".
- No CLI flag, config key, or rule behavior changed.

**Full changelog**: https://github.com/jyooi/agent-simple-english/compare/v0.4.0...v0.5.0

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"e3531d53e42d6056b7c247477c8b5a3969f889ff","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 211070f..e3531d5` (3 files, version-only changes)</code>
- <code>`bun install --frozen-lockfile` then confirmed `node_modules/effect/package.json` version is 4.0.0-rc.112</code>
- <code>`bun src/cli/main.ts --version` prints 0.5.0 with exit 0</code>
- `Manual check that package.json, .claude-plugin/plugin.json, and .claude-plugin/marketplace.json all report 0.5.0`
- `Manual CLI lint of a file with a progressive verb (exit 1, violation reported) and a clean file (exit 0)`
- <code>Manual CLI run with an invalid config key showing `rules.not-a-rule: Unexpected key with value &#34;hard&#34;` (exit 2)</code>
- <code>`bunx vitest run test/cli/cli.test.ts` (includes the --version E2E test)</code>
- `bunx vitest run test/config/schema.test.ts`
- <code>`git tag` confirms no tag was created; `git status` clean after cleanup</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

