### PR TITLE
chore: prepare v0.5.2 release

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "simple-english",
       "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "author": {
         "name": "JIA YI"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "simple-english",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Apply technical and house-style writing rules to writes, edits, and git commit messages.",
   "repository": "https://github.com/jyooi/agent-simple-english",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-simple-english",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Technical and house-style English lint engine, CLI, and host adapters",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Bump the version to 0.5.2 in package.json and the two Claude plugin manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012KwU4vavpQgpfL6vsFQw7w