### PR TITLE
refactor: remove dead code and duplicate helpers from the HUF-319 cleanup wave

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
         "micromark-util-html-tag-name": "^2.0.1",
         "micromark-util-normalize-identifier": "^2.0.1",
         "micromark-util-types": "^2.0.2",
-        "unicode-case-folding": "^1.1.1",
         "wink-eng-lite-web-model": "^1.8.1",
         "wink-nlp": "^2.4.0",
       },
@@ -568,8 +567,6 @@
     "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
-
-    "unicode-case-folding": ["unicode-case-folding@1.1.1", "", {}, "sha512-ZAYziAnMTBisO2dT5tyGvBFMNsIfonOS/BZTd3UZaKWtXMOZqK8s8HRUCrlKxGCTeCxCuCjS/6HW+4a6G+rbzw=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 

--- a/docs/adr/0002-claude-code-reply-feedback.md
+++ b/docs/adr/0002-claude-code-reply-feedback.md
@@ -8,10 +8,11 @@ ADR 0001 records its redaction limit.
 
 The `Stop` hook reads `last_assistant_message` from the event.
 This event field is authoritative because the transcript can lag behind the completed reply.
-When the field is present, the latest user transcript record gives the base turn identity.
+The latest user transcript record gives the base turn identity.
 A hash of the event reply identifies each rewrite in that turn.
-When the field is absent, the latest assistant transcript entry gives the reply and its identity.
-It checks the reply.
+A missing `last_assistant_message` field returns a non-blocking warning and records no reply.
+
+The hook checks the reply.
 In non-strict mode, it records only hard violation feedback.
 It does not block or change the completed reply in this mode.
 Session state retains the processed reply identity and ignores duplicate `Stop` events.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "micromark-util-html-tag-name": "^2.0.1",
     "micromark-util-normalize-identifier": "^2.0.1",
     "micromark-util-types": "^2.0.2",
-    "unicode-case-folding": "^1.1.1",
     "wink-eng-lite-web-model": "^1.8.1",
     "wink-nlp": "^2.4.0"
   },

--- a/src/adapter/feedback.ts
+++ b/src/adapter/feedback.ts
@@ -2,7 +2,6 @@ import type { RuleId } from "../engine/rules/registry.ts"
 import type { Violation } from "../engine/types.ts"
 
 function suggestedFix(violation: Violation): string {
-  if (violation.suggestion !== undefined) return `Use "${violation.suggestion}".`
   if (violation.suggestions !== undefined && violation.suggestions.length > 0) {
     return `Use one of these approved alternatives: ${violation.suggestions.map((item) => `"${item}"`).join(", ")}.`
   }
@@ -38,4 +37,13 @@ export function formatViolations(
   violations: readonly Violation[],
 ): string {
   return `${heading} ${path}:\n${violationDetails(violations)}`
+}
+
+export function splitViolations<V extends Violation>(
+  violations: readonly V[],
+): { readonly hard: V[]; readonly soft: V[] } {
+  return {
+    hard: violations.filter((violation) => violation.severity === "hard"),
+    soft: violations.filter((violation) => violation.severity === "soft"),
+  }
 }

--- a/src/cli/hook.ts
+++ b/src/cli/hook.ts
@@ -3,7 +3,7 @@ import { open, readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { Cause, Effect } from "effect"
 import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-message.ts"
-import { formatViolations } from "../adapter/feedback.ts"
+import { formatViolations, splitViolations } from "../adapter/feedback.ts"
 import { ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import { loadConfiguredDictionary } from "../dictionary/configured.ts"
@@ -24,6 +24,7 @@ import {
   hasProcessedReply,
   setReplyFeedback,
 } from "./session-state.ts"
+import { tryAsync } from "./try-async.ts"
 
 interface CommonEvent {
   readonly cwd: string
@@ -244,47 +245,11 @@ function proposedEdit(
 }
 
 const readEditFile = (path: string) =>
-  Effect.tryPromise({
-    try: () => readFile(path, "utf8"),
-    catch: (cause) => new Error(`cannot read edit file ${path}: ${cause}`),
-  })
+  tryAsync(`cannot read edit file ${path}`, () => readFile(path, "utf8"))
 
 interface AssistantReply {
   readonly identity: string
   readonly text: string
-}
-
-function assistantReply(line: string, path: string, offset: number): AssistantReply | undefined {
-  let value: unknown
-  try {
-    value = JSON.parse(line) as unknown
-  } catch {
-    return undefined
-  }
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
-  const entry = value as Record<string, unknown>
-  if (entry.type !== "assistant") return undefined
-  const message = record(entry.message, "assistant transcript message")
-  const content = message.content
-  if (!Array.isArray(content)) {
-    throw new Error(`assistant transcript message in ${path} must contain content blocks`)
-  }
-  const uuid = entry.uuid
-  const identity =
-    typeof uuid === "string" && uuid.length > 0
-      ? `uuid:${uuid}`
-      : `offset:${offset}:${createHash("sha256").update(line).digest("hex")}`
-  const text = content
-    .filter(
-      (block): block is { type: "text"; text: string } =>
-        typeof block === "object" &&
-        block !== null &&
-        (block as Record<string, unknown>).type === "text" &&
-        typeof (block as Record<string, unknown>).text === "string",
-    )
-    .map((block) => block.text)
-    .join("\n")
-  return { identity, text }
 }
 
 const TRANSCRIPT_CHUNK_SIZE = 64 * 1024
@@ -384,23 +349,6 @@ async function readTranscriptRange(
   return buffer
 }
 
-async function assistantReplyInRange(
-  file: Awaited<ReturnType<typeof open>>,
-  path: string,
-  start: number,
-  end: number,
-): Promise<AssistantReply | undefined> {
-  const length = end - start
-  const headerLength = Math.min(length, TRANSCRIPT_ENTRY_HEADER_SIZE)
-  const header = await readTranscriptRange(file, path, start, headerLength)
-  if (transcriptEntryKind(header.toString("utf8")) !== "assistant") return undefined
-  const line =
-    headerLength === length
-      ? header.toString("utf8")
-      : (await readTranscriptRange(file, path, start, length)).toString("utf8")
-  return assistantReply(line, path, start)
-}
-
 async function turnIdentityInRange(
   file: Awaited<ReturnType<typeof open>>,
   path: string,
@@ -464,12 +412,6 @@ async function latestTranscriptEntry<T>(
   }
 }
 
-async function assistantReplyFromTranscript(path: string): Promise<AssistantReply> {
-  const reply = await latestTranscriptEntry(path, assistantReplyInRange)
-  if (reply !== undefined) return reply
-  throw new Error(`cannot find an assistant reply in ${path}`)
-}
-
 async function assistantReplyFromEvent(text: string, path: string): Promise<AssistantReply> {
   const turnIdentity = await latestTranscriptEntry(path, turnIdentityInRange)
   if (turnIdentity === undefined) throw new Error(`cannot find a reply turn in ${path}`)
@@ -477,45 +419,28 @@ async function assistantReplyFromEvent(text: string, path: string): Promise<Assi
   return { identity: `${turnIdentity}:reply:${textHash}`, text }
 }
 
-const readAssistantReply = (path: string) =>
-  Effect.tryPromise({
-    try: () => assistantReplyFromTranscript(path),
-    catch: (cause) => new Error(`cannot read assistant reply from ${path}: ${cause}`),
-  })
-
 const readEventAssistantReply = (text: string, path: string) =>
-  Effect.tryPromise({
-    try: () => assistantReplyFromEvent(text, path),
-    catch: (cause) => new Error(`cannot read assistant reply turn from ${path}: ${cause}`),
-  })
+  tryAsync(`cannot read assistant reply turn from ${path}`, () =>
+    assistantReplyFromEvent(text, path),
+  )
 
 const replyWasProcessed = (sessionId: string, replyIdentity: string) =>
-  Effect.tryPromise({
-    try: () => hasProcessedReply(sessionId, replyIdentity),
-    catch: (cause) => new Error(`cannot read session state: ${cause}`),
-  })
+  tryAsync("cannot read session state", () => hasProcessedReply(sessionId, replyIdentity))
 
 const updateReplyFeedback = (
   sessionId: string,
   replyIdentity: string,
   feedback: string | undefined,
 ) =>
-  Effect.tryPromise({
-    try: () => setReplyFeedback(sessionId, replyIdentity, feedback),
-    catch: (cause) => new Error(`cannot update session state: ${cause}`),
-  })
+  tryAsync("cannot update session state", () =>
+    setReplyFeedback(sessionId, replyIdentity, feedback),
+  )
 
 const takePendingFeedback = (sessionId: string) =>
-  Effect.tryPromise({
-    try: () => consumePendingFeedback(sessionId),
-    catch: (cause) => new Error(`cannot read session state: ${cause}`),
-  })
+  tryAsync("cannot read session state", () => consumePendingFeedback(sessionId))
 
 const readSessionControl = (sessionId: string) =>
-  Effect.tryPromise({
-    try: () => getSessionControl(sessionId),
-    catch: (cause) => new Error(`cannot read session state: ${cause}`),
-  })
+  tryAsync("cannot read session state", () => getSessionControl(sessionId))
 
 const loadLintOptions = (cwd: string, tagger: Tagger) =>
   Effect.gen(function* () {
@@ -531,16 +456,6 @@ const loadLintOptions = (cwd: string, tagger: Tagger) =>
     })
     return { ...config, dictionary, ruleData, tagger } satisfies LintOptions
   })
-
-function splitViolations(violations: readonly ReportViolation[]): {
-  readonly hard: ReportViolation[]
-  readonly soft: ReportViolation[]
-} {
-  return {
-    hard: violations.filter((violation) => violation.severity === "hard"),
-    soft: violations.filter((violation) => violation.severity === "soft"),
-  }
-}
 
 type EvaluationObservation = Omit<ObservationDraft, "sessionId" | "cwd">
 
@@ -603,15 +518,18 @@ function textDecision(
 
 function evaluateReply(event: StopEvent, tagger: Tagger): Effect.Effect<HookEvaluation, Error> {
   return Effect.gen(function* () {
-    const reply = yield* event.lastAssistantMessage === undefined
-      ? readAssistantReply(event.transcriptPath)
-      : readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath)
+    if (event.lastAssistantMessage === undefined) {
+      return yield* Effect.fail(
+        new Error(`last_assistant_message was not provided for ${event.transcriptPath}`),
+      )
+    }
+    const reply = yield* readEventAssistantReply(event.lastAssistantMessage, event.transcriptPath)
     if (yield* replyWasProcessed(event.sessionId, reply.identity)) {
       return { output: {} as Record<string, never> }
     }
     const options = yield* loadLintOptions(event.cwd, tagger)
     const violations = lint("prose-file", reply.text, options).violations
-    const hard = violations.filter((violation) => violation.severity === "hard")
+    const { hard } = splitViolations(violations)
     const feedback =
       hard.length === 0
         ? undefined

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -2,6 +2,7 @@
 import { readFile } from "node:fs/promises"
 import { Effect, Result } from "effect"
 import packageManifest from "../../package.json" with { type: "json" }
+import { splitViolations } from "../adapter/feedback.ts"
 import { loadConfig } from "../config/load.ts"
 import { loadConfiguredDictionary } from "../dictionary/configured.ts"
 import { loadRuleData } from "../dictionary/load.ts"
@@ -102,7 +103,6 @@ interface FileViolation {
   readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
-  readonly suggestion?: string
 }
 
 interface CliReport {
@@ -138,7 +138,7 @@ const toCliReport = (
     violations,
     summary: {
       total: violations.length,
-      hard: violations.filter((violation) => violation.severity === "hard").length,
+      hard: splitViolations(violations).hard.length,
     },
     skipped,
   }

--- a/src/cli/observation-log.ts
+++ b/src/cli/observation-log.ts
@@ -3,6 +3,7 @@ import { mkdir, open, readdir, readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { createInterface } from "node:readline"
 import type { LintKind, ReportViolation } from "../engine/types.ts"
+import { isFileError } from "../fs-error.ts"
 import { applicationStateDirectory } from "./state-directory.ts"
 
 export type ObservationEvent = "write" | "edit" | "commit-message" | "reply"
@@ -55,12 +56,6 @@ export interface ObservationDraft {
 const observationsDirectory = (): string => join(applicationStateDirectory(), "observations")
 
 const verdictsPath = (): string => join(applicationStateDirectory(), "verdicts.jsonl")
-
-function isFileError(cause: unknown, code: string): boolean {
-  return (
-    typeof cause === "object" && cause !== null && (cause as NodeJS.ErrnoException).code === code
-  )
-}
 
 async function appendJsonLine(path: string, value: unknown): Promise<void> {
   await mkdir(applicationStateDirectory(), { recursive: true, mode: 0o700 })

--- a/src/cli/session-state.ts
+++ b/src/cli/session-state.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto"
 import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises"
 import { join } from "node:path"
+import { setTimeout as wait } from "node:timers/promises"
+import { isFileError } from "../fs-error.ts"
 import { applicationStateDirectory } from "./state-directory.ts"
 
 export interface SessionControl {
@@ -18,9 +20,6 @@ const DEFAULT_CONTROL: SessionControl = { enabled: true, strict: false }
 const LOCK_STALE_MILLISECONDS = 10_000
 const LOCK_RETRY_MILLISECONDS = 5
 const LOCK_RETRIES = 200
-
-const isFileError = (cause: unknown, code: string): boolean =>
-  typeof cause === "object" && cause !== null && (cause as { code?: string }).code === code
 
 const sessionsDirectory = (): string => join(applicationStateDirectory(), "sessions")
 
@@ -41,27 +40,16 @@ function optionalString(state: Record<string, unknown>, name: string): string | 
   return value as string | undefined
 }
 
-function decodeState(text: string, path: string): SessionState {
+function decodeState(text: string, path: string): SessionState | undefined {
   const value = JSON.parse(text) as unknown
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error(`invalid session state in ${path}`)
   }
   const state = value as Record<string, unknown>
+  if (state.version !== 3) return undefined
   const pendingFeedback = optionalString(state, "pendingFeedback")
-  if (state.version === 1 && typeof pendingFeedback === "string") {
-    return { version: 3, ...DEFAULT_CONTROL, pendingFeedback }
-  }
   const lastProcessedReply = optionalString(state, "lastProcessedReply")
-  if (state.version === 2 && lastProcessedReply !== undefined && lastProcessedReply.length > 0) {
-    return {
-      version: 3,
-      ...DEFAULT_CONTROL,
-      lastProcessedReply,
-      ...(pendingFeedback === undefined ? {} : { pendingFeedback }),
-    }
-  }
   if (
-    state.version !== 3 ||
     typeof state.enabled !== "boolean" ||
     typeof state.strict !== "boolean" ||
     (state.strict && !state.enabled) ||
@@ -99,9 +87,6 @@ async function writeState(sessionId: string, state: SessionState): Promise<void>
     await rm(temporaryPath, { force: true })
   }
 }
-
-const wait = (milliseconds: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, milliseconds))
 
 async function acquireLock(sessionId: string): Promise<() => Promise<void>> {
   const directory = sessionsDirectory()

--- a/src/cli/try-async.ts
+++ b/src/cli/try-async.ts
@@ -1,0 +1,7 @@
+import { Effect } from "effect"
+
+export const tryAsync = <T>(label: string, run: () => Promise<T>): Effect.Effect<T, Error> =>
+  Effect.tryPromise({
+    try: run,
+    catch: (cause) => new Error(`${label}: ${cause}`),
+  })

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
 import { Effect } from "effect"
+import { isFileError } from "../fs-error.ts"
 import { mergeConfigs } from "./merge.ts"
 import { ConfigError, decodeConfig, type SteConfig } from "./schema.ts"
 
@@ -32,9 +33,6 @@ export const legacyGlobalConfigPath = (cwd = process.cwd()): string =>
 export const legacyProjectConfigPath = (cwd: string): string =>
   join(cwd, ".pi", "simple-english.json")
 
-const isMissingFile = (cause: unknown): boolean =>
-  typeof cause === "object" && cause !== null && (cause as { code?: string }).code === "ENOENT"
-
 const readConfigFile = (
   path: string,
   optional: boolean,
@@ -45,7 +43,7 @@ const readConfigFile = (
   }).pipe(
     Effect.matchEffect({
       onFailure: (cause) =>
-        optional && isMissingFile(cause)
+        optional && isFileError(cause, "ENOENT")
           ? Effect.succeed(undefined)
           : Effect.fail(new ConfigError(`cannot read config file ${path}: ${cause}`)),
       onSuccess: (text) =>

--- a/src/engine/case-fold.ts
+++ b/src/engine/case-fold.ts
@@ -1,4 +1,3 @@
-import { caseFold } from "unicode-case-folding"
 import { TOKEN_RUN_PATTERN } from "./tokens.ts"
 
 export interface CaseFoldedToken {
@@ -7,7 +6,9 @@ export interface CaseFoldedToken {
   readonly offset: number
 }
 
-export const caseFoldKey = (text: string): string => caseFold(text)
+// ponytail: toLowerCase() does not fold "ss" from sharp s or merge sigma forms.
+// Add unicode-case-folding back if a dictionary needs that reach.
+export const caseFoldKey = (text: string): string => text.toLowerCase()
 
 export const tokenizeCaseFolded = (line: string): readonly CaseFoldedToken[] =>
   Array.from(line.matchAll(TOKEN_RUN_PATTERN), (match) => ({

--- a/src/engine/markdown.ts
+++ b/src/engine/markdown.ts
@@ -18,12 +18,6 @@ interface MarkdownAnalysis {
   readonly sentenceBoundaryLines: boolean[]
 }
 
-export interface MarkdownCodeResult {
-  readonly lines: string[]
-  readonly structuralLines: string[]
-  readonly structuralBlanks: boolean[]
-}
-
 interface AnalysisState {
   readonly source: string
   readonly parseLines: readonly string[]
@@ -606,79 +600,4 @@ export function blankMarkdownForLint(
   exemptBlockQuotes = false,
 ): MarkdownAnalysis {
   return analyzeMarkdown(inputLines, contentStarts, includeDictionary, exemptBlockQuotes)
-}
-
-export function blankMarkdownCodeWithStructure(
-  inputLines: readonly string[],
-  contentStarts: readonly number[] = inputLines.map(() => 0),
-): MarkdownCodeResult {
-  const analysis = analyzeMarkdown(inputLines, contentStarts, false)
-  return {
-    lines: analysis.lines,
-    structuralLines: analysis.structuralLines,
-    structuralBlanks: analysis.structuralBlanks,
-  }
-}
-
-export function blankMarkdownCode(
-  inputLines: readonly string[],
-  contentStarts: readonly number[] = inputLines.map(() => 0),
-): string[] {
-  return analyzeMarkdown(inputLines, contentStarts, false).lines
-}
-
-export function maskMarkdownCode(text: string): string {
-  return blankMarkdownCode(text.split("\n")).join("\n")
-}
-
-export function blankMarkdownDestinations(
-  lines: readonly string[],
-  contentStarts: readonly number[] = lines.map(() => 0),
-): string[] {
-  return analyzeMarkdown(lines, contentStarts).dictionaryLines
-}
-
-export function blankInlineCode(lines: readonly string[]): string[] {
-  const source = lines.join("\n")
-  const mask = new Uint8Array(source.length)
-  const parser = source.includes(")") ? commonMarkParser : codeOnlyInlineParser
-  const pending = [...(parser.parseInline(source, 0) as readonly InlineElement[])]
-
-  while (pending.length > 0) {
-    const element = pending.pop()
-    if (element === undefined) continue
-    if (element.children !== undefined) pending.push(...element.children)
-    if (inlineElementName(element) === "InlineCode") {
-      markRange(mask, element.from, element.to)
-    }
-  }
-
-  let offset = 0
-  return lines.map((line) => {
-    const characters = line.split("")
-    for (let index = 0; index < line.length; index++) {
-      if (mask[offset + index] !== 0) characters[index] = " "
-    }
-    offset += line.length + 1
-    return characters.join("")
-  })
-}
-
-export function proseVisibility(text: string): Uint8Array {
-  const visibility = new Uint8Array(text.length)
-  const sourceLines = text.split("\n")
-  const proseLines = blankMarkdownCode(sourceLines)
-  let offset = 0
-
-  for (let index = 0; index < sourceLines.length; index++) {
-    const line = sourceLines[index] ?? ""
-    if (line === proseLines[index]) visibility.fill(1, offset, offset + line.length)
-    offset += line.length
-    if (offset < text.length) {
-      visibility[offset] = 1
-      offset++
-    }
-  }
-
-  return visibility
 }

--- a/src/engine/rules/phrasal-verb.ts
+++ b/src/engine/rules/phrasal-verb.ts
@@ -46,7 +46,7 @@ export function phrasalVerb(lines: readonly string[], dictionary: Dictionary): V
       message: `Do not use a phrasal verb. Use "${suggestion}", not "${match.found.toLowerCase()}".`,
       line: match.line,
       column: match.column,
-      suggestion,
+      suggestions: [suggestion],
     })),
   )
 }

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -16,7 +16,6 @@ export interface Violation {
   readonly suggestions?: readonly string[]
   readonly line: number
   readonly column: number
-  readonly suggestion?: string
 }
 
 export interface ReportViolation extends Violation {

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -16,7 +16,7 @@ import type { AutocompleteItem } from "@earendil-works/pi-tui"
 import { Effect } from "effect"
 import { Type } from "typebox"
 import { blankCommitMetadata, findCommitInvocations } from "../adapter/commit-message.ts"
-import { formatViolations, violationDetails } from "../adapter/feedback.ts"
+import { formatViolations, splitViolations, violationDetails } from "../adapter/feedback.ts"
 import { formatStatusSummary, ruleSummary } from "../adapter/rule-summary.ts"
 import { loadConfig } from "../config/load.ts"
 import type { SteConfig } from "../config/schema.ts"
@@ -292,7 +292,7 @@ function showReplyReport(
   report: LintReport,
   queueFeedback: boolean,
 ): void {
-  const hard = report.violations.filter((violation) => violation.severity === "hard")
+  const { hard } = splitViolations(report.violations)
   const softCount = report.summary.total - report.summary.hard
   state.pendingReplyFeedback =
     queueFeedback && hard.length > 0 ? formatReplyFeedback(hard) : undefined
@@ -364,8 +364,7 @@ function lintProposedText(
     sourceDialect: classification.sourceDialect,
     previousText,
   })
-  const hard = report.violations.filter((violation) => violation.severity === "hard")
-  const soft = report.violations.filter((violation) => violation.severity === "soft")
+  const { hard, soft } = splitViolations(report.violations)
   notifyWarnings(ctx, path, soft)
   if (hard.length === 0) {
     if (soft.length > 0) {
@@ -457,7 +456,7 @@ function lintStrictReply(
   }
   const report = lintReply(state, text)
   showReplyReport(state, ctx, report, false)
-  const hard = report.violations.filter((violation) => violation.severity === "hard")
+  const { hard } = splitViolations(report.violations)
   if (hard.length === 0) return undefined
   return {
     block: true,

--- a/src/fs-error.ts
+++ b/src/fs-error.ts
@@ -1,0 +1,5 @@
+export function isFileError(cause: unknown, code: string): boolean {
+  return (
+    typeof cause === "object" && cause !== null && (cause as NodeJS.ErrnoException).code === code
+  )
+}

--- a/test/cli/cli.test.ts
+++ b/test/cli/cli.test.ts
@@ -243,7 +243,7 @@ describe("simple-english CLI", () => {
       expect.objectContaining({
         ruleId: "phrasal-verb",
         severity: "hard",
-        suggestion: "do",
+        suggestions: ["do"],
       }),
       expect.objectContaining({ ruleId: "marketing", severity: "soft" }),
     ])

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -221,8 +221,8 @@ describe("simple-english CLI config", () => {
     expect(result.code).toBe(1)
     const report = JSON.parse(result.stdout)
     expect(report.violations).toEqual([
-      expect.objectContaining({ ruleId: "phrasal-verb", suggestion: "do" }),
-      expect.objectContaining({ ruleId: "phrasal-verb", suggestion: "continue" }),
+      expect.objectContaining({ ruleId: "phrasal-verb", suggestions: ["do"] }),
+      expect.objectContaining({ ruleId: "phrasal-verb", suggestions: ["continue"] }),
     ])
   })
 

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import {
   appendFile,
   copyFile,
@@ -791,6 +792,28 @@ describe("simple-english CLI hook mode", () => {
     )
     expect(decision(firstSession.output).additionalContext).toContain("[contraction]")
     expect(await stateFiles(xdgStateHome)).toHaveLength(1)
+  })
+
+  test("ignores pending feedback from a pre-version-3 session state file", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+    const sessionsDirectory = join(xdgStateHome, "simple-english", "sessions")
+    await mkdir(sessionsDirectory, { recursive: true })
+    const stateFile = `${createHash("sha256").update("legacy-session").digest("hex")}.json`
+    await writeFile(
+      join(sessionsDirectory, stateFile),
+      JSON.stringify({
+        version: 2,
+        lastProcessedReply: "uuid:reply-1",
+        pendingFeedback: "Stale feedback from an old state format.",
+      }),
+    )
+
+    const submitted = await runReplyHook(userPromptEvent(cwd, "legacy-session"), cwd, xdgStateHome)
+
+    expect(submitted.code).toBe(0)
+    expect(submitted.output).toEqual({})
   })
 
   test("allows Stop with a non-blocking warning when last_assistant_message is missing", async () => {

--- a/test/cli/hook.test.ts
+++ b/test/cli/hook.test.ts
@@ -136,10 +136,6 @@ function promptEntry(prompt: string, uuid: string): string {
   })}\n`
 }
 
-async function writeTranscript(path: string, reply: string, uuid = "reply-1"): Promise<void> {
-  await writeFile(path, transcriptEntry(reply, uuid))
-}
-
 async function stateFiles(xdgStateHome: string): Promise<string[]> {
   try {
     return await readdir(join(xdgStateHome, "simple-english", "sessions"))
@@ -530,13 +526,11 @@ describe("simple-english CLI hook mode", () => {
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
     const transcriptPath = join(cwd, "session-1.jsonl")
-    await writeTranscript(
-      transcriptPath,
-      "It is important to note that we can't carry out the test; close the valve.",
-    )
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    const reply = "It is important to note that we can't carry out the test; close the valve."
 
     const stopped = await runReplyHook(
-      stopEvent(cwd, "session-1", transcriptPath),
+      stopEvent(cwd, "session-1", transcriptPath, reply),
       cwd,
       xdgStateHome,
     )
@@ -564,7 +558,7 @@ describe("simple-english CLI hook mode", () => {
     const consumedState = JSON.parse(
       await readFile(join(xdgStateHome, "simple-english", "sessions", files[0] as string), "utf8"),
     ) as SessionState
-    expect(consumedState.lastProcessedReply).toBe("uuid:reply-1")
+    expect(consumedState.lastProcessedReply).toMatch(/^turn-uuid:prompt-1:reply:[0-9a-f]{64}$/)
     expect(consumedState.pendingFeedback).toBeUndefined()
 
     const submittedAgain = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
@@ -576,13 +570,14 @@ describe("simple-english CLI hook mode", () => {
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
     const transcriptPath = join(cwd, "session-1.jsonl")
-    await writeTranscript(transcriptPath, "This isn't permitted.")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
+    const reply = "This isn't permitted."
 
-    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
+    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath, reply), cwd, xdgStateHome)
     const firstSubmission = await runReplyHook(userPromptEvent(cwd, "session-1"), cwd, xdgStateHome)
     expect(decision(firstSubmission.output).additionalContext).toContain("[contraction]")
 
-    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
+    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath, reply), cwd, xdgStateHome)
     const duplicateSubmission = await runReplyHook(
       userPromptEvent(cwd, "session-1"),
       cwd,
@@ -590,8 +585,12 @@ describe("simple-english CLI hook mode", () => {
     )
     expect(duplicateSubmission.output).toEqual({})
 
-    await appendFile(transcriptPath, transcriptEntry("This can't continue.", "reply-2"))
-    await runReplyHook(stopEvent(cwd, "session-1", transcriptPath), cwd, xdgStateHome)
+    await appendFile(transcriptPath, promptEntry("Check it again.", "prompt-2"))
+    await runReplyHook(
+      stopEvent(cwd, "session-1", transcriptPath, "This can't continue."),
+      cwd,
+      xdgStateHome,
+    )
     const secondSubmission = await runReplyHook(
       userPromptEvent(cwd, "session-1"),
       cwd,
@@ -643,24 +642,37 @@ describe("simple-english CLI hook mode", () => {
     temporaryDirectories.push(xdgStateHome)
 
     const cleanTranscriptPath = join(cwd, "clean-session.jsonl")
-    await writeTranscript(cleanTranscriptPath, "This isn't permitted.")
-    await runReplyHook(stopEvent(cwd, "clean-session", cleanTranscriptPath), cwd, xdgStateHome)
+    await writeFile(cleanTranscriptPath, promptEntry("Check it.", "clean-prompt-1"))
+    await runReplyHook(
+      stopEvent(cwd, "clean-session", cleanTranscriptPath, "This isn't permitted."),
+      cwd,
+      xdgStateHome,
+    )
     expect(await stateFiles(xdgStateHome)).toHaveLength(1)
 
-    for (const [sessionId, reply] of [
-      ["clean-session", "Close the valve."],
-      ["soft-session", "It is important to note that the valve is open."],
-    ] as const) {
-      const transcriptPath = join(cwd, `${sessionId}.jsonl`)
-      await writeTranscript(transcriptPath, reply, `${sessionId}-clean-reply`)
-      const result = await runReplyHook(
-        stopEvent(cwd, sessionId, transcriptPath),
+    await appendFile(cleanTranscriptPath, promptEntry("Check it again.", "clean-prompt-2"))
+    const cleanResult = await runReplyHook(
+      stopEvent(cwd, "clean-session", cleanTranscriptPath, "Close the valve."),
+      cwd,
+      xdgStateHome,
+    )
+    expect(cleanResult.code).toBe(0)
+    expect(cleanResult.output).toEqual({})
+
+    const softTranscriptPath = join(cwd, "soft-session.jsonl")
+    await writeFile(softTranscriptPath, promptEntry("Check it.", "soft-prompt-1"))
+    const softResult = await runReplyHook(
+      stopEvent(
         cwd,
-        xdgStateHome,
-      )
-      expect(result.code).toBe(0)
-      expect(result.output).toEqual({})
-    }
+        "soft-session",
+        softTranscriptPath,
+        "It is important to note that the valve is open.",
+      ),
+      cwd,
+      xdgStateHome,
+    )
+    expect(softResult.code).toBe(0)
+    expect(softResult.output).toEqual({})
 
     const files = await stateFiles(xdgStateHome)
     expect(files).toHaveLength(2)
@@ -700,7 +712,7 @@ describe("simple-english CLI hook mode", () => {
     await writeFile(transcriptPath, `${toolEntry}\n${assistantEntry}\n`)
 
     const stopped = await runHook(
-      stopEvent(cwd, "large-session", transcriptPath),
+      stopEvent(cwd, "large-session", transcriptPath, "This isn't permitted."),
       cwd,
       join(repoRoot, "test", "fixtures", "failing-large-transcript-read-preload.js"),
       undefined,
@@ -732,7 +744,7 @@ describe("simple-english CLI hook mode", () => {
     await writeFile(transcriptPath, `${assistantEntry}${toolEntry}\n`)
 
     const stopped = await runHook(
-      stopEvent(cwd, "trailing-tool-session", transcriptPath),
+      stopEvent(cwd, "trailing-tool-session", transcriptPath, "This isn't permitted."),
       cwd,
       join(repoRoot, "test", "fixtures", "failing-large-transcript-read-preload.js"),
       undefined,
@@ -756,9 +768,13 @@ describe("simple-english CLI hook mode", () => {
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
     const transcriptPath = join(cwd, "first-session.jsonl")
-    await writeTranscript(transcriptPath, "This isn't permitted.")
+    await writeFile(transcriptPath, promptEntry("Check it.", "prompt-1"))
 
-    await runReplyHook(stopEvent(cwd, "first-session", transcriptPath), cwd, xdgStateHome)
+    await runReplyHook(
+      stopEvent(cwd, "first-session", transcriptPath, "This isn't permitted."),
+      cwd,
+      xdgStateHome,
+    )
 
     const otherSession = await runReplyHook(
       userPromptEvent(cwd, "second-session"),
@@ -777,13 +793,31 @@ describe("simple-english CLI hook mode", () => {
     expect(await stateFiles(xdgStateHome)).toHaveLength(1)
   })
 
-  test("allows Stop when the transcript cannot be read", async () => {
+  test("allows Stop with a non-blocking warning when last_assistant_message is missing", async () => {
     const cwd = await makeProject()
     const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
     temporaryDirectories.push(xdgStateHome)
 
     const result = await runReplyHook(
       stopEvent(cwd, "session-1", join(cwd, "missing.jsonl")),
+      cwd,
+      xdgStateHome,
+    )
+
+    expect(result.code).toBe(0)
+    expect(result.output.continue).toBe(true)
+    expect(result.output.systemMessage).toContain("Writing-rule hook error")
+    expect(result.output.systemMessage).toContain("last_assistant_message was not provided")
+    expect(await stateFiles(xdgStateHome)).toEqual([])
+  })
+
+  test("allows Stop when the transcript cannot be read", async () => {
+    const cwd = await makeProject()
+    const xdgStateHome = await mkdtemp(join(tmpdir(), "ste-hook-state-"))
+    temporaryDirectories.push(xdgStateHome)
+
+    const result = await runReplyHook(
+      stopEvent(cwd, "session-1", join(cwd, "missing.jsonl"), "This isn't permitted."),
       cwd,
       xdgStateHome,
     )

--- a/test/engine/dictionary.test.ts
+++ b/test/engine/dictionary.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from "vitest"
 import type { ApprovedWordList, Dictionary } from "../../src/dictionary/schema.ts"
 import { lint } from "../../src/engine/lint.ts"
-import { blankMarkdownDestinations } from "../../src/engine/markdown.ts"
+import { blankMarkdownForLint } from "../../src/engine/markdown.ts"
 import type { Tagger } from "../../src/engine/tagger.ts"
+
+const blankMarkdownDestinations = (lines: readonly string[]): string[] =>
+  blankMarkdownForLint(
+    lines,
+    lines.map(() => 0),
+    true,
+  ).dictionaryLines
 
 const dictionary = {
   formatVersion: 1,

--- a/test/engine/hedging.test.ts
+++ b/test/engine/hedging.test.ts
@@ -58,7 +58,7 @@ describe("lint prose-file: hedging rule", () => {
         commit: "fixture",
         path: "hedging.json",
       },
-      entries: [{ unapproved: ["große sache"], suggestions: ["delete"] }],
+      entries: [{ unapproved: ["grosse sache"], suggestions: ["delete"] }],
     } as const satisfies Dictionary
 
     const report = lint("prose-file", "İ GROSSE SACHE.", {

--- a/test/engine/markdown.bench.ts
+++ b/test/engine/markdown.bench.ts
@@ -1,5 +1,12 @@
 import { describe, test } from "vitest"
-import { blankMarkdownDestinations } from "../../src/engine/markdown.ts"
+import { blankMarkdownForLint } from "../../src/engine/markdown.ts"
+
+const blankMarkdownDestinations = (lines: readonly string[]): string[] =>
+  blankMarkdownForLint(
+    lines,
+    lines.map(() => 0),
+    true,
+  ).dictionaryLines
 
 const sizes = [4_000, 8_000, 16_000] as const
 const runOptions = {

--- a/test/engine/markdown.test.ts
+++ b/test/engine/markdown.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, test } from "vitest"
-import {
-  blankInlineCode,
-  blankMarkdownCode,
-  blankMarkdownDestinations,
-} from "../../src/engine/markdown.ts"
+import { blankMarkdownForLint } from "../../src/engine/markdown.ts"
+
+const blankMarkdownCode = (lines: readonly string[]): string[] =>
+  blankMarkdownForLint(
+    lines,
+    lines.map(() => 0),
+    false,
+  ).lines
+
+const blankMarkdownDestinations = (lines: readonly string[]): string[] =>
+  blankMarkdownForLint(
+    lines,
+    lines.map(() => 0),
+    true,
+  ).dictionaryLines
 
 const parserThresholdPrefix = `${"Alphaword ".repeat(1_100)}\n\n`
 
@@ -128,7 +138,6 @@ describe("Markdown parser masking", () => {
     const input = "[Alpha](target`) Betaword `"
 
     expect(blankMarkdownCode([input])).toEqual([input])
-    expect(blankInlineCode([input])).toEqual([input])
   })
 
   test("masks parser-classified malformed raw-content blocks", () => {

--- a/test/engine/marketing.test.ts
+++ b/test/engine/marketing.test.ts
@@ -108,7 +108,7 @@ describe("lint prose-file: marketing rule", () => {
     ])
   })
 
-  test("matches Unicode case variants with different lowercase forms", () => {
+  test("matches an uppercase Unicode variant of a lowercase dictionary entry", () => {
     const extension = {
       formatVersion: 1,
       source: {
@@ -120,7 +120,7 @@ describe("lint prose-file: marketing rule", () => {
       entries: [{ unapproved: ["σ"], suggestions: ["plain"] }],
     } as const satisfies Dictionary
 
-    const report = lint("prose-file", "A ς platform.", {
+    const report = lint("prose-file", "A Σ platform.", {
       ruleData: { marketing: extension },
     })
 
@@ -129,7 +129,7 @@ describe("lint prose-file: marketing rule", () => {
         ruleId: "marketing",
         line: 1,
         column: 3,
-        message: expect.stringContaining("ς"),
+        message: expect.stringContaining("σ"),
       }),
     ])
   })

--- a/test/engine/phrasal-verb.test.ts
+++ b/test/engine/phrasal-verb.test.ts
@@ -14,7 +14,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
       severity: "hard",
       line: 1,
       column: 1,
-      suggestion: "do",
+      suggestions: ["do"],
     })
     expect(violation?.message).toContain('"do"')
     expect(violation?.message.toLowerCase()).toContain("carry out")
@@ -43,7 +43,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
     for (const [text, suggestion] of cases) {
       const report = lint("prose-file", text)
       const violation = report.violations.find((v) => v.ruleId === "phrasal-verb")
-      expect(violation?.suggestion, text).toBe(suggestion)
+      expect(violation?.suggestions, text).toEqual([suggestion])
     }
   })
 
@@ -67,7 +67,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
     })
 
     expect(report.violations).toEqual([
-      expect.objectContaining({ ruleId: "phrasal-verb", suggestion: "do" }),
+      expect.objectContaining({ ruleId: "phrasal-verb", suggestions: ["do"] }),
     ])
   })
 
@@ -120,7 +120,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
         commit: "fixture",
         path: "phrasal-verbs.json",
       },
-      entries: [{ unapproved: ["straße aus"], suggestions: ["leave"] }],
+      entries: [{ unapproved: ["strasse aus"], suggestions: ["leave"] }],
     } as const satisfies Dictionary
 
     const report = lint("prose-file", "İ STRASSE AUS now.", {
@@ -132,7 +132,7 @@ describe("lint prose-file: phrasal-verb rule", () => {
         ruleId: "phrasal-verb",
         line: 1,
         column: 3,
-        suggestion: "leave",
+        suggestions: ["leave"],
       }),
     ])
   })

--- a/test/extension/extension.test.ts
+++ b/test/extension/extension.test.ts
@@ -390,7 +390,6 @@ describe("pi extension wiring", { concurrent: false }, () => {
     expect(manifest.bin).toEqual({ "simple-english": "src/cli/main.ts" })
     expect(manifest.dependencies).toMatchObject({
       effect: expect.any(String),
-      "unicode-case-folding": expect.any(String),
       "wink-eng-lite-web-model": expect.any(String),
       "wink-nlp": expect.any(String),
     })


### PR DESCRIPTION
## Intent

Captain: "run /ponytail:ponytail-audit on my agent-simple-english local repo, then assign work for worker later".
After the audit review, the captain told firstmate to proceed with the plan agreed under /kun.
The agreed work for this task is the cleanup wave of that audit (Linear HUF-319).
Delete code that no caller needs, with no behavior change for a Claude Code or pi user.

1. In `src/engine/markdown.ts`, delete `proseVisibility`, `maskMarkdownCode`, `blankMarkdownCodeWithStructure`, and `MarkdownCodeResult`. They have no caller anywhere.
`blankMarkdownCode`, `blankInlineCode`, and `blankMarkdownDestinations` are called only from tests and the bench. Point those tests at `blankMarkdownForLint` and delete the exports.
2. In `src/cli/hook.ts`, delete the transcript reverse-scan fallback that runs only when Claude Code omits `last_assistant_message`. That fallback is `assistantReply`, `assistantReplyInRange`, `assistantReplyFromTranscript`, and `readAssistantReply`. ADR 0002 already names the event field authoritative. A missing field returns the existing non-blocking warning. Keep `turnIdentityInRange` and `latestTranscriptEntry`, the turn identity still needs them.
3. In `src/cli/session-state.ts`, delete the version 1 and version 2 state migrations in `decodeState`. Treat a non-version-3 file as absent.
4. Replace the `unicode-case-folding` dependency with `toLowerCase()`. `src/engine/rules/dictionary.ts` already lowercases, so two rules disagree today. Remove the package from `package.json`.
5. While you are in a touched file, apply the small dedupe items from the audit report. Skip any item whose file this task does not otherwise touch.

The dedupe items are: one memo helper for the four `WeakMap` rule caches, one ENOENT helper, one `tryAsync` wrapper, and `splitViolations` exported from `feedback.ts`. Also a dialect map in `kinds.ts`, `node:util` `parseArgs` in `main.ts`, `node:timers/promises` in `session-state.ts`, and one `suggestions` field on `Violation`.

## What Changed

- Deleted unused markdown exports (`proseVisibility`, `maskMarkdownCode`, `blankMarkdownCodeWithStructure`, `blankMarkdownCode`, `blankInlineCode`, `blankMarkdownDestinations`, `MarkdownCodeResult`), the Stop hook transcript reverse-scan fallback for a missing `last_assistant_message`, and the version 1 and 2 session state migrations, which now treat a non-version-3 file as absent. ADR 0002 records the missing-field warning.
- Replaced the `unicode-case-folding` dependency with `toLowerCase()` in `src/engine/case-fold.ts` so dictionary and phrasal-verb matching fold case the same way, and removed the package from `package.json` and `bun.lock`.
- Deduplicated helpers: one `isFileError` in `src/fs-error.ts`, one `tryAsync` wrapper in `src/cli/try-async.ts`, `splitViolations` exported from `feedback.ts` and used by the hook, CLI, and extension, `node:timers/promises` for the lock wait, and a single `suggestions` field on `Violation` in place of `suggestion`. Tests and the bench now target `blankMarkdownForLint` and the new hook behavior.

## Risk Assessment

✅ Low: The change is deletion and mechanical dedupe with tests retargeted to the surviving public seams, the missing last_assistant_message path is covered by a new E2E test, and the only open question is whether two listed dedupe items in touched files were deliberately deferred.

## Testing

Installed dependencies from the lockfile, ran the nine test files that touch the changed modules, added a regression test proving a version-2 session state file is treated as absent (fails at base, passes at target), and captured CLI hook and JSON-report transcripts that show each of the four deletion items behaving as the intent requires. Everything passed. No UI surface is involved, so the evidence is CLI output.

<details>
<summary>Evidence: CLI transcripts: hook without last_assistant_message, hook feedback round-trip, legacy state ignored, --json suggestions[], dependency removed</summary>

```text
\### 1. Stop hook without last_assistant_message -> non-blocking warning, transcript fallback removed
{"continue":true,"systemMessage":"Writing-rule hook error: last_assistant_message was not provided for /tmp/tmp.sGJT1V3zeb/s.jsonl. The event is allowed."}
 (exit=0)

\### 2. Stop hook with last_assistant_message lints the reply; UserPromptSubmit then surfaces the feedback
{}
 (exit=0)
{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"Writing-rule reply feedback for assistant reply:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}
 (exit=0)

\### 3. Version-2 session state file with pending feedback is treated as absent
{}
 (exit=0)

\### 4. CLI --json report: phrasal-verb carries suggestions[] and no suggestion field, uppercase matches via toLowerCase, inline code masked
{
  "violations": [
    {
      "file": "doc.md",
      "ruleId": "phrasal-verb",
      "severity": "soft",
      "message": "Do not use a phrasal verb. Use \"do\", not \"carry out\".",
      "line": 1,
      "column": 9,
      "suggestions": [
        "do"
      ],
      "snippet": "We must carry out the test in `carry out` code."
    },
    {
      "file": "doc.md",
      "ruleId": "phrasal-verb",
      "severity": "soft",
      "message": "Do not use a phrasal verb. Use \"do\", not \"carry out\".",
      "line": 3,
      "column": 1,
      "suggestions": [
        "do"
      ],
      "snippet": "CARRY OUT it."
    }
  ],
  "summary": {
    "total": 2,
    "hard": 0
  },
  "skipped": []
}
 (exit=0)

\### 5. unicode-case-folding is gone from package.json, bun.lock, and node_modules
bun.lock:0
package.json:0
ls: cannot access 'node_modules/unicode-case-folding': No such file or directory
```
</details>

- Evidence: [New regression test for the removed version 1 and 2 state migrations](https://github.com/jyooi/agent-simple-english/blob/2ae36ad97a0a40aad0b1467702559f9d8334dcb0/test/cli/hook.test.ts)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2ae36ad97a0a40aad0b1467702559f9d8334dcb0","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `src/cli/main.ts:46` - Intent item 5 says: &#34;While you are in a touched file, apply the small dedupe items from the audit report. Skip any item whose file this task does not otherwise touch.&#34; Two listed items live in files this change touches but were not applied: `node:util` `parseArgs` in `src/cli/main.ts` (the hand-rolled `parseArgs` at line 46 stays, while the file was edited for `splitViolations` and the `suggestion` field), and the one memo helper for the four `WeakMap` rule caches (`src/engine/rules/phrasal-verb.ts` line 14 was edited for `suggestions` but keeps its own cache). The commit body does not say these were skipped or why. Both remedies carry behavior-change tension: `node:util` `parseArgs` would alter unknown-flag and `--kind` missing-value error text that `test/cli` pins, and the memo helper would touch three untouched rule files. The author should confirm whether these two items are deliberately deferred or must land in this wave.
- ℹ️ `src/engine/case-fold.ts:11` - `caseFoldKey` now uses `toLowerCase()`, so dictionary entries with a sharp s or final sigma no longer match their uppercase forms. The intent authorizes this and the bundled dictionary data contains no non-ASCII entries, so no Claude Code or pi user sees a change. The tests in `test/engine/hedging.test.ts`, `phrasal-verb.test.ts`, and `marketing.test.ts` were rewritten to pin the narrower semantics rather than deleted, which keeps coverage of the Turkish dotted-I path.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bun install --frozen-lockfile` (worktree had no node_modules; confirmed unicode-case-folding is not installed)</code>
- <code>`bunx vitest run test/cli/hook.test.ts -t &#34;pre-version-3&#34;` at target: passes; with base `src/cli/session-state.ts` restored: fails (stale pendingFeedback surfaced)</code>
- `bunx vitest run test/cli/hook.test.ts test/cli/cli.test.ts test/cli/config.test.ts test/engine/markdown.test.ts test/engine/dictionary.test.ts test/engine/phrasal-verb.test.ts test/engine/hedging.test.ts test/engine/marketing.test.ts test/extension/extension.test.ts`
- <code>Manual `bun src/cli/main.ts hook` transcripts: Stop without last_assistant_message, Stop plus UserPromptSubmit with a contraction reply, UserPromptSubmit against a hand-written version-2 state file</code>
- <code>Manual `bun src/cli/main.ts --json doc.md` with lowercase, uppercase, and inline-code phrasal verbs</code>
- `grep -c unicode-case-folding package.json bun.lock`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
