### PR TITLE
chore: prepare v0.5.1 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "simple-english",
       "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "author": {
         "name": "JIA YI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-simple-english",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Intent

Captain: "go v0.5.1" (2026-09-08). Earlier the same day the captain asked: "so whats next ? can we make another release ?". Firstmate proposed a patch release and the captain approved it.
This release carries three changes merged on main since v0.5.0:
- https://github.com/jyooi/agent-simple-english/pull/56 reads Markdown block structure from the micromark parser only. Three regex block readers are gone. A star thematic break, a setext underline, a deeper block quote, or a lone pipe line between two paragraphs now ends the first paragraph. That removes paragraph-length false positives. A heading-like line inside a raw HTML block now counts as HTML text, as CommonMark says, so sentence-length reports a larger count there.
- https://github.com/jyooi/agent-simple-english/pull/55 removes dead code and duplicate helpers. The `unicode-case-folding` dependency is gone, and case folding uses `toLowerCase`. The transcript reverse-scan fallback in the hook is gone. Old session-state migrations are gone.
- https://github.com/jyooi/agent-simple-english/pull/54 adds a guard test for the strict output boundary. No behavior change.
No CLI flag, config key, or rule name changed in any of the three.
This task is the version-bump PR only. It also carries the verification pass the captain queued as Linear HUF-317 for the Effect v4 build: the pi extension loads from a clean install without dev dependencies, the hook blocks a hard violation and allows clean prose, error messages read well for a human, and the project docs name the Effect version. The worker runs those checks and records the output in the PR body.
The tag, the GitHub release, the npm publish, and the plugin update come after the merge. Do not tag, do not publish, do not create a release.
Linear ticket: HUF-322.

## What Changed

- Bump the package version from 0.5.0 to 0.5.1 in `package.json`.
- Bump the plugin version from 0.5.0 to 0.5.1 in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
- No code, config key, CLI flag, or rule name changes. The tag, GitHub release, and npm publish follow after merge.

## Risk Assessment

✅ Low: The change bumps the same three version strings that the v0.5.0 release commit bumped, no other file references the version, bun.lock does not record the root package version, and the diff adds no tag, release, or publish behavior that the intent forbids.

## Testing

Ran the HUF-317 verification pass against the v0.5.1 change: clean --omit=dev install of the packed tarball, hook deny/allow gate and SessionStart injection from that install, extension module load with host peers, CLI error-message review, docs Effect version check, and the targeted hook, plugin-manifest, extension, and config test files. Everything passed and the outputs are recorded as evidence files for the PR body. Temp install and project directories were removed and the worktree is clean.

<details>
<summary>Evidence: Clean install without dev deps (effect 4.0.0-rc.112, no dev packages)</summary>

```text
$ npm install --omit=dev

added 47 packages in 13s

$ ls node_modules (top level)
character-entities
debug
decode-named-character-reference
dequal
detect-libc
devlop
effect
fast-check
fault
format
@lezer
micromark
micromark-core-commonmark
micromark-extension-frontmatter
micromark-extension-gfm-table
micromark-factory-destination
micromark-factory-label
micromark-factory-space
micromark-factory-title
micromark-factory-whitespace
micromark-util-character
micromark-util-chunked
micromark-util-classify-character
micromark-util-combine-extensions
micromark-util-decode-numeric-character-reference
micromark-util-encode
micromark-util-html-tag-name
micromark-util-normalize-identifier
micromark-util-resolve-all
micromark-util-sanitize-uri
micromark-util-subtokenize
micromark-util-symbol
micromark-util-types
ms
msgpackr
@msgpackr-extract
msgpackr-extract
node-gyp-build-optional-packages
pure-rand
@types
wink-eng-lite-web-model
wink-nlp

$ node_modules/effect/package.json version
4.0.0-rc.112

$ dev deps present?
vitest: absent
typescript: absent
@biomejs/biome: absent
@earendil-works/pi-coding-agent: absent
typebox: absent
jiti: absent
```
</details>
<details>
<summary>Evidence: Hook gate from clean install: deny hard violation, allow clean prose, SessionStart rules</summary>

<code>$ echo &lt;Write event &#34;This isn&#39;t permitted.&#34;&gt; | bun src/cli/main.ts hook&#10;{&#34;hookSpecificOutput&#34;:{&#34;hookEventName&#34;:&#34;PreToolUse&#34;,&#34;permissionDecision&#34;:&#34;deny&#34;,&#34;permissionDecisionReason&#34;:&#34;Writing rules blocked write for /tmp/ste-proj/notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \&#34;isn&#39;t\&#34;. Suggested fix: Write the contracted words in full.&#34;}}&#10;&#10;$ echo &lt;Write event &#34;Open the valve.&#34;&gt; | bun src/cli/main.ts hook&#10;{&#34;hookSpecificOutput&#34;:{&#34;hookEventName&#34;:&#34;PreToolUse&#34;,&#34;permissionDecision&#34;:&#34;allow&#34;}}</code>

```text
# Hook gate from the clean --omit=dev install

## Hard violation (contraction) -> expect deny
$ echo <Write event with content "This isn't permitted."> | bun src/cli/main.ts hook
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"Writing rules blocked write for /tmp/ste-proj-Uxyh/notes.md:\n- line 1, column 6 [contraction]: Do not use a contraction. Write the words in full. Found \"isn't\". Suggested fix: Write the contracted words in full."}}
exit 0

## Clean prose -> expect allow
$ echo <Write event with content "Open the valve."> | bun src/cli/main.ts hook
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}
exit 0

## SessionStart -> rule summary injected
{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"## Writing rules\n\nApply these enabled rules to prose that you write or edit:\n\n### Rules derived from ASD-STE100 Simplified Technical English\n\n- [hard] Do not use contractions. Write the words in full.\n- [soft] Use approved words from the STE dictionary.\n- [hard] Use no more than six sentences in one paragraph.\n- [soft] Use an approved single-word verb instead of a phrasal verb.\n- [hard] Do not use semicolons. Write two sentences.\n- [hard] Keep each sentence to 25 words or fewer.\n- [hard] Do not use progressi
exit 
```
</details>
<details>
<summary>Evidence: pi extension module loads from clean install</summary>

```text
# Extension module load from the clean --omit=dev install
# Peer deps @earendil-works/* and typebox linked in, as the pi host supplies them at runtime
$ bun -e "const m = await import(\"./src/extension/index.ts\"); console.log(Object.keys(m), typeof m.default, m.default.name)"
[ "default" ] function simpleEnglishExtension
exit 0
```
</details>
<details>
<summary>Evidence: Config and dictionary error messages (Effect v4 decode text)</summary>

<code>invalid config in &lt;proj&gt;/.simple-english.json:&#10;rules.contractoin: Unexpected key with value &#34;hard&#34;&#10;&#10;invalid config in &lt;proj&gt;/.simple-english.json:&#10;rules.contraction: Expected &#34;hard&#34;, &#34;soft&#34;, or &#34;off&#34;, got &#34;loud&#34;&#10;&#10;Cannot load STE dictionary from &lt;proj&gt;/dict.json: approvedWords[1]: Expected a non-empty string, got &#34;&#34;&#10;&#10;Cannot load STE dictionary from &lt;proj&gt;/dict.json: formatVersion: Expected 1, got 2</code>

```text
# Error messages from the clean install (Effect 4.0.0-rc.112 schema decode text)

## Config: unknown rule name
$ simple-english --config .simple-english.json a.md   # {"rules":{"contractoin":"hard"}}
invalid config in <proj>/.simple-english.json:
  rules.contractoin: Unexpected key with value "hard"
exit 2

## Config: wrong severity value
$ simple-english --config .simple-english.json a.md   # {"rules":{"contraction":"loud"}}
invalid config in <proj>/.simple-english.json:
  rules.contraction: Expected "hard", "soft", or "off", got "loud"
exit 2

## Config: malformed JSON
$ simple-english --config .simple-english.json a.md   # {"rules":
invalid JSON in <proj>/.simple-english.json: SyntaxError: JSON Parse error: Unexpected EOF
exit 2

## Config: missing file
$ simple-english --config missing.json a.md
cannot read config file <proj>/missing.json: Error: ENOENT: no such file or directory, open '<proj>/missing.json'
exit 2

## Dictionary: empty approved word
$ simple-english --config .simple-english.json a.md   # approvedWords: ["valve",""]
invalid config in <proj>/.simple-english.json:
  dictionary: Unexpected key with value {"approvedWords":"<proj>/dict.json"}
exit 2

## CLI: unknown flag
$ simple-english --bogus a.md
unknown flag "--bogus"
exit 2

## CLI: hard violation report on a file
$ simple-english b.md   # "We're checking that the valve doesn't leak."
<proj>/b.md:1:1 [hard] contraction Do not use a contraction. Write the words in full. Found "We're".
<proj>/b.md:1:31 [hard] contraction Do not use a contraction. Write the words in full. Found "doesn't".
exit 1

## Dictionary: empty approved word (approvedWordsPath)
$ simple-english --config .simple-english.json a.md   # approvedWords: ["valve",""]
Cannot load STE dictionary from <proj>/dict.json: approvedWords[1]: Expected a non-empty string, got ""
exit 2

## Dictionary: wrong formatVersion
$ simple-english --config .simple-english.json a.md   # formatVersion: 2
Cannot load STE dictionary from <proj>/dict.json: formatVersion: Expected 1, got 2
exit 2

## Dictionary: missing file
$ simple-english --config .simple-english.json a.md   # approvedWordsPath -> nope.json
Cannot load STE dictionary from <proj>/nope.json: cannot read file: ENOENT: no such file or directory, open '<proj>/nope.json'
exit 2
```
</details>
<details>
<summary>Evidence: Docs name the pinned Effect version and it matches the installed one</summary>

```text
# Docs name the pinned Effect version
$ grep -rn "4.0.0-rc.112" AGENTS.md CLAUDE.md README.md docs package.json
CLAUDE.md:17:- `effect` is pinned to the exact version `4.0.0-rc.112`, with no caret.
AGENTS.md:17:- `effect` is pinned to the exact version `4.0.0-rc.112`, with no caret.
package.json:49:    "effect": "4.0.0-rc.112",

$ installed: node_modules/effect version
4.0.0-rc.112
```
</details>
<details>
<summary>Evidence: Version bump consistent across three manifests</summary>

```text
$ grep -n "\"version\"" package.json .claude-plugin/plugin.json .claude-plugin/marketplace.json
package.json:3:  "version": "0.5.1",
.claude-plugin/marketplace.json:14:      "version": "0.5.1",
.claude-plugin/plugin.json:4:  "version": "0.5.1",
```
</details>
<details>
<summary>Evidence: Targeted vitest run (hook, plugin manifest, extension, config)</summary>

```text
$ vitest run test/cli/hook.test.ts test/extension/claude-plugin.test.ts test/extension/extension.test.ts test/config

 RUN  v5.0.0 ~/.no-mistakes/worktrees/5b49eff34526/01M20HY501JX6VGKCVK22HZY09


 Test Files  5 passed (5)
      Tests  126 passed (126)
   Start at  21:07:30
   Duration  14.81s (tests 92%, import 4%, transform 4%)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b4ffc54cd4d0bbe5fa0f98b6a020341aa9fd3e9b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm pack` then `npm install --omit=dev` of the 0.5.1 tarball in a temp dir; checked node_modules for effect version and absence of vitest, typescript, biome, pi-coding-agent, typebox, jiti</code>
- <code>`bun src/cli/main.ts hook` from the clean install with a PreToolUse Write event containing &#34;isn&#39;t&#34; (deny) and &#34;Open the valve.&#34; (allow), plus a SessionStart event (rule summary injected)</code>
- <code>`bun -e &#34;import(&#39;./src/extension/index.ts&#39;)&#34;` from the clean install with @earendil-works/* and typebox peers linked in as the pi host supplies them</code>
- `CLI error text from the clean install: unknown rule name, wrong severity, malformed JSON, missing config, empty dictionary word, wrong dictionary formatVersion, missing dictionary file, unknown flag, hard violation report`
- <code>`grep -rn 4.0.0-rc.112 AGENTS.md CLAUDE.md README.md docs package.json` compared with installed node_modules/effect version</code>
- <code>`bun run test -- test/cli/hook.test.ts test/extension/claude-plugin.test.ts test/extension/extension.test.ts test/config` (126 tests, all pass; claude-plugin.test.ts pins plugin.json and marketplace.json versions to package.json)</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
